### PR TITLE
Preset hover states [1/3]: clear every hover-radius attribute on reset

### DIFF
--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -3429,7 +3429,20 @@ function SectionEdit(props) {
 															inheritedBorderHoverRadius.inherited
 														)}
 														state={borderHoverRadiusBinding}
-														onReset={() => resetToken('borderHoverRadius')}
+														// The kind is stated rather than looked up: no preset
+														// property binds `borderHoverRadius`, so `resetToken`
+														// would resolve `undefined` and clear the desktop
+														// attribute to a bare `''` -- leaving the tablet/mobile
+														// companions and the unit untouched, and storing a string
+														// where the block declares a four-side array.
+														onReset={() =>
+															resetAttr(
+																'borderHoverRadius',
+																setAttributes,
+																'dimension',
+																metadata.attributes
+															)
+														}
 														isLinked={borderHoverRadiusIsLinked}
 														onToggleLink={toggleBorderHoverRadiusLink}
 														unit={borderHoverRadiusUnit}

--- a/src/extension/token-indicators/index.js
+++ b/src/extension/token-indicators/index.js
@@ -376,11 +376,13 @@ export function presetPropertyReference(blockName, propertyKey, attributes, libr
  * Shared by the per-control reset (`resetAttr`) and the picker's reset-all, so their clearing convention
  * cannot drift.
  *
- * @param {string}  attr       The primary attribute name.
- * @param {string}  kind       The property kind, so a dimension/border also clears its companions.
- * @param {?Object} [declared] The block's declared attributes (`getBlockType(name).attributes`), read for
- *                             the shape a dimension clears to and which companions exist. Omit when the
- *                             caller has no block to read it from.
+ * @param {string}  attr              The primary attribute name.
+ * @param {string}  kind              The property kind, so a dimension/border also clears its companions.
+ * @param {?Object} [declared]        The block's declared attributes (`getBlockType(name).attributes`), read
+ *                                    for the shape a dimension clears to and which companions exist. Omit
+ *                                    when the caller has no block to read it from.
+ * @param {?Object} [responsiveAttrs] The binding's declared `{ tablet, mobile }` attribute names, for a block
+ *                                    that names its per-device attributes outside the prefix convention.
  *
  * @since TBD
  *


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4264/let-a-preset-set-hover-state-properties-button-section

:video_camera: https://www.loom.com/share/bec2090b5ff74822908acd988cad6827

Answers [this review comment](https://github.com/stellarwp/kadence-blocks/pull/1450#discussion_r3887705850).

The Section's hover-radius reset looked its kind up on the block's preset binding, and nothing bound `borderHoverRadius` — so `resetAttrPatch()` fell through to its scalar branch and wrote a bare `{ borderHoverRadius: '' }`. `tabletBorderHoverRadius`, `mobileBorderHoverRadius` and `borderHoverRadiusUnit` were left untouched, and the desktop attribute came back as a string where `block.json` declares a four-side array — which the box control reads as a custom value rather than a reset.

The kind is now stated at the call site, the way the Button's ten per-state resets already do. Stated rather than derived because `usePresetBinding()` returns an empty map when the registry is inactive.

Also documents `resetAttrPatch()`'s fourth parameter, which had no `@param`.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resetting of hover border-radius settings so dimension values clear correctly.

* **Documentation**
  * Clarified guidance for resetting responsive and declared attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
