### PR TITLE
[DTM] SOFT-3908 [3/4]: inheritance pill and screen wiring

### DIFF
--- a/src/style-library/__tests__/inheritance-pill.test.js
+++ b/src/style-library/__tests__/inheritance-pill.test.js
@@ -1,0 +1,91 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { InheritancePill } from '../components/atoms/InheritancePill';
+
+const PILL_CLASS = 'kadence-blocks-style-library__inheritance-pill';
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+describe('InheritancePill', () => {
+	/**
+	 * The inherited variant names the palette the value comes from and is not a control.
+	 *
+	 * @return void
+	 */
+	it('renders the inherited variant as static text naming the source palette', () => {
+		act(() => root.render(<InheritancePill variant="inherited" sourceLabel="Default" />));
+
+		const pill = container.querySelector(`.${PILL_CLASS}`);
+
+		expect(pill.tagName).toBe('SPAN');
+		expect(pill.textContent).toBe('From Default');
+		expect(container.querySelector('button')).toBeNull();
+	});
+
+	/**
+	 * The reset variant is a real button whose visible text stays short while its accessible name
+	 * says which color it resets and where the value comes back from.
+	 *
+	 * @return void
+	 */
+	it('renders the reset variant as a button with a descriptive accessible name', () => {
+		act(() =>
+			root.render(
+				<InheritancePill variant="reset" sourceLabel="Default" swatchName="Main 3" onReset={() => {}} />
+			)
+		);
+
+		const pill = container.querySelector(`.${PILL_CLASS}`);
+
+		expect(pill.tagName).toBe('BUTTON');
+		expect(pill.textContent).toBe('Reset');
+		expect(pill.getAttribute('aria-label')).toBe('Reset Main 3 to Default');
+	});
+
+	/**
+	 * Clicking the reset variant calls back exactly once.
+	 *
+	 * @return void
+	 */
+	it('calls onReset when the reset variant is clicked', () => {
+		const onReset = jest.fn();
+
+		act(() => root.render(<InheritancePill variant="reset" swatchName="Main 3" onReset={onReset} />));
+		act(() => container.querySelector('button').click());
+
+		expect(onReset).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * A write holding the screen busy, or the card being pending delete, disables the button so a
+	 * second click cannot queue a duplicate write.
+	 *
+	 * @return void
+	 */
+	it('disables the reset variant while isDisabled is true', () => {
+		act(() => root.render(<InheritancePill variant="reset" onReset={() => {}} isDisabled={true} />));
+		expect(container.querySelector('button').disabled).toBe(true);
+	});
+});

--- a/src/style-library/__tests__/palette-inheritance.test.js
+++ b/src/style-library/__tests__/palette-inheritance.test.js
@@ -1,0 +1,314 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
+import { usePalettes } from '../hooks/use-palettes';
+
+// A factory, not bare automocking — `use-palettes.js` pulls in `../api/client`, which imports
+// `@wordpress/api-fetch` (externalized to the `wp.apiFetch` global in production, not an installed
+// npm dependency), so automocking would fail to resolve it. This screen only reads the hook's
+// return value.
+jest.mock('../hooks/use-palettes', () => ({
+	usePalettes: jest.fn(),
+}));
+
+// Same cross-module-copy rationale as `preset-screen.test.js`: `@wordpress/components`' own nested
+// `react`/`react-dom` copy trips React's "Invalid hook call" guard under the top-level renderer
+// this test uses. Stand-ins are enough — this test reads pill text and clicks one button. The
+// screen mounts more than `ColorPaletteSettings`-style tests do (`ScreenHeader`, `SelectDropdown`,
+// `ActivatePaletteButton`, and the create/rename/delete/add-group modals all live under it), so this
+// list covers every export those organisms reach for, not only the ones the screen itself imports.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isBusy, isDestructive, variant, icon, ...props }) => <button {...props}>{children}</button>,
+	Notice: ({ children, isDismissible, onRemove, status, ...props }) => <div {...props}>{children}</div>,
+	DropdownMenu: () => null,
+	MenuGroup: ({ children }) => <div>{children}</div>,
+	MenuItem: ({ children, ...props }) => <button {...props}>{children}</button>,
+	// Never opened by these tests, so only the toggle needs to render.
+	Dropdown: ({ renderToggle }) => renderToggle({ isOpen: false, onToggle: () => {} }),
+	Spinner: () => <span className="components-spinner" />,
+	ExternalLink: ({ children, ...props }) => <a {...props}>{children}</a>,
+	Tooltip: ({ children }) => children,
+	Modal: ({ children, title, onRequestClose }) => (
+		<div role="dialog" aria-label={title}>
+			{children}
+		</div>
+	),
+	TextControl: (props) => <input {...props} />,
+	SelectControl: ({ children, options, ...props }) => (
+		<select {...props}>
+			{(options ?? []).map((option) => (
+				<option key={option.value} value={option.value}>
+					{option.label}
+				</option>
+			))}
+		</select>
+	),
+}));
+
+// `@wordpress/icons` nests its own `react` copy for the same reason; the glyphs are only passed
+// through as props here.
+jest.mock('@wordpress/icons', () => ({
+	Icon: (props) => <span className="components-icon" {...props} />,
+	dragHandle: 'dragHandle',
+	moreVertical: 'moreVertical',
+	plus: 'plus',
+	check: 'check',
+	chevronDown: 'chevronDown',
+}));
+
+const PILL_CLASS = 'kadence-blocks-style-library__inheritance-pill';
+const LIBRARY = { feed: {}, slug: 'default', version: 1, rest: {}, refreshFeed: jest.fn() };
+const ROUTE = { screen: 'color-palette', scope: 'secondary', item: '' };
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	jest.clearAllMocks();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Build a `usePalettes` stub for a two-swatch palette: one inherited, one overridden.
+ *
+ * @param {Object} [overrides] Fields merged over the defaults — e.g. `{ editingId: 'default' }`.
+ *
+ * @since TBD
+ *
+ * @return {Object} The `usePalettes` stub.
+ */
+function makePalettes(overrides = {}) {
+	return {
+		listing: {
+			defaultId: 'default',
+			currentId: 'secondary',
+			palettes: [
+				{ id: 'default', label: 'Base', groups: [] },
+				{ id: 'secondary', label: 'Secondary', groups: [] },
+			],
+			userCreated: ['secondary'],
+		},
+		activeId: 'secondary',
+		editingId: 'secondary',
+		isEditingActive: true,
+		palette: {
+			groups: [
+				{
+					id: 'accent',
+					label: 'Accent',
+					swatches: [
+						{ token: 'accent.one', label: 'Main 1', $value: '#3182ce', overridden: false },
+						{ token: 'accent.two', label: 'Main 3', $value: '#794c25', overridden: true },
+					],
+				},
+			],
+		},
+		isLoading: false,
+		isBusy: false,
+		openError: null,
+		activateError: null,
+		createError: null,
+		renameError: null,
+		deleteError: null,
+		structureError: null,
+		clearOpenError: jest.fn(),
+		clearActivateError: jest.fn(),
+		clearCreateError: jest.fn(),
+		clearRenameError: jest.fn(),
+		clearDeleteError: jest.fn(),
+		clearStructureError: jest.fn(),
+		openPalette: jest.fn(() => Promise.resolve()),
+		activatePalette: jest.fn(() => Promise.resolve()),
+		createPalette: jest.fn(() => Promise.resolve()),
+		renamePalette: jest.fn(() => Promise.resolve()),
+		deletePalette: jest.fn(() => Promise.resolve()),
+		saveSwatchEdits: jest.fn(() => Promise.resolve()),
+		removeSwatch: jest.fn(() => Promise.resolve()),
+		resetSwatch: jest.fn(() => Promise.resolve()),
+		isSwatchCustom: jest.fn(() => false),
+		addColor: jest.fn(() => Promise.resolve()),
+		addingGroupIds: [],
+		addGroup: jest.fn(() => Promise.resolve()),
+		reorderSwatches: jest.fn(() => Promise.resolve()),
+		renameGroup: jest.fn(() => Promise.resolve()),
+		removeGroup: jest.fn(() => Promise.resolve()),
+		...overrides,
+	};
+}
+
+/**
+ * Render the screen against a `usePalettes` stub.
+ *
+ * @param {Object} palettes The stub returned by `makePalettes`.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function renderScreen(palettes) {
+	usePalettes.mockReturnValue(palettes);
+
+	act(() =>
+		root.render(<ColorPaletteScreen label="Color Palette" route={ROUTE} navigate={() => {}} library={LIBRARY} />)
+	);
+}
+
+describe('Color Palette inheritance pills', () => {
+	/**
+	 * On a non-default palette each card states its own state: the un-overridden color names the
+	 * palette it follows, the overridden one offers the way back.
+	 *
+	 * @return void
+	 */
+	it('gives an inherited swatch the source pill and an overridden swatch the Reset button', () => {
+		renderScreen(makePalettes());
+
+		const pills = [...container.querySelectorAll(`.${PILL_CLASS}`)];
+
+		expect(pills).toHaveLength(2);
+		expect(pills[0].textContent).toBe('From Base');
+		expect(pills[0].tagName).toBe('SPAN');
+		expect(pills[1].textContent).toBe('Reset');
+		expect(pills[1].tagName).toBe('BUTTON');
+	});
+
+	/**
+	 * The default palette defines the values, so its cards have nothing to inherit and show no
+	 * pill at all.
+	 *
+	 * @return void
+	 */
+	it('shows no pill while the default palette is being edited', () => {
+		renderScreen(makePalettes({ editingId: 'default' }));
+
+		expect(container.querySelectorAll(`.${PILL_CLASS}`)).toHaveLength(0);
+	});
+
+	/**
+	 * Clicking Reset reverts that one swatch through the hook, naming the swatch's own token.
+	 *
+	 * The click is awaited inside an async `act()`, not the plain synchronous form used elsewhere in
+	 * this file: the screen's own `.then()` (which restores focus to the card) resolves on a
+	 * microtask after the mocked `resetSwatch` promise settles, and only an async `act()` flushes
+	 * that before the assertion runs.
+	 *
+	 * @return void
+	 */
+	it('reverts the swatch through resetSwatch when Reset is clicked', async () => {
+		const palettes = makePalettes();
+
+		renderScreen(palettes);
+		await act(async () => container.querySelector(`.${PILL_CLASS}--reset`).click());
+
+		expect(palettes.resetSwatch).toHaveBeenCalledWith('accent.two');
+	});
+
+	/**
+	 * A write already in flight anywhere on the screen disables the Reset button, so a second
+	 * click cannot queue a write the hook would reject anyway.
+	 *
+	 * @return void
+	 */
+	it('disables Reset while the screen is busy', () => {
+		renderScreen(makePalettes({ isBusy: true }));
+
+		expect(container.querySelector(`.${PILL_CLASS}--reset`).disabled).toBe(true);
+	});
+
+	/**
+	 * A swatch that is optimistically deleted keeps its Reset button (it still carries an override
+	 * until the delete confirms), but disabled — a card that reads as dead must not leave the pill
+	 * as its only tabbable control.
+	 *
+	 * @return void
+	 */
+	it('disables Reset on a swatch that is pending delete', () => {
+		const palettes = makePalettes();
+		palettes.palette.groups[0].swatches[1].pendingDelete = true;
+
+		renderScreen(palettes);
+
+		expect(container.querySelector(`.${PILL_CLASS}--reset`).disabled).toBe(true);
+	});
+
+	/**
+	 * On a successful reset the card's pill flips from the Reset button to the static "From" pill —
+	 * driven here by re-rendering with the store's own post-reset shape, the way the real
+	 * `usePalettes` would after the write resolves.
+	 *
+	 * @return void
+	 */
+	it('flips the pill to the static state after a successful reset', async () => {
+		const palettes = makePalettes();
+		let resolveReset;
+		palettes.resetSwatch = jest.fn(
+			() =>
+				new Promise((resolve) => {
+					resolveReset = resolve;
+				})
+		);
+
+		renderScreen(palettes);
+
+		await act(async () => {
+			container.querySelector(`.${PILL_CLASS}--reset`).click();
+			resolveReset();
+		});
+
+		// A new `palette` object, not a mutation in place: `gridGroups` is memoized on
+		// `palettes.palette`'s identity, exactly like the real store's own effective view replaces
+		// itself on every write rather than being edited in place.
+		palettes.palette = {
+			groups: [
+				{
+					...palettes.palette.groups[0],
+					swatches: palettes.palette.groups[0].swatches.map((swatch) =>
+						swatch.token === 'accent.two' ? { ...swatch, overridden: false } : swatch
+					),
+				},
+			],
+		};
+		renderScreen(palettes);
+
+		const pills = [...container.querySelectorAll(`.${PILL_CLASS}`)];
+
+		expect(pills).toHaveLength(2);
+		expect(pills.every((pill) => pill.tagName === 'SPAN')).toBe(true);
+	});
+
+	/**
+	 * A failed reset leaves the override in place: the swatch keeps its Reset button, and it is
+	 * still enabled once the screen is no longer busy.
+	 *
+	 * @return void
+	 */
+	it('keeps the override and the operable Reset button after a failed reset', async () => {
+		const palettes = makePalettes();
+		palettes.resetSwatch = jest.fn(() => Promise.reject(new Error('write failed')));
+
+		renderScreen(palettes);
+		await act(async () => container.querySelector(`.${PILL_CLASS}--reset`).click());
+
+		const resetButton = container.querySelector(`.${PILL_CLASS}--reset`);
+
+		expect(resetButton).not.toBeNull();
+		expect(resetButton.disabled).toBe(false);
+	});
+});

