### PR TITLE
Preset hover states [2/3]: let a preset scope a property to a UI state

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Css_Builder.php
@@ -3,6 +3,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Css_Builder as Preset_Css_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Composes_Selector_Suffix;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Binding;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
@@ -55,6 +56,7 @@ use RuntimeException;
  */
 final class Css_Builder {
 
+	use Composes_Selector_Suffix;
 	use Sanitizes_Css_Value;
 
 	/**
@@ -252,6 +254,15 @@ final class Css_Builder {
 					continue;
 				}
 
+				// A state binding (`:hover` and friends) belongs to the selected-preset projector alone. This
+				// layer renders only the `$default` preset, so its rule carries no preset class and matches
+				// every instance of the block — and a state rule outranks the block's own resting
+				// per-instance rule, so emitting one here would repaint content that never opted into a state.
+				// See Binding::CSS_STATE.
+				if ( $binding->is_state() ) {
+					continue;
+				}
+
 				$prop = $binding->css_prop();
 
 				// A per-corner slot list is a CSS shorthand here — this is a css-emitting surface, so the
@@ -370,27 +381,4 @@ final class Css_Builder {
 		return $this->memo[ $memo_key ] = $css;
 	}
 
-	/**
-	 * Compose a binding's optional `css_selector` into the suffix appended after the block's `.wp-block-*`
-	 * class. A bare selector (e.g. `img`) is treated as a descendant and gets the combinator space inserted
-	 * for it, so the declaration never has to carry a load-bearing leading space. A suffix that already
-	 * opens with a combinator or attachment character (`>`, `+`, `~`, `.`, `:`, `#`, `[`, `&`) is used
-	 * verbatim, so child combinators (`> img`) and compound/stateful selectors (`.is-style-rounded`) stay
-	 * expressible. Empty when the binding names no descendant — the rule targets the block root.
-	 *
-	 * @since TBD
-	 *
-	 * @param string|null $selector The binding's raw `css_selector`, or null when it names none.
-	 *
-	 * @return string The selector suffix, ready to concatenate after the block class.
-	 */
-	private function selector_suffix( ?string $selector ): string {
-		$selector = trim( (string) $selector );
-
-		if ( $selector === '' ) {
-			return '';
-		}
-
-		return strpbrk( $selector[0], '>+~.:#[&' ) === false ? ' ' . $selector : $selector;
-	}
 }

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -37,10 +37,11 @@ use RuntimeException;
  *   2. Per (block, preset) scoped rules — ".wp-block-<block>.kb-preset--<preset>" — pointing each
  *      --global-<slot> at the canonical preset var, plus a class-less ".wp-block-<block>" rule for the
  *      $default preset so a block with no preset selected still shows its preset.
- *   3. Per (block, preset) STATE rules for any binding declaring a `css_state` — the same two scopes with the
- *      block class neutralized by `:where()` and the state suffix appended
- *      (":where(.wp-block-<block>).kb-preset--<preset>:hover > .kt-inside-inner-col") — carrying a real
- *      declaration, "<css_prop>: var(<canonical preset var>)", rather than a var retarget.
+ *   3. Per (block, preset) STATE rules for any binding declaring a `css_state` — the block-and-preset
+ *      qualification wrapped in `:where()` so it costs no specificity, with the state suffix appended
+ *      (":where(.wp-block-<block>.kb-preset--<preset>):hover > .kt-inside-inner-col") — carrying a real
+ *      declaration, "<css_prop>: var(<canonical preset var>)", rather than a var retarget. The $default's
+ *      counterpart is qualified by "this block carries no preset class" so the two can never both match.
  *      A state has no variable of the block's own to point at: the block renders its resting appearance
  *      from an attribute or a token default, and its state appearance only when the block itself sets one,
  *      so there is nothing for a preset to redirect. This layer supplies the state rule outright. It is
@@ -640,7 +641,7 @@ final class Css_Builder {
 				$css .= $this->state_rules(
 					$block,
 					(string) $preset,
-					$this->state_scope( $data['selector'] ) . $preset_class,
+					$this->state_scope( $data['selector'], $preset_class ),
 					$properties,
 					$editor
 				);
@@ -679,36 +680,43 @@ final class Css_Builder {
 				$css .= $data['selector'] . '{' . $declarations . '}';
 			}
 
-			$css .= $this->state_rules( $block, $default, $this->state_scope( $data['selector'] ), $properties, $editor );
+			$css .= $this->state_rules( $block, $default, $this->state_scope( $data['selector'], null ), $properties, $editor );
 		}
 
 		return $css;
 	}
 
 	/**
-	 * The block half of a state rule's scope: the block selector wrapped in `:where()`, which matches exactly
-	 * as it did but contributes no specificity.
+	 * The scope a state rule is emitted under: the whole block-and-preset qualification wrapped in `:where()`,
+	 * so it matches exactly as it would unwrapped while contributing no specificity of its own.
 	 *
 	 * Every other layer of this projection writes custom properties, whose specificity never competes with a
 	 * block's own declarations. A state rule writes a real declaration, so it does — and the layering rule the
 	 * whole projection rests on is that a preset yields to the block's own CSS. Left un-neutralized, the block
-	 * class plus the preset class would put a state rule at two classes before the state's own weight, which is
+	 * class plus the preset class would put a state rule two classes above the state's own weight, which is
 	 * more than most blocks spend on their per-instance rules; a preset's hover would then beat a hover the
 	 * user set on the block itself.
 	 *
-	 * Neutralizing the block class rather than the preset class is what keeps a selected preset's state ahead
-	 * of the `$default`'s: the named rule carries exactly one class more, so it wins without depending on the
-	 * order the two are emitted in. What remains is the binding's own `css_state`, which is where a block's
-	 * author states the weight that block needs — the only place that knows what the block's own rules cost.
+	 * With the qualification weightless, a state rule weighs exactly what the binding's `css_state` names —
+	 * which is where a block's author states the weight that block needs, the only place that knows what the
+	 * block's own rules cost. That also leaves a named preset's rule and the `$default`'s at the SAME weight,
+	 * which is why the `$default`'s is qualified by "this block has no preset class" rather than by nothing:
+	 * the two must never both match, since neither could then outrank the other.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $selector The block's `.wp-block-*` selector.
+	 * @param string      $selector The block's `.wp-block-*` selector.
+	 * @param string|null $preset   The preset class selector (leading dot included) for a named preset, or
+	 *                              null for the `$default`'s rule.
 	 *
 	 * @return string
 	 */
