### PR TITLE
[DTM] SOFT-3908 [4/4]: palette inheritance notice

### DIFF
--- a/src/style-library/__tests__/palette-inheritance.test.js
+++ b/src/style-library/__tests__/palette-inheritance.test.js
@@ -292,7 +292,7 @@ describe('Color Palette inheritance pills', () => {
 		expect(pills).toHaveLength(2);
 		expect(pills.every((pill) => pill.tagName === 'SPAN')).toBe(true);
 		expect(container.querySelector('.kadence-blocks-style-library__palette-inheritance-notice').textContent).toBe(
-			'2 colors in this palette still follow Base. Editing them in Base updates them here too, until you customize them.'
+			'2 colors in this palette still follow Base. Until you customize them in this palette, editing them in Base will also update them here.'
 		);
 	});
 
@@ -328,7 +328,7 @@ describe('Color Palette inheritance notice', () => {
 		renderScreen(makePalettes());
 
 		expect(container.querySelector(`.${NOTICE_CLASS}`).textContent).toBe(
-			'1 color in this palette still follows Base. Editing it in Base updates it here too, until you customize it.'
+			'1 color in this palette still follows Base. Until you customize it in this palette, editing it in Base will also update it here.'
 		);
 	});
 

--- a/src/style-library/__tests__/palette-inheritance.test.js
+++ b/src/style-library/__tests__/palette-inheritance.test.js
@@ -249,13 +249,13 @@ describe('Color Palette inheritance pills', () => {
 	});
 
 	/**
-	 * On a successful reset the card's pill flips from the Reset button to the static "From" pill —
-	 * driven here by re-rendering with the store's own post-reset shape, the way the real
-	 * `usePalettes` would after the write resolves.
+	 * On a successful reset the card's pill flips from the Reset button to the static "From" pill,
+	 * and the inheritance notice's count goes up by one — driven here by re-rendering with the
+	 * store's own post-reset shape, the way the real `usePalettes` would after the write resolves.
 	 *
 	 * @return void
 	 */