--- a/src/style-library/components/atoms/InheritancePill.js
+++ b/src/style-library/components/atoms/InheritancePill.js
@@ -1,0 +1,74 @@
+/**
+ * The one pill slot a swatch card carries under its value line, in either of its two states: a
+ * static pill naming the palette the color still comes from, or the button that drops this
+ * palette's own value and puts the color back on that source.
+ *
+ * Both states occupy the same slot, so a card either says where its value comes from or offers the
+ * way back — never both, and never a slot that changes the card's height.
+ *
+ * Deliberately no icon and no tooltip: the pill's own words carry the meaning, and at this size a
+ * glyph reads as a smudge.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './InheritancePill.scss';
+
+/**
+ * Render the inheritance pill.
+ *
+ * @param {Object}   props               The component props.
+ * @param {string}   props.variant       `'inherited'` for the static pill, `'reset'` for the button.
+ * @param {string}   [props.sourceLabel] The display label of the palette the value comes from.
+ * @param {string}   [props.swatchName]  The color's name, used only in the reset button's
+ *                                       accessible name — the visible text stays "Reset" so a row
+ *                                       of pills stays scannable.
+ * @param {Function} [props.onReset]     Called when the reset button is clicked.
+ * @param {boolean}  [props.isDisabled]  Whether this pill's action is unavailable right now.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The pill.
+ */
+export function InheritancePill({
+	variant,
+	sourceLabel = '',
+	swatchName = '',
+	onReset = () => {},
+	isDisabled = false,
+}) {
+	if ('reset' === variant) {
+		return (
+			<button
+				type="button"
+				className="kadence-blocks-style-library__inheritance-pill kadence-blocks-style-library__inheritance-pill--reset"
+				onClick={onReset}
+				disabled={isDisabled}
+				aria-label={sprintf(
+					// translators: 1: the color's name, 2: the palette its value comes back from.
+					__('Reset %1$s to %2$s', 'kadence-blocks'),
+					swatchName,
+					sourceLabel
+				)}
+			>
+				{__('Reset', 'kadence-blocks')}
+			</button>
+		);
+	}
+
+	return (
+		<span className="kadence-blocks-style-library__inheritance-pill kadence-blocks-style-library__inheritance-pill--inherited">
+			{sprintf(
+				// translators: %s: the palette this color's value comes from.
+				__('From %s', 'kadence-blocks'),
+				sourceLabel
+			)}
+		</span>
+	);
+}