-	private function state_scope( string $selector ): string {
-		return ':where(' . $selector . ')';
+	private function state_scope( string $selector, ?string $preset ): string {
+		$qualifier = $preset !== null
+			? $selector . $preset
+			: $selector . ':not([class*="' . Style::get_class_prefix() . '"])';
+
+		return ':where(' . $qualifier . ')';
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -37,9 +37,10 @@ use RuntimeException;
  *   2. Per (block, preset) scoped rules — ".wp-block-<block>.kb-preset--<preset>" — pointing each
  *      --global-<slot> at the canonical preset var, plus a class-less ".wp-block-<block>" rule for the
  *      $default preset so a block with no preset selected still shows its preset.
- *   3. Per (block, preset) STATE rules for any binding declaring a `css_state` — the same two scopes with
- *      the state suffix appended (".wp-block-<block>.kb-preset--<preset>:hover > .kt-inside-inner-col") —
- *      carrying a real declaration, "<css_prop>: var(<canonical preset var>)", rather than a var retarget.
+ *   3. Per (block, preset) STATE rules for any binding declaring a `css_state` — the same two scopes with the
+ *      block class neutralized by `:where()` and the state suffix appended
+ *      (":where(.wp-block-<block>).kb-preset--<preset>:hover > .kt-inside-inner-col") — carrying a real
+ *      declaration, "<css_prop>: var(<canonical preset var>)", rather than a var retarget.
  *      A state has no variable of the block's own to point at: the block renders its resting appearance
  *      from an attribute or a token default, and its state appearance only when the block itself sets one,
  *      so there is nothing for a preset to redirect. This layer supplies the state rule outright. It is
@@ -629,14 +630,20 @@ final class Css_Builder {
 
 		foreach ( $collected as $block => $data ) {
 			foreach ( $data['presets'] as $preset => $properties ) {
-				$scope        = $data['selector'] . '.' . Style::preset_class( (string) $preset );
+				$preset_class = '.' . Style::preset_class( (string) $preset );
 				$declarations = $this->slot_declarations( $block, (string) $preset, $properties );
 
 				if ( $declarations !== '' ) {
-					$css .= $scope . '{' . $declarations . '}';
+					$css .= $data['selector'] . $preset_class . '{' . $declarations . '}';
 				}
 
-				$css .= $this->state_rules( $block, (string) $preset, $scope, $properties, $editor );
+				$css .= $this->state_rules(
+					$block,
+					(string) $preset,
+					$this->state_scope( $data['selector'] ) . $preset_class,
+					$properties,
+					$editor
+				);
 			}
 		}
 
@@ -672,10 +679,36 @@ final class Css_Builder {
 				$css .= $data['selector'] . '{' . $declarations . '}';
 			}
 
-			$css .= $this->state_rules( $block, $default, $data['selector'], $properties, $editor );
+			$css .= $this->state_rules( $block, $default, $this->state_scope( $data['selector'] ), $properties, $editor );
 		}
 
 		return $css;
+	}
+
+	/**
+	 * The block half of a state rule's scope: the block selector wrapped in `:where()`, which matches exactly
+	 * as it did but contributes no specificity.
+	 *
+	 * Every other layer of this projection writes custom properties, whose specificity never competes with a
+	 * block's own declarations. A state rule writes a real declaration, so it does — and the layering rule the
+	 * whole projection rests on is that a preset yields to the block's own CSS. Left un-neutralized, the block
+	 * class plus the preset class would put a state rule at two classes before the state's own weight, which is
+	 * more than most blocks spend on their per-instance rules; a preset's hover would then beat a hover the
+	 * user set on the block itself.
+	 *
+	 * Neutralizing the block class rather than the preset class is what keeps a selected preset's state ahead
+	 * of the `$default`'s: the named rule carries exactly one class more, so it wins without depending on the
+	 * order the two are emitted in. What remains is the binding's own `css_state`, which is where a block's
+	 * author states the weight that block needs — the only place that knows what the block's own rules cost.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $selector The block's `.wp-block-*` selector.
+	 *
+	 * @return string
+	 */
+	private function state_scope( string $selector ): string {
+		return ':where(' . $selector . ')';
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -717,6 +717,12 @@ final class Css_Builder {
 	 * Grouped by suffix so a block with several state properties on the same element emits one rule, matching
 	 * how the block-default-CSS layer groups its own descendant rules.
 	 *
+	 * A `css_state` may name several states at once, comma separated (`*.kb-button:hover,*.kb-button:focus`),
+	 * for the many blocks whose own CSS treats hover and keyboard focus as one look. Each part is scoped
+	 * independently — the scope is repeated per part rather than distributed over the group — because a
+	 * selector list only applies its leading compound to its FIRST part, so a naive concatenation would leave
+	 * every part after the first matching the whole document.
+	 *
 	 * @since TBD
 	 *
 	 * @param string                                                                                          $block      The block name.
@@ -735,25 +741,56 @@ final class Css_Builder {
 				continue;
 			}
 
-			$suffix = $this->selector_suffix( $editor ? $info['editor'] : $info['state'] );
+			$suffixes = $this->state_suffixes( $editor ? $info['editor'] : $info['state'] );
 
-			// An empty suffix would put the declaration on the block root with no state at all, which is the
-			// block-default layer's job and would repaint every instance. A state binding whose suffix
+			// An empty suffix list would put the declaration on the block root with no state at all, which is
+			// the block-default layer's job and would repaint every instance. A state binding whose suffix
 			// sanitizes away contributes nothing rather than silently becoming a resting-state rule.
-			if ( $suffix === '' ) {
+			if ( $suffixes === [] ) {
 				continue;
 			}
 
-			$by_suffix[ $suffix ][] = $info['prop'] . ':var(' . $this->preset_var( $block, $preset, (string) $property ) . ')';
+			$by_suffix[ implode( ',', $suffixes ) ][] = $info['prop'] . ':var(' . $this->preset_var( $block, $preset, (string) $property ) . ')';
 		}
 
 		$css = '';
 
 		foreach ( $by_suffix as $suffix => $declarations ) {
-			$css .= $scope . $suffix . '{' . implode( ';', $declarations ) . ';}';
+			$parts = array_map(
+				static function ( string $part ) use ( $scope ): string {
+					return $scope . $part;
+				},
+				explode( ',', (string) $suffix )
+			);
+
+			$css .= implode( ',', $parts ) . '{' . implode( ';', $declarations ) . ';}';
 		}
 
 		return $css;
+	}
+
+	/**
+	 * Split a binding's raw state selector into its individual, composed suffixes, dropping any part that
+	 * sanitizes away to nothing.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|null $state The binding's raw `css_state` / `editor_css_state`.
+	 *
+	 * @return string[] The composed suffixes, empty when the binding names no usable state.
+	 */
+	private function state_suffixes( ?string $state ): array {
+		$suffixes = [];
+
+		foreach ( explode( ',', (string) $state ) as $part ) {
+			$suffix = $this->selector_suffix( $part );
+
+			if ( $suffix !== '' ) {
+				$suffixes[] = $suffix;
+			}
+		}
+
+		return $suffixes;
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -4,6 +4,7 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Composes_Selector_Suffix;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Scope;
@@ -36,6 +37,15 @@ use RuntimeException;
  *   2. Per (block, preset) scoped rules — ".wp-block-<block>.kb-preset--<preset>" — pointing each
  *      --global-<slot> at the canonical preset var, plus a class-less ".wp-block-<block>" rule for the
  *      $default preset so a block with no preset selected still shows its preset.
+ *   3. Per (block, preset) STATE rules for any binding declaring a `css_state` — the same two scopes with
+ *      the state suffix appended (".wp-block-<block>.kb-preset--<preset>:hover > .kt-inside-inner-col") —
+ *      carrying a real declaration, "<css_prop>: var(<canonical preset var>)", rather than a var retarget.
+ *      A state has no variable of the block's own to point at: the block renders its resting appearance
+ *      from an attribute or a token default, and its state appearance only when the block itself sets one,
+ *      so there is nothing for a preset to redirect. This layer supplies the state rule outright. It is
+ *      the ONLY layer that renders a state binding — the block-default-CSS projector skips them, because
+ *      that layer renders only the $default preset and so would put a state rule on every instance of the
+ *      block whether or not a preset asked for one. See {@see Binding::CSS_STATE}.
  *
  * Scoping is per (block, preset): the same preset name on two blocks ("ghost" on a Button and a Row) gets
  * its own qualified rule, so values never collide. Both named presets and the "$default" preset carry
@@ -50,6 +60,7 @@ use RuntimeException;
  */
 final class Css_Builder {
 
+	use Composes_Selector_Suffix;
 	use Sanitizes_Css_Identifier;
 	use Sanitizes_Css_Value;
 
@@ -140,7 +151,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @var array<string, array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}>>
+	 * @var array<string, array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}>>
 	 */
 	private array $collected = [];
 
@@ -171,7 +182,26 @@ final class Css_Builder {
 	 * @return string The CSS, or an empty string when no block contributes a slot-targeted value.
 	 */
 	public function css( string $active_slug, array $breakpoints = [] ): string {
-		return $this->build( $active_slug, $breakpoints );
+		return $this->build( $active_slug, $breakpoints, false );
+	}
+
+	/**
+	 * Build the EDITOR-scoped version of the active library's preset CSS. Identical to {@see self::css()} for
+	 * every layer but the state rules: the canonical vars and the `--global-*` / `--kb-*` retargets carry no
+	 * dependency on the markup's shape, so they are reused verbatim. A state binding declaring an
+	 * `editor_css_state` has its rule re-scoped to the element the editor actually renders — the Section
+	 * paints `.kadence-inner-column-inner` in the canvas and `.kt-inside-inner-col` on the front end — so the
+	 * state lands in the preview too.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                $active_slug The active library's slug.
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
+	 *
+	 * @return string The CSS, or an empty string when no block contributes a slot-targeted value.
+	 */
+	public function editor_css( string $active_slug, array $breakpoints = [] ): string {
+		return $this->build( $active_slug, $breakpoints, true );
 	}
 
 	/**
@@ -192,23 +222,25 @@ final class Css_Builder {
 	 * @return string
 	 */
 	public function css_for_version( string $active_slug, string $version, array $breakpoints = [] ): string {
-		$cache_key = 'preset_css_root_' . KADENCE_BLOCKS_VERSION . '_' . $active_slug . '_' . $version . '_' . $this->breakpoint_signature( $breakpoints );
+		return $this->for_version( $active_slug, $version, $breakpoints, false );
+	}
 
-		if ( isset( $this->memo[ $cache_key ] ) ) {
-			return $this->memo[ $cache_key ];
-		}
-
-		$cached = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
-
-		if ( $found && is_string( $cached ) ) {
-			return $this->memo[ $cache_key ] = $cached;
-		}
-
-		$css = $this->build( $active_slug, $breakpoints );
-
-		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
-
-		return $this->memo[ $cache_key ] = $css;
+	/**
+	 * Cached version of editor_css(): same memo/object-cache mechanics as {@see self::css_for_version()}, but
+	 * keyed under a distinct `editor` context so the editor-scoped string (which differs from the front-end
+	 * one for any state binding declaring an `editor_css_state`) never collides with, or gets served in place
+	 * of, the front-end cache entry.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                $active_slug The active library's slug.
+	 * @param string                $version     The store version the active library was built from.
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
+	 *
+	 * @return string
+	 */
+	public function editor_css_for_version( string $active_slug, string $version, array $breakpoints = [] ): string {
+		return $this->for_version( $active_slug, $version, $breakpoints, true );
 	}
 
 	/**
@@ -229,23 +261,59 @@ final class Css_Builder {
 	}
 
 	/**
+	 * Shared cache/memo plumbing for {@see self::css_for_version()} and {@see self::editor_css_for_version()}.
+	 * The context (front end vs editor) is folded into both the per-request memo key and the object-cache key
+	 * so the two builds never share a cache slot.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                $active_slug The active library's slug.
+	 * @param string                $version     The store version the active library was built from.
+	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
+	 * @param bool                  $editor      Whether to build the editor-scoped CSS.
+	 *
+	 * @return string
+	 */
+	private function for_version( string $active_slug, string $version, array $breakpoints, bool $editor ): string {
+		$context   = $editor ? 'editor' : 'front';
+		$cache_key = 'preset_css_root_' . $context . '_' . KADENCE_BLOCKS_VERSION . '_' . $active_slug . '_' . $version . '_' . $this->breakpoint_signature( $breakpoints );
+
+		if ( isset( $this->memo[ $cache_key ] ) ) {
+			return $this->memo[ $cache_key ];
+		}
+
+		$cached = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+
+		if ( $found && is_string( $cached ) ) {
+			return $this->memo[ $cache_key ] = $cached;
+		}
+
+		$css = $this->build( $active_slug, $breakpoints, $editor );
+
+		wp_cache_set( $cache_key, $css, self::CACHE_GROUP, DAY_IN_SECONDS );
+
+		return $this->memo[ $cache_key ] = $css;
+	}
+
+	/**
 	 * Build (uncached) the active library's preset CSS: the canonical preset-var definitions followed by the
 	 * per-preset scoped rules and the class-less $default rules. The single assembly definition shared by
-	 * css() and the cached css_for_version().
+	 * css()/editor_css() and their cached counterparts.
 	 *
 	 * @since TBD
 	 *
 	 * @param string                $active_slug The active library slug.
 	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
+	 * @param bool                  $editor      Whether to scope state rules to the editor's markup.
 	 *
 	 * @return string
 	 */
-	private function build( string $active_slug, array $breakpoints = [] ): string {
+	private function build( string $active_slug, array $breakpoints, bool $editor ): string {
 		$collected = $this->collect( $active_slug );
 
 		return $this->canonical_block( $collected )
-			. $this->scoped_presets( $collected )
-			. $this->scoped_default( $collected )
+			. $this->scoped_presets( $collected, $editor )
+			. $this->scoped_default( $collected, $editor )
 			. $this->responsive_blocks( $active_slug, $collected, $breakpoints );
 	}
 
@@ -258,7 +326,7 @@ final class Css_Builder {
 	 *
 	 * @param string $slug The library slug to resolve against.
 	 *
-	 * @return array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}>
+	 * @return array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}>
 	 */
 	private function collect( string $slug ): array {
 		$key = $slug . '_' . $this->store->get_version( $slug );
@@ -302,6 +370,34 @@ final class Css_Builder {
 						continue;
 					}
 
+					// Only a "dimension" kind binding ever carries a per-slot list (the write-time
+					// guard rejects one on any other kind); gating the slot split on this, rather than
+					// on the value's own shape, avoids a false-positive split of an unrelated value that
+					// happens to contain spaces (e.g. a shadow literal).
+					$dimension = $bindings->kind( $property ) === Preset_Bindings::get_kind_dimension();
+
+					// A state binding carries a declaration rather than a var retarget, and both of its selectors
+					// are collected so the front-end and editor builds share one memoized walk. It contributes
+					// nothing without a property to set, since the state rule IS that declaration.
+					if ( $binding->is_state() ) {
+						$prop = $binding->css_prop();
+
+						if ( $prop === null ) {
+							continue;
+						}
+
+						$properties[ $property ] = [
+							'target'    => null,
+							'value'     => $value,
+							'dimension' => $dimension,
+							'prop'      => $prop,
+							'state'     => $binding->css_state(),
+							'editor'    => $binding->editor_css_state(),
+						];
+
+						continue;
+					}
+
 					$target = $this->target_var( $binding );
 
 					if ( $target === null ) {
@@ -311,11 +407,10 @@ final class Css_Builder {
 					$properties[ $property ] = [
 						'target'    => $target,
 						'value'     => $value,
-						// Only a "dimension" kind binding ever carries a per-slot list (the write-time
-						// guard rejects one on any other kind); gating the slot split on this, rather than
-						// on the value's own shape, avoids a false-positive split of an unrelated value that
-						// happens to contain spaces (e.g. a shadow literal).
-						'dimension' => $bindings->kind( $property ) === Preset_Bindings::get_kind_dimension(),
+						'dimension' => $dimension,
+						'prop'      => null,
+						'state'     => null,
+						'editor'    => null,
 					];
 				}
 
@@ -350,7 +445,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
@@ -370,7 +465,7 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
@@ -408,7 +503,7 @@ final class Css_Builder {
 	 * @param string                                  $block    The block name.
 	 * @param string                                  $preset   The preset slug.
 	 * @param string                                  $property The block property.
-	 * @param array{target:string, value:string, dimension:bool} $info The property's collected target/value/kind.
+	 * @param array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string} $info The property's collected target/value/kind.
 	 *
 	 * @return string
 	 */
@@ -525,20 +620,23 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
-	private function scoped_presets( array $collected ): string {
+	private function scoped_presets( array $collected, bool $editor ): string {
 		$css = '';
 
 		foreach ( $collected as $block => $data ) {
 			foreach ( $data['presets'] as $preset => $properties ) {
-				$declarations = $this->slot_declarations( $block, $preset, $properties );
+				$scope        = $data['selector'] . '.' . Style::preset_class( (string) $preset );
+				$declarations = $this->slot_declarations( $block, (string) $preset, $properties );
 
 				if ( $declarations !== '' ) {
-					$css .= $data['selector'] . '.' . Style::preset_class( $preset ) . '{' . $declarations . '}';
+					$css .= $scope . '{' . $declarations . '}';
 				}
+
+				$css .= $this->state_rules( $block, (string) $preset, $scope, $properties, $editor );
 			}
 		}
 
@@ -553,11 +651,11 @@ final class Css_Builder {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The active library's collected presets.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}> $collected The active library's collected presets.
 	 *
 	 * @return string
 	 */
-	private function scoped_default( array $collected ): string {
+	private function scoped_default( array $collected, bool $editor ): string {
 		$css = '';
 
 		foreach ( $collected as $block => $data ) {
@@ -567,11 +665,14 @@ final class Css_Builder {
 				continue;
 			}
 
-			$declarations = $this->slot_declarations( $block, $default, $data['presets'][ $default ] );
+			$properties   = $data['presets'][ $default ];
+			$declarations = $this->slot_declarations( $block, $default, $properties );
 
 			if ( $declarations !== '' ) {
 				$css .= $data['selector'] . '{' . $declarations . '}';
 			}
+
+			$css .= $this->state_rules( $block, $default, $data['selector'], $properties, $editor );
 		}
 
 		return $css;
@@ -584,7 +685,7 @@ final class Css_Builder {
 	 *
 	 * @param string                                            $block      The block name.
 	 * @param string                                            $preset     The preset slug.
-	 * @param array<string, array{target:string, value:string, dimension:bool}> $properties The preset's collected properties.
+	 * @param array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}> $properties The preset's collected properties.
 	 *
 	 * @return string
 	 */
@@ -592,10 +693,67 @@ final class Css_Builder {
 		$declarations = '';
 
 		foreach ( $properties as $property => $info ) {
-			$declarations .= $info['target'] . ':var(' . $this->preset_var( $block, $preset, $property ) . ');';
+			// A state property has no variable of the block's own to retarget; it is emitted as its own rule
+			// by state_rules() instead.
+			if ( $info['target'] === null ) {
+				continue;
+			}
+
+			$declarations .= $info['target'] . ':var(' . $this->preset_var( $block, $preset, (string) $property ) . ');';
 		}
 
 		return $declarations;
+	}
+
+	/**
+	 * Emit one preset's state rules for a block: per distinct state suffix, a
+	 * "<scope><suffix>{<css_prop>:var(<canonical preset var>);}" rule.
+	 *
+	 * The scope is the caller's — the preset-classed selector for a named preset, the bare block selector for
+	 * the $default one — so the same specificity relationship the var-retarget layers have is preserved: a
+	 * selected preset's state outranks the $default's, and the block's own per-instance state rule outranks
+	 * both.
+	 *
+	 * Grouped by suffix so a block with several state properties on the same element emits one rule, matching
+	 * how the block-default-CSS layer groups its own descendant rules.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                                                                                          $block      The block name.
+	 * @param string                                                                                          $preset     The preset slug, for the canonical var name.
+	 * @param string                                                                                          $scope      The selector the state suffix is appended to.
+	 * @param array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}> $properties The preset's collected properties.
+	 * @param bool                                                                                            $editor     Whether to use each binding's editor state suffix.
+	 *
+	 * @return string
+	 */
+	private function state_rules( string $block, string $preset, string $scope, array $properties, bool $editor ): string {
+		$by_suffix = [];
+
+		foreach ( $properties as $property => $info ) {
+			if ( $info['prop'] === null ) {
+				continue;
+			}
+
+			$suffix = $this->selector_suffix( $editor ? $info['editor'] : $info['state'] );
+
+			// An empty suffix would put the declaration on the block root with no state at all, which is the
+			// block-default layer's job and would repaint every instance. A state binding whose suffix
+			// sanitizes away contributes nothing rather than silently becoming a resting-state rule.
+			if ( $suffix === '' ) {
+				continue;
+			}
+
+			$by_suffix[ $suffix ][] = $info['prop'] . ':var(' . $this->preset_var( $block, $preset, (string) $property ) . ')';
+		}
+
+		$css = '';
+
+		foreach ( $by_suffix as $suffix => $declarations ) {
+			$css .= $scope . $suffix . '{' . implode( ';', $declarations ) . ';}';
+		}
+
+		return $css;
 	}
 
 	/**
@@ -694,7 +852,7 @@ final class Css_Builder {
 	 * @since TBD
 	 *
 	 * @param string                $active_slug The active library's slug.
-	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:string, value:string, dimension:bool}>>}> $collected The collected preset structure, for the block/preset list.
+	 * @param array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}> $collected The collected preset structure, for the block/preset list.
 	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
 	 *
 	 * @return string

--- a/includes/resources/Design_Tokens/Projection/Preset/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Projector.php
@@ -106,7 +106,7 @@ final class Projector extends Abstract_Css_Projector {
 			return;
 		}
 
-		$css = $this->css();
+		$css = $this->editor_css();
 
 		if ( $css !== '' ) {
 			wp_add_inline_style( 'kadence-blocks-global-editor-styles', $css );
@@ -131,6 +131,32 @@ final class Projector extends Abstract_Css_Projector {
 			$version = $this->store->get_version( $active );
 
 			return $this->css_builder->css_for_version( $active, $version, $this->breakpoints() );
+		} catch ( Throwable $e ) {
+			return '';
+		}
+	}
+
+	/**
+	 * Build the EDITOR-scoped preset CSS for the single active token library.
+	 *
+	 * Overrides the base's "editor output equals front-end output" default because one layer is markup-aware:
+	 * a state rule (a binding declaring a `css_state`) carries a selector suffix, and a block whose editor renders the
+	 * bound element under a different class declares an `editor_css_state` for it. Every other layer — the
+	 * canonical `:root` vars and the block-root var retargets — is reused verbatim.
+	 *
+	 * Degrades the same way {@see self::css()} does: an unreadable store version or an unresolvable preset
+	 * yields an empty string rather than an exception, so the editor loads without the inline style.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function editor_css(): string {
+		try {
+			$active  = $this->active->get();
+			$version = $this->store->get_version( $active );
+
+			return $this->css_builder->editor_css_for_version( $active, $version, $this->breakpoints() );
 		} catch ( Throwable $e ) {
 			return '';
 		}

--- a/includes/resources/Design_Tokens/Projection/Preset/Style.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Style.php
@@ -40,4 +40,16 @@ final class Style {
 	public static function preset_class( string $preset ): string {
 		return self::CLASS_PREFIX . self::sanitize_identifier( $preset );
 	}
+
+	/**
+	 * The class prefix every selected preset shares, e.g. "kb-preset--". Read by the projector to build the
+	 * "no preset selected" test its `$default` state rule is scoped by.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_class_prefix(): string {
+		return self::CLASS_PREFIX;
+	}
 }

--- a/includes/resources/Design_Tokens/Projection/Traits/Composes_Selector_Suffix.php
+++ b/includes/resources/Design_Tokens/Projection/Traits/Composes_Selector_Suffix.php
@@ -1,0 +1,38 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits;
+
+/**
+ * Shared composer for the selector suffix a binding appends after a block's `.wp-block-*` class, used by
+ * every projector that emits a real CSS declaration rather than a custom property.
+ *
+ * @since TBD
+ */
+trait Composes_Selector_Suffix {
+
+	/**
+	 * Compose a binding's optional selector suffix into the string appended after the block's `.wp-block-*`
+	 * class. A bare selector (e.g. `img`) is treated as a descendant and gets the combinator space inserted
+	 * for it, so the declaration never has to carry a load-bearing leading space. A suffix that already
+	 * opens with a combinator or attachment character (`>`, `+`, `~`, `.`, `:`, `#`, `[`, `&`) is used
+	 * verbatim, so child combinators (`> img`), compound selectors (`.is-style-rounded`) and state
+	 * selectors (`:hover .kb-svg-icon-wrap`) stay expressible. A descendant whose own selector opens with
+	 * one of those characters asks for the space with a leading `*`, which adds no specificity of its own.
+	 * Empty when the binding names none — the rule targets the block root.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|null $selector The binding's raw `css_selector` / `css_state`, or null when it names none.
+	 *
+	 * @return string The selector suffix, ready to concatenate after the block class.
+	 */
+	private function selector_suffix( ?string $selector ): string {
+		$selector = trim( (string) $selector );
+
+		if ( $selector === '' ) {
+			return '';
+		}
+
+		return strpbrk( $selector[0], '>+~.:#[&' ) === false ? ' ' . $selector : $selector;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Traits/Composes_Selector_Suffix.php
+++ b/includes/resources/Design_Tokens/Projection/Traits/Composes_Selector_Suffix.php
@@ -20,6 +20,12 @@ trait Composes_Selector_Suffix {
 	 * one of those characters asks for the space with a leading `*`, which adds no specificity of its own.
 	 * Empty when the binding names none — the rule targets the block root.
 	 *
+	 * A leading `&` is expanded rather than passed through. It reads naturally to anyone used to SCSS, but
+	 * this emits flat CSS, where `.wp-block-example&:hover` is not a selector at all and the browser drops
+	 * the whole rule — a binding written that way would silently do nothing. The SCSS meaning is honored:
+	 * `&:hover` attaches and `& .child` descends, which is exactly the distinction the whitespace after the
+	 * `&` already carries.
+	 *
 	 * @since TBD
 	 *
 	 * @param string|null $selector The binding's raw `css_selector` / `css_state`, or null when it names none.
@@ -33,6 +39,21 @@ trait Composes_Selector_Suffix {
 			return '';
 		}
 
-		return strpbrk( $selector[0], '>+~.:#[&' ) === false ? ' ' . $selector : $selector;
+		if ( $selector[0] === '&' ) {
+			$rest = substr( $selector, 1 );
+
+			// A space after the `&` is the whole signal: `& .child` descends, `&:hover` attaches. Tested
+			// before trimming, so the combinator this inserts is the only whitespace that survives.
+			$descends = $rest !== ltrim( $rest );
+			$rest     = trim( $rest );
+
+			if ( $rest === '' ) {
+				return '';
+			}
+
+			return $descends ? ' ' . $rest : $rest;
+		}
+
+		return strpbrk( $selector[0], '>+~.:#[' ) === false ? ' ' . $selector : $selector;
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -140,6 +140,10 @@ final class Binding {
 	 * the combinator space, one opening with a combinator or attachment character is used verbatim, and a
 	 * leading `*` is how a descendant whose own selector starts with `.` asks for the space.
 	 *
+	 * Several states may be named at once, comma separated (`*.kb-button:hover,*.kb-button:focus`), for a
+	 * block whose own CSS treats hover and keyboard focus as one look. The projector scopes each part on its
+	 * own, so every part is qualified by the block and preset rather than only the first.
+	 *
 	 * @since TBD
 	 *
 	 * @var string

--- a/includes/resources/Design_Tokens/Registry/Binding.php
+++ b/includes/resources/Design_Tokens/Registry/Binding.php
@@ -120,6 +120,49 @@ final class Binding {
 	private const EDITOR_CSS_SELECTOR = 'editor_css_selector';
 
 	/**
+	 * Inline target: the selector suffix — pseudo-class included — that scopes this property to a UI state
+	 * rather than to the block's resting appearance, e.g. `:hover > .kt-inside-inner-col` for the Section's
+	 * hover background. Declaring it makes the binding a STATE binding, which changes which projector
+	 * renders it and how.
+	 *
+	 * A state binding is rendered only by the selected-preset projector, which emits a real declaration
+	 * (`<css_prop>: var(<preset var>)`) scoped to `.wp-block-<block>.kb-preset--<preset><css_state>` — and,
+	 * for the block's `$default` preset, to the class-less `.wp-block-<block><css_state>`. The
+	 * block-default-CSS projector skips it entirely: that layer renders only the `$default` preset, so its
+	 * rule would be present on every block whether or not a preset asked for a state, and any `:hover` rule
+	 * outranks the block's own resting per-instance rule — a shipped state default would repaint content
+	 * that never opted in.
+	 *
+	 * The whole suffix lives here, pseudo included, because which element carries the state differs per
+	 * block: the Section and the Icon are hovered on the block root and paint a descendant
+	 * (`:hover > .kt-inside-inner-col`), while the Button is hovered on the element it paints
+	 * (`*.kb-button:hover`). It is composed exactly like {@see self::CSS_SELECTOR} — a bare selector gains
+	 * the combinator space, one opening with a combinator or attachment character is used verbatim, and a
+	 * leading `*` is how a descendant whose own selector starts with `.` asks for the space.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const CSS_STATE = 'css_state';
+
+	/**
+	 * Inline target: the state selector suffix to use instead of `css_state` when the preset projector is
+	 * building for the editor canvas, for a block whose editor markup renders the bound property on a
+	 * different element than its saved markup does (the Section paints `.kadence-inner-column-inner` in the
+	 * editor and `.kt-inside-inner-col` on the front end).
+	 *
+	 * The per-state counterpart to {@see self::EDITOR_CSS_SELECTOR}, and it behaves the same way: optional,
+	 * with `css_state` reused in the editor when omitted, which is right for every block whose two render
+	 * paths agree on the element.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const EDITOR_CSS_STATE = 'editor_css_state';
+
+	/**
 	 * Editor-only target: the block attribute the editor control for this property writes, so the
 	 * indicator layer can tell whether a control is bound to the active preset or has been overridden.
 	 * Deliberately NOT a projection target — it is excluded from STRING_TARGETS / inline_targets(), so it
@@ -167,7 +210,7 @@ final class Binding {
 	 *
 	 * @var string[]
 	 */
-	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::BLOCK_ATTR, self::CSS_PROP, self::CSS_SELECTOR, self::EDITOR_CSS_SELECTOR, self::CSS_VAR ];
+	private const STRING_TARGETS = [ self::KADENCE_SLOT, self::BLOCK_ATTR, self::CSS_PROP, self::CSS_SELECTOR, self::EDITOR_CSS_SELECTOR, self::CSS_STATE, self::EDITOR_CSS_STATE, self::CSS_VAR ];
 
 	/**
 	 * The block property this binding drives, e.g. "button-bg". Carried for error messages and so a
@@ -420,6 +463,48 @@ final class Binding {
 		$selector = $this->projections[ self::EDITOR_CSS_SELECTOR ] ?? null;
 
 		return is_string( $selector ) ? $selector : $this->css_selector();
+	}
+
+	/**
+	 * The state selector suffix this binding's declaration is scoped to (e.g. ":hover > .kt-inside-inner-col"),
+	 * or null when the binding drives the block's resting appearance. Its presence is what marks a binding as
+	 * a state binding — see {@see self::CSS_STATE} for what that changes. Inline only.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function css_state(): ?string {
+		$selector = $this->projections[ self::CSS_STATE ] ?? null;
+
+		return is_string( $selector ) ? $selector : null;
+	}
+
+	/**
+	 * The state selector suffix for the EDITOR canvas: the declared `editor_css_state` when the block's
+	 * editor markup paints a different element than its saved markup, and otherwise {@see self::css_state()},
+	 * which is right whenever the two render paths agree. Inline only.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|null
+	 */
+	public function editor_css_state(): ?string {
+		$selector = $this->projections[ self::EDITOR_CSS_STATE ] ?? null;
+
+		return is_string( $selector ) ? $selector : $this->css_state();
+	}
+
+	/**
+	 * Whether this binding scopes its property to a UI state rather than to the block's resting appearance.
+	 * True exactly when it declares a `css_state`.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_state(): bool {
+		return $this->css_state() !== null;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -353,6 +353,40 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A state binding contributes no rule here even though it names a `css_prop`. This layer renders only the
+	 * `$default` preset, so its rule carries no preset class and matches every instance of the block — and a
+	 * state rule outranks the block's own resting per-instance rule, so emitting one would repaint content
+	 * that never opted into a state. The selected-preset projector owns state rules instead.
+	 *
+	 * @return void
+	 */
+	public function testItContributesNothingForAStateBinding(): void {
+		$registry = new Token_Registry();
+		$registry->register(
+			[
+				'id'    => 'semantic.radius.media',
+				'type'  => 'dimension',
+				'label' => 'Media Radius',
+			]
+		);
+		$registry->register_preset_bindings(
+			[
+				'block'    => 'kadence/image',
+				'bindings' => [
+					'borderRadius' => [
+						'token'     => 'semantic.radius.media',
+						'css_prop'  => 'border-radius',
+						'css_state' => ':hover img',
+					],
+				],
+			]
+		);
+
+		$this->assertSame( '', $this->builder( $registry )->css() );
+		$this->assertSame( '', $this->builder( $registry )->editor_css() );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItInsertsTheDescendantCombinatorForABareCssSelector(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -195,6 +195,122 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A binding declaring a `css_state` is emitted as a real declaration scoped to the preset class plus the
+	 * state suffix, rather than as a custom-property retarget on the block root.
+	 *
+	 * @return void
+	 */
+	public function testItEmitsAStateRuleForAStateBinding(): void {
+		$this->seedStatePresets();
+
+		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-state-fixture.kb-preset--flare:hover *.kb-svg-icon-wrap'
+				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
+			$css
+		);
+	}
+
+	/**
+	 * A state binding never reaches the block-root retarget layer: it has no variable of the block's own to
+	 * point at, so nothing about it appears inside the `.kb-preset--<preset>` rule itself.
+	 *
+	 * @return void
+	 */
+	public function testAStateBindingIsNotEmittedAsAVarRetarget(): void {
+		$this->seedStatePresets();
+
+		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-state-fixture.kb-preset--flare{'
+				. '--kb-icon-color:var(--kb-token--preset--kadence-state-fixture--flare--color);}',
+			$css
+		);
+		$this->assertStringNotContainsString( '--kb-icon-color-hover', $css );
+	}
+
+	/**
+	 * The `$default` preset's state rule carries no preset class, so a block with no preset selected still
+	 * shows its default preset's state — the same treatment the retarget layer gives the `$default`.
+	 *
+	 * @return void
+	 */
+	public function testTheDefaultPresetsStateRuleIsClassLess(): void {
+		$this->seedStatePresets();
+
+		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-state-fixture:hover *.kb-svg-icon-wrap'
+				. '{color:var(--kb-token--preset--kadence-state-fixture--glow--color-hover);}',
+			$css
+		);
+	}
+
+	/**
+	 * The editor build re-scopes a state rule to the binding's `editor_css_state`, so a block whose canvas
+	 * markup paints a different element than its saved markup still previews the state.
+	 *
+	 * @return void
+	 */
+	public function testTheEditorBuildUsesTheEditorStateSelector(): void {
+		$this->seedStatePresets();
+
+		$css = $this->builder( $this->stateRegistry() )->editor_css( 'default' );
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-state-fixture.kb-preset--flare:hover *.kt-svg-icon'
+				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
+			$css
+		);
+		$this->assertStringNotContainsString( ':hover *.kb-svg-icon-wrap', $css );
+	}
+
+	/**
+	 * A state property's value still lives in the canonical `:root` preset var the state rule references, so
+	 * it keeps its alias indirection and follows the active library exactly as every other property does.
+	 *
+	 * @return void
+	 */
+	public function testAStateBindingStillDefinesItsCanonicalPresetVar(): void {
+		$this->seedStatePresets();
+
+		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
+
+		$this->assertStringContainsString(
+			'--kb-token--preset--kadence-state-fixture--flare--color-hover:var(--kb-token--semantic--color--link);',
+			$css
+		);
+	}
+
+	/**
+	 * A state binding that names no `css_prop` has no declaration to emit — the state rule IS that
+	 * declaration — so it contributes nothing rather than an empty rule.
+	 *
+	 * @return void
+	 */
+	public function testAStateBindingWithoutACssPropContributesNothing(): void {
+		$this->seedStatePresets();
+
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block'    => 'kadence/state-fixture',
+				'bindings' => [
+					'color-hover' => [
+						'token'     => 'semantic.color.icon',
+						'css_state' => ':hover *.kb-svg-icon-wrap',
+					],
+				],
+			]
+		);
+
+		$this->assertSame( '', $this->builder( $registry )->css( 'default' ) );
+	}
+
+	/**
 	 * Build the CSS builder with a given registry and the real (baseline-backed) preset resolver.
 	 *
 	 * @param Token_Registry $registry The registry to build from.
@@ -593,5 +709,76 @@ final class Css_BuilderTest extends TestCase {
 		$end    = strpos( $css, '}}', $start );
 
 		return $end === false ? '' : substr( $css, $start, $end - $start );
+	}
+
+	/**
+	 * A registry binding one resting property and one state property on a block the baseline knows nothing
+	 * about, so the state assertions read only what {@see self::seedStatePresets()} put there.
+	 *
+	 * The state binding declares a different `editor_css_state` than its `css_state` on purpose: that is the
+	 * only thing separating the front-end build from the editor one, so it is what the editor test needs.
+	 *
+	 * @return Token_Registry
+	 */
+	private function stateRegistry(): Token_Registry {
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block'    => 'kadence/state-fixture',
+				'bindings' => [
+					'color'       => [
+						'token'        => 'semantic.color.icon',
+						'css_prop'     => 'color',
+						'css_selector' => '*.kb-svg-icon-wrap',
+						'css_var'      => 'kb-icon-color',
+					],
+					'color-hover' => [
+						'token'            => 'semantic.color.icon',
+						'css_prop'         => 'color',
+						'css_state'        => ':hover *.kb-svg-icon-wrap',
+						'editor_css_state' => ':hover *.kt-svg-icon',
+					],
+				],
+			]
+		);
+
+		return $registry;
+	}
+
+	/**
+	 * Store two presets for the state fixture block — a `$default` ("glow") and a named one ("flare") — each
+	 * setting both the resting color and the state color, so one build exercises the class-less rule and the
+	 * preset-classed one together.
+	 *
+	 * @return void
+	 */
+	private function seedStatePresets(): void {
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/state-fixture' => [
+							'$default' => 'glow',
+							'glow'     => [
+								'label'  => 'Glow',
+								'tokens' => [
+									'color'       => '{semantic.color.icon}',
+									'color-hover' => '{semantic.color.text}',
+								],
+							],
+							'flare'    => [
+								'label'  => 'Flare',
+								'tokens' => [
+									'color'       => '{semantic.color.icon}',
+									'color-hover' => '{semantic.color.link}',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -286,6 +286,38 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A `css_state` naming several states, comma separated, scopes EACH part by the block and preset. Left
+	 * undistributed, a selector list would apply its leading compound to the first part only, so every part
+	 * after it would match the whole document.
+	 *
+	 * @return void
+	 */
+	public function testItScopesEveryPartOfAMultiStateSelector(): void {
+		$this->seedStatePresets();
+
+		$registry = new Token_Registry();
+		$registry->register_preset_bindings(
+			[
+				'block'    => 'kadence/state-fixture',
+				'bindings' => [
+					'color-hover' => [
+						'token'     => 'semantic.color.icon',
+						'css_prop'  => 'color',
+						'css_state' => '*.kb-button:hover,*.kb-button:focus',
+					],
+				],
+			]
+		);
+
+		$this->assertStringContainsString(
+			'.wp-block-kadence-state-fixture.kb-preset--flare *.kb-button:hover,'
+				. '.wp-block-kadence-state-fixture.kb-preset--flare *.kb-button:focus'
+				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
+			$this->builder( $registry )->css( 'default' )
+		);
+	}
+
+	/**
 	 * A state binding that names no `css_prop` has no declaration to emit — the state rule IS that
 	 * declaration — so it contributes nothing rather than an empty rule.
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -206,7 +206,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
 
 		$this->assertStringContainsString(
-			':where(.wp-block-kadence-state-fixture).kb-preset--flare:hover *.kb-svg-icon-wrap'
+			':where(.wp-block-kadence-state-fixture.kb-preset--flare):hover *.kb-svg-icon-wrap'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
 			$css
 		);
@@ -243,7 +243,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
 
 		$this->assertStringContainsString(
-			':where(.wp-block-kadence-state-fixture):hover *.kb-svg-icon-wrap'
+			':where(.wp-block-kadence-state-fixture:not([class*="kb-preset--"])):hover *.kb-svg-icon-wrap'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--glow--color-hover);}',
 			$css
 		);
@@ -261,7 +261,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->stateRegistry() )->editor_css( 'default' );
 
 		$this->assertStringContainsString(
-			':where(.wp-block-kadence-state-fixture).kb-preset--flare:hover *.kt-svg-icon'
+			':where(.wp-block-kadence-state-fixture.kb-preset--flare):hover *.kt-svg-icon'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
 			$css
 		);
@@ -310,8 +310,8 @@ final class Css_BuilderTest extends TestCase {
 		);
 
 		$this->assertStringContainsString(
-			':where(.wp-block-kadence-state-fixture).kb-preset--flare *.kb-button:hover,'
-				. ':where(.wp-block-kadence-state-fixture).kb-preset--flare *.kb-button:focus'
+			':where(.wp-block-kadence-state-fixture.kb-preset--flare) *.kb-button:hover,'
+				. ':where(.wp-block-kadence-state-fixture.kb-preset--flare) *.kb-button:focus'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
 			$this->builder( $registry )->css( 'default' )
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -318,6 +318,39 @@ final class Css_BuilderTest extends TestCase {
 	}
 
 	/**
+	 * A `css_state` written the SCSS way, `&:hover`, attaches to the block selector. Passed through as
+	 * written it would emit `.wp-block-…&:hover`, which is not a selector at all — the browser would drop
+	 * the rule and the binding would silently do nothing.
+	 *
+	 * @return void
+	 */
+	public function testItExpandsALeadingAmpersandOntoTheBlockSelector(): void {
+		$this->seedStatePresets();
+
+		$this->assertStringContainsString(
+			':where(.wp-block-kadence-state-fixture.kb-preset--flare):hover'
+				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
+			$this->builder( $this->stateRegistry( '&:hover' ) )->css( 'default' )
+		);
+	}
+
+	/**
+	 * The space after a leading `&` carries the same meaning it does in SCSS: `& .child` descends rather
+	 * than attaching, so the combinator survives the expansion.
+	 *
+	 * @return void
+	 */
+	public function testALeadingAmpersandKeepsItsDescendantCombinator(): void {
+		$this->seedStatePresets();
+
+		$this->assertStringContainsString(
+			':where(.wp-block-kadence-state-fixture.kb-preset--flare) .kb-svg-icon-wrap:hover'
+				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
+			$this->builder( $this->stateRegistry( '& .kb-svg-icon-wrap:hover' ) )->css( 'default' )
+		);
+	}
+
+	/**
 	 * A state binding that names no `css_prop` has no declaration to emit — the state rule IS that
 	 * declaration — so it contributes nothing rather than an empty rule.
 	 *
@@ -750,9 +783,11 @@ final class Css_BuilderTest extends TestCase {
 	 * The state binding declares a different `editor_css_state` than its `css_state` on purpose: that is the
 	 * only thing separating the front-end build from the editor one, so it is what the editor test needs.
 	 *
+	 * @param string $state The `css_state` to declare, defaulting to the icon's own hover selector.
+	 *
 	 * @return Token_Registry
 	 */
-	private function stateRegistry(): Token_Registry {
+	private function stateRegistry( string $state = ':hover *.kb-svg-icon-wrap' ): Token_Registry {
 		$registry = new Token_Registry();
 		$registry->register_preset_bindings(
 			[
@@ -767,7 +802,7 @@ final class Css_BuilderTest extends TestCase {
 					'color-hover' => [
 						'token'            => 'semantic.color.icon',
 						'css_prop'         => 'color',
-						'css_state'        => ':hover *.kb-svg-icon-wrap',
+						'css_state'        => $state,
 						'editor_css_state' => ':hover *.kt-svg-icon',
 					],
 				],

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -206,7 +206,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-state-fixture.kb-preset--flare:hover *.kb-svg-icon-wrap'
+			':where(.wp-block-kadence-state-fixture).kb-preset--flare:hover *.kb-svg-icon-wrap'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
 			$css
 		);
@@ -243,7 +243,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->stateRegistry() )->css( 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-state-fixture:hover *.kb-svg-icon-wrap'
+			':where(.wp-block-kadence-state-fixture):hover *.kb-svg-icon-wrap'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--glow--color-hover);}',
 			$css
 		);
@@ -261,7 +261,7 @@ final class Css_BuilderTest extends TestCase {
 		$css = $this->builder( $this->stateRegistry() )->editor_css( 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-state-fixture.kb-preset--flare:hover *.kt-svg-icon'
+			':where(.wp-block-kadence-state-fixture).kb-preset--flare:hover *.kt-svg-icon'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
 			$css
 		);
@@ -310,8 +310,8 @@ final class Css_BuilderTest extends TestCase {
 		);
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-state-fixture.kb-preset--flare *.kb-button:hover,'
-				. '.wp-block-kadence-state-fixture.kb-preset--flare *.kb-button:focus'
+			':where(.wp-block-kadence-state-fixture).kb-preset--flare *.kb-button:hover,'
+				. ':where(.wp-block-kadence-state-fixture).kb-preset--flare *.kb-button:focus'
 				. '{color:var(--kb-token--preset--kadence-state-fixture--flare--color-hover);}',
 			$this->builder( $registry )->css( 'default' )
 		);

--- a/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/BindingTest.php
@@ -148,6 +148,104 @@ final class BindingTest extends TestCase {
 	}
 
 	/**
+	 * A declared css_state is exposed verbatim and marks the binding as a state binding, which is what tells
+	 * the projectors it carries a declaration scoped to a UI state rather than the block's resting look.
+	 *
+	 * @return void
+	 */
+	public function testCssStateMarksTheBindingAsAStateBinding(): void {
+		$binding = Binding::from_array(
+			'backgroundHover',
+			[
+				'token'     => 'semantic.color.column-bg',
+				'css_prop'  => 'background-color',
+				'css_state' => ':hover > .kt-inside-inner-col',
+			]
+		);
+
+		$this->assertSame( ':hover > .kt-inside-inner-col', $binding->css_state() );
+		$this->assertTrue( $binding->is_state() );
+	}
+
+	/**
+	 * A binding that declares no css_state is a resting-state binding, so both its state accessors read null
+	 * and it never reaches the preset projector's state layer.
+	 *
+	 * @return void
+	 */
+	public function testABindingWithoutACssStateIsNotAStateBinding(): void {
+		$binding = Binding::from_array(
+			'background',
+			[
+				'token'    => 'semantic.color.column-bg',
+				'css_prop' => 'background-color',
+			]
+		);
+
+		$this->assertNull( $binding->css_state() );
+		$this->assertNull( $binding->editor_css_state() );
+		$this->assertFalse( $binding->is_state() );
+	}
+
+	/**
+	 * A declared editor_css_state replaces css_state for the editor build alone, for a block whose editor
+	 * markup paints a different element than its saved markup does.
+	 *
+	 * @return void
+	 */
+	public function testEditorCssStateOverridesTheFrontEndState(): void {
+		$binding = Binding::from_array(
+			'backgroundHover',
+			[
+				'token'            => 'semantic.color.column-bg',
+				'css_prop'         => 'background-color',
+				'css_state'        => ':hover > .kt-inside-inner-col',
+				'editor_css_state' => ':hover > .kadence-inner-column-inner',
+			]
+		);
+
+		$this->assertSame( ':hover > .kt-inside-inner-col', $binding->css_state() );
+		$this->assertSame( ':hover > .kadence-inner-column-inner', $binding->editor_css_state() );
+	}
+
+	/**
+	 * With no editor_css_state declared, the editor reuses the front-end state selector — right for every
+	 * block whose two render paths agree on the element, and what keeps the override opt-in.
+	 *
+	 * @return void
+	 */
+	public function testEditorCssStateFallsBackToTheFrontEndState(): void {
+		$binding = Binding::from_array(
+			'hColor',
+			[
+				'token'     => 'semantic.color.icon',
+				'css_prop'  => 'color',
+				'css_state' => ':hover *.kb-svg-icon-wrap',
+			]
+		);
+
+		$this->assertSame( ':hover *.kb-svg-icon-wrap', $binding->editor_css_state() );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItThrowsWhenCssStateIsNotAString(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Binding::from_array( 'backgroundHover', [ 'css_state' => [] ] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testItThrowsWhenEditorCssStateIsNotAString(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		Binding::from_array( 'backgroundHover', [ 'editor_css_state' => 42 ] );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testItThrowsWhenCssPropIsNotAString(): void {


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4264/let-a-preset-set-hover-state-properties-button-section

:video_camera: https://www.loom.com/share/bec2090b5ff74822908acd988cad6827

A preset could set no hover property on any block. The Button's two are not a counterexample — they retarget `--global-palette-btn-bg-hover` and `--global-palette-btn-hover`, palette variables the theme's own `:hover` CSS already reads, so the projector never emits a pseudo-class at all. Every other property reaches the page as a custom property on the block root, which a state has nowhere to hang off.

Adds `css_state` to a binding: the selector suffix, pseudo-class included, that scopes a property to a state. `Preset\Css_Builder` renders one as a real declaration under `:where(.wp-block-<block>.kb-preset--<preset>)<css_state>`, with the `$default`'s counterpart qualified by "this block carries no preset class" so the two can never both match. `Block_Default_Css` skips state bindings — that layer renders only the `$default` preset, so its rule would land on every instance whether or not a preset asked for a state.

The `:where()` is what keeps the layering rule intact: a state rule writes a real declaration, so unlike every other layer here its specificity competes with the block's own CSS. Weightless qualification leaves a state rule weighing exactly what its `css_state` names, which is where a block's author states the weight that block needs.

State rules are also the first preset output that depends on markup shape, so the builder grows an editor build keyed separately in the object cache, the way the block-default builder already keys its two.

No binding declares a `css_state` yet — this is the capability the per-block wiring builds on.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for state-specific styling, including selectors such as hover states, in generated preset CSS.
  - Added separate CSS generation for front-end and editor experiences, with editor-specific state selectors where available.
  - State styles now support scoped selectors and continue to define their associated preset values.

- **Bug Fixes**
  - Prevented state-specific rules from being emitted in default-preset CSS.
  - Improved handling of missing or invalid state selectors and bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