-	it('flips the pill to the static state after a successful reset', async () => {
+	it('flips the pill to the static state and grows the notice count after a successful reset', async () => {
 		const palettes = makePalettes();
 		let resolveReset;
 		palettes.resetSwatch = jest.fn(
@@ -291,6 +291,9 @@ describe('Color Palette inheritance pills', () => {
 
 		expect(pills).toHaveLength(2);
 		expect(pills.every((pill) => pill.tagName === 'SPAN')).toBe(true);
+		expect(container.querySelector('.kadence-blocks-style-library__palette-inheritance-notice').textContent).toBe(
+			'2 colors in this palette still follow Base. Editing them in Base updates them here too, until you customize them.'
+		);
 	});
 
 	/**
@@ -310,5 +313,48 @@ describe('Color Palette inheritance pills', () => {
 
 		expect(resetButton).not.toBeNull();
 		expect(resetButton.disabled).toBe(false);
+	});
+});
+
+describe('Color Palette inheritance notice', () => {
+	const NOTICE_CLASS = 'kadence-blocks-style-library__palette-inheritance-notice';
+
+	/**
+	 * The notice counts the colors that still follow the default palette and names that palette.
+	 *
+	 * @return void
+	 */
+	it('counts the colors that still follow the default palette', () => {
+		renderScreen(makePalettes());
+
+		expect(container.querySelector(`.${NOTICE_CLASS}`).textContent).toBe(
+			'1 color in this palette still follows Base. Editing it in Base updates it here too, until you customize it.'
+		);
+	});
+
+	/**
+	 * With every color customized there is nothing left to explain, so the notice is absent rather
+	 * than stating zero.
+	 *
+	 * @return void
+	 */
+	it('renders nothing when every color is customized', () => {
+		const palettes = makePalettes();
+		palettes.palette.groups[0].swatches[0].overridden = true;
+
+		renderScreen(palettes);
+
+		expect(container.querySelector(`.${NOTICE_CLASS}`)).toBeNull();
+	});
+
+	/**
+	 * The default palette has no source to follow, so the notice never appears on it.
+	 *
+	 * @return void
+	 */
+	it('renders nothing while the default palette is being edited', () => {
+		renderScreen(makePalettes({ editingId: 'default' }));
+
+		expect(container.querySelector(`.${NOTICE_CLASS}`)).toBeNull();
 	});
 });

--- a/src/style-library/components/molecules/PaletteInheritanceNotice.js
+++ b/src/style-library/components/molecules/PaletteInheritanceNotice.js
@@ -38,8 +38,8 @@ export function PaletteInheritanceNotice({ count, sourceLabel }) {
 			{sprintf(
 				/* translators: 1: number of colors, 2: the source palette's name. */
 				_n(
-					'%1$d color in this palette still follows %2$s. Editing it in %2$s updates it here too, until you customize it.',
-					'%1$d colors in this palette still follow %2$s. Editing them in %2$s updates them here too, until you customize them.',
+					'%1$d color in this palette still follows %2$s. Until you customize it in this palette, editing it in %2$s will also update it here.',
+					'%1$d colors in this palette still follow %2$s. Until you customize them in this palette, editing them in %2$s will also update them here.',
 					count,
 					'kadence-blocks'
 				),

--- a/src/style-library/components/molecules/PaletteInheritanceNotice.js
+++ b/src/style-library/components/molecules/PaletteInheritanceNotice.js
@@ -1,0 +1,51 @@
+/**
+ * The notice above the swatch grid, stating how many of this palette's colors still take their
+ * value from the palette they were built on, and what that means when that palette is edited.
+ *
+ * Stated once, in place, rather than behind a tooltip on each card: inheritance is the state of
+ * every card here, and a hint that only pays off for a user who already suspects something is not
+ * an explanation.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './PaletteInheritanceNotice.scss';
+
+/**
+ * Render the palette inheritance notice.
+ *
+ * @param {Object} props             The component props.
+ * @param {number} props.count       How many colors still follow the source palette.
+ * @param {string} props.sourceLabel The source palette's display label.
+ *
+ * @since TBD
+ *
+ * @return {?JSX.Element} The notice, or null when nothing is inherited.
+ */
+export function PaletteInheritanceNotice({ count, sourceLabel }) {
+	if (count < 1 || !sourceLabel) {
+		return null;
+	}
+
+	return (
+		<p className="kadence-blocks-style-library__palette-inheritance-notice" role="status">
+			{sprintf(
+				/* translators: 1: number of colors, 2: the source palette's name. */
+				_n(
+					'%1$d color in this palette still follows %2$s. Editing it in %2$s updates it here too, until you customize it.',
+					'%1$d colors in this palette still follow %2$s. Editing them in %2$s updates them here too, until you customize them.',
+					count,
+					'kadence-blocks'
+				),
+				count,
+				sourceLabel
+			)}
+		</p>
+	);
+}

--- a/src/style-library/components/molecules/PaletteInheritanceNotice.scss
+++ b/src/style-library/components/molecules/PaletteInheritanceNotice.scss
@@ -1,0 +1,11 @@
+.kadence-blocks-style-library__palette-inheritance-notice {
+	box-sizing: border-box;
+	margin: 0 0 var(--kb-sl-space-20);
+	padding: var(--kb-sl-space-10) var(--kb-sl-space-15);
+	border: var(--kb-sl-border-width-input) solid var(--kb-sl-color-theme);
+	border-radius: var(--kb-sl-radius-m);
+	background: var(--kb-sl-color-theme-tint-4);
+	color: var(--kb-sl-color-text-primary);
+	font-size: var(--kb-sl-font-size-s);
+	line-height: var(--kb-sl-line-height-m);
+}

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -24,6 +24,7 @@ import { SwatchGrid } from '../organisms/SwatchGrid';
 import { SelectDropdown } from '../molecules/SelectDropdown';
 import { ScreenDescription } from '../molecules/ScreenDescription';
 import { EmptyState } from '../molecules/EmptyState';
+import { PaletteInheritanceNotice } from '../molecules/PaletteInheritanceNotice';
 import { Skeleton } from '../atoms/Skeleton';
 import { ActivatePaletteButton } from '../organisms/ActivatePaletteButton';
 import { CreatePaletteModal } from '../organisms/CreatePaletteModal';
@@ -35,6 +36,7 @@ import { DeleteColorGroupModal } from '../organisms/DeleteColorGroupModal';
 import { usePalettes } from '../../hooks/use-palettes';
 import { useLoadingAnnouncement } from '../../hooks/use-loading-announcement';
 import {
+	inheritedSwatchCount,
 	isUserCreatedPalette,
 	mapPaletteToSwatchGroups,
 	paletteDisplayLabel,
@@ -334,6 +336,9 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 						<Notice status="error" onRemove={palettes.clearStructureError}>
 							{palettes.structureError.message}
 						</Notice>
+					)}
+					{showsInheritance && (
+						<PaletteInheritanceNotice count={inheritedSwatchCount(gridGroups)} sourceLabel={defaultLabel} />
 					)}
 					<SwatchGrid
 						groups={gridGroups}


### PR DESCRIPTION
States the inheritance rule once, above the grid, instead of leaving it to be inferred from the pills.

Stacked on #1469.

## What it says

> 17 colors in this palette still follow Default. Until you customize them in this palette, editing them in Default will also update them here.

Rendered only while the palette being edited has a source to inherit from, and only while something still inherits — customize the last one and the notice goes away rather than announcing zero. Singular and plural are separate strings, so one color reads "1 color … still follows … until you customize it".

Like the pills, the palette is named from the listing rather than the literal word "Default", so renaming the default palette renames it here too.

The count comes from the mapped grid groups — the cards actually on screen — so an optimistically added color counts immediately and one being deleted stops counting before the write settles, instead of the number contradicting the grid under it.

`role="status"` on the notice means the count change after a reset is announced, which is the only feedback a screen-reader user gets that the reset landed once the pill they activated has been replaced.

## Test plan

`npm test -- src/style-library/__tests__/palette-inheritance.test.js`

Covers the exact sentence for the current count, absence when every color is customized, and absence on the default palette. The reset round-trip test in the previous slice asserts the count grows when a color goes back to inherited.

The whole app suite is green, and `npx eslint src/style-library` is clean.

## Screenshots

shows the notice above the grid with the pills underneath it.
<img width="1480" height="812" alt="secondary-palette-pills-and-notice" src="https://github.com/user-attachments/assets/eb43c175-04db-41ee-a695-3f76c120551b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessible notice to color palette screens when colors are inherited from another palette.
  * Notices now show the number of inherited colors and explain how updates to the source palette affect them.
  * Added singular and plural messaging, with no notice shown for fully customized or default palettes.

* **Bug Fixes**
  * Corrected inheritance counts after palette colors are reset to inherited values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