--- a/src/style-library/components/atoms/InheritancePill.scss
+++ b/src/style-library/components/atoms/InheritancePill.scss
@@ -1,0 +1,41 @@
+.kadence-blocks-style-library__inheritance-pill {
+	display: inline-flex;
+	align-items: center;
+	box-sizing: border-box;
+	// The two variants must measure the same height even though only one of them draws a border:
+	// a transparent border on the static pill keeps both boxes identical, so a mixed row of cards
+	// stays on one baseline.
+	border: var(--kb-sl-border-width-input) solid transparent;
+	border-radius: var(--kb-sl-radius-full);
+	padding: 0 var(--kb-sl-space-10);
+	font-size: var(--kb-sl-font-size-xs);
+	font-weight: var(--kb-sl-font-weight-regular);
+	// 1.125rem, matching `MetaChip` — the pill ramp, not on the line-height scale.
+	line-height: 1.125rem;
+	white-space: nowrap;
+}
+
+// Not a control: no hover treatment and no pointer cursor, so nothing invites a click that does
+// nothing.
+.kadence-blocks-style-library__inheritance-pill--inherited {
+	background: var(--kb-sl-color-gray-100);
+	color: var(--kb-sl-color-text-muted);
+}
+
+.kadence-blocks-style-library__inheritance-pill--reset {
+	border-color: var(--kb-sl-color-gray-400);
+	background: transparent;
+	color: var(--kb-sl-color-theme);
+	cursor: pointer;
+
+	&:hover:not(:disabled),
+	&:focus-visible {
+		border-color: var(--kb-sl-color-theme);
+		background: var(--kb-sl-color-theme-tint-4);
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+}

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -9,7 +9,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { Button, DropdownMenu, MenuGroup, MenuItem, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical, plus } from '@wordpress/icons';
@@ -18,6 +18,7 @@ import { moreVertical, plus } from '@wordpress/icons';
  * Internal dependencies
  */
 import { colord } from '../../helpers/colord';
+import { InheritancePill } from '../atoms/InheritancePill';
 import { ScreenHeader } from '../organisms/ScreenHeader';
 import { SwatchGrid } from '../organisms/SwatchGrid';
 import { SelectDropdown } from '../molecules/SelectDropdown';
@@ -37,6 +38,7 @@ import {
 	isUserCreatedPalette,
 	mapPaletteToSwatchGroups,
 	paletteDisplayLabel,
+	paletteShowsInheritance,
 	paletteSuccessorOptions,
 } from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
@@ -160,6 +162,49 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	const isEditingUserCreated = isUserCreatedPalette(palettes.listing, palettes.editingId);
 	const activeRow = palettes.listing.palettes.find((row) => row.id === palettes.activeId);
 
+	// The pills only exist on a palette that has something to inherit FROM, and both the pill and
+	// the notice name that palette by its current label — the default palette can be renamed, so
+	// the word on the card has to come from the listing rather than from a literal.
+	const showsInheritance = paletteShowsInheritance(palettes.listing, palettes.editingId);
+	const defaultLabel = paletteDisplayLabel(
+		palettes.listing.palettes.find((row) => row.id === palettes.listing.defaultId)
+	);
+
+	/**
+	 * Reset one swatch's override, then, on success, move focus to that card's own select button —
+	 * the pill that was just clicked is about to unmount (the card flips back to the static "From"
+	 * pill), and React would otherwise drop focus to `<body>`. The card and its select button are
+	 * resolved from the click event up front rather than through a ref, since `card` is only needed
+	 * once the promise settles and may be gone from the document by then; a failed reset leaves the
+	 * Reset button in place, so focus is left alone on failure.
+	 *
+	 * @param {Event}  event The click event from the pill's own button.
+	 * @param {string} token The swatch token to reset.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	const handleResetSwatch = useCallback(
+		(event, token) => {
+			if (palettes.isBusy) {
+				return;
+			}
+
+			const card = event.currentTarget?.closest('.kadence-blocks-style-library__swatch-card');
+
+			palettes
+				.resetSwatch(token)
+				.then(() => {
+					card?.querySelector('.kadence-blocks-style-library__swatch-card-select')?.focus();
+				})
+				// Swallowed: a failure already surfaces as a toast from inside `resetSwatch`, and the
+				// card simply keeps showing its override.
+				.catch(() => {});
+		},
+		[palettes.isBusy, palettes.resetSwatch]
+	);
+
 	const options = useMemo(
 		() =>
 			palettes.listing.palettes.map((row) => ({
@@ -186,9 +231,21 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 					// delete, where reordering something about to vanish is not meaningful.
 					isDraggable: !item.pendingDelete,
 					isPendingDelete: item.pendingDelete,
+					pill:
+						!showsInheritance || !defaultLabel ? null : item.overridden ? (
+							<InheritancePill
+								variant="reset"
+								sourceLabel={defaultLabel}
+								swatchName={item.name}
+								isDisabled={palettes.isBusy || item.pendingDelete}
+								onReset={(event) => handleResetSwatch(event, item.id)}
+							/>
+						) : (
+							<InheritancePill variant="inherited" sourceLabel={defaultLabel} />
+						),
 				})),
 			})),
-		[palettes.palette]
+		[palettes.palette, palettes.isBusy, showsInheritance, defaultLabel, handleResetSwatch]
 	);
 
 	return (


### PR DESCRIPTION
Fills the slot from the previous slice: on a palette that is not the default one, every swatch card now states where its color comes from, or offers the way back.

Stacked on #1468.

## What a card shows

| Palette being edited | Swatch | Slot |
| --- | --- | --- |
| the default palette | any | nothing, and no space reserved |
| any other palette | still inherits | a static `From <default palette name>` pill |
| any other palette | has its own value | a `Reset` button |

Reset drops this palette's own value for that one token and puts the color back on the palette it inherits from. It calls `usePalettes().resetSwatch()` — the same granular per-token revert the settings panel's own Reset has always used, now reachable from the card itself.

The source palette is never the literal word "Default": both the pill and the button's accessible name interpolate the default palette's current display label, read from the listing on every render, so renaming that palette renames it here. When the listing has no label to offer, the pill is omitted rather than rendering "From ".

## Accessibility

- The static pill is a `span` with no hover treatment and no pointer cursor — it states a fact, it is not a control.
- Reset's visible text stays one word so a row of pills stays scannable; its accessible name is `Reset <color> to <palette>`.
- Reset is disabled while any write holds the screen busy, and on a card whose swatch is being deleted — otherwise it would be the only tabbable control left on a card the UI already presents as inert.
- A successful reset replaces the focused button with the static pill, so focus moves to that card's own select button instead of falling to `body`. A failed reset leaves focus alone, because the button is still there.
- The drag overlay copy never carries the pill, so a drag does not put a duplicate control under the pointer.

## Test plan

`npm test -- src/style-library/__tests__/inheritance-pill.test.js src/style-library/__tests__/palette-inheritance.test.js`

The atom's own tests cover both variants, the accessible name, the click, and the disabled path. The screen tests mount the real `ColorPaletteScreen` and cover: which pill each swatch gets, no pills at all on the default palette, `resetSwatch` called with the right token, Reset disabled while busy and while pending delete, the pill flipping back to the static state after a successful reset, and the override surviving a failed one.

The whole app suite is green, and `npx eslint src/style-library` is clean.

## Screenshots
the two states side by side
<img width="1567" height="340" alt="accent-row-pill-states" src="https://github.com/user-attachments/assets/6e463bec-3d06-49eb-ace8-ea45fbab921c" />

the hover treatment
<img width="1566" height="338" alt="default-palette-accent-row" src="https://github.com/user-attachments/assets/33a3ad63-5697-4ad8-a039-29fcef6aa7a5" />

no pills on the default palette
<img width="1567" height="340" alt="reset-pill-hover" src="https://github.com/user-attachments/assets/c8775c74-e310-4c33-b4fe-ca8d72ad6e01" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inheritance indicators to color palette swatches.
  * Overridden swatches now include controls to restore inherited values.
  * Restoring a value returns focus to the relevant swatch selector.
  * Reset controls are disabled during busy or pending-delete states.

* **Bug Fixes**
  * Reset failures now preserve the current state without unexpectedly changing focus.

* **Tests**
  * Added coverage for inheritance labels, reset behavior, accessibility, disabled states, and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->