### PR TITLE
Preset hover states [3/3]: bind the hover properties the block controls expose

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -378,6 +378,10 @@
 				"$type": "color",
 				"$value": "{primitive.color.neutral.200}"
 			},
+			"border-hover": {
+				"$type": "color",
+				"$value": "{primitive.color.neutral.200}"
+			},
 			"link": {
 				"$type": "color",
 				"$value": "{primitive.color.brand.primary}"
@@ -418,11 +422,19 @@
 				"$type": "color",
 				"$value": "{primitive.color.brand.primary}"
 			},
+			"icon-hover": {
+				"$type": "color",
+				"$value": "{primitive.color.brand.primary}"
+			},
 			"rowlayout-bg": {
 				"$type": "color",
 				"$value": "{primitive.color.transparent}"
 			},
 			"column-bg": {
+				"$type": "color",
+				"$value": "{primitive.color.transparent}"
+			},
+			"column-bg-hover": {
 				"$type": "color",
 				"$value": "{primitive.color.transparent}"
 			},
@@ -474,6 +486,10 @@
 				"$type": "dimension",
 				"$value": "0"
 			},
+			"column-hover": {
+				"$type": "dimension",
+				"$value": "0"
+			},
 			"heading": {
 				"$type": "dimension",
 				"$value": "0"
@@ -483,10 +499,18 @@
 			"default": {
 				"$type": "dimension",
 				"$value": "{primitive.dimension.border-width.sm}"
+			},
+			"default-hover": {
+				"$type": "dimension",
+				"$value": "{primitive.dimension.border-width.sm}"
 			}
 		},
 		"border-style": {
 			"default": {
+				"$type": "borderStyle",
+				"$value": "none"
+			},
+			"default-hover": {
 				"$type": "borderStyle",
 				"$value": "none"
 			}
@@ -583,6 +607,16 @@
 				}
 			},
 			"button": {
+				"$type": "shadow",
+				"$value": {
+					"color": "{primitive.color.transparent}",
+					"offsetX": "0px",
+					"offsetY": "0px",
+					"blur": "0px",
+					"spread": "0px"
+				}
+			},
+			"button-hover": {
 				"$type": "shadow",
 				"$value": {
 					"color": "{primitive.color.transparent}",

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -309,6 +309,48 @@ $palette_delivery_color_tokens = [
 	],
 ];
 
+/**
+ * The state selector every Button hover binding is scoped by, on the FRONT END.
+ *
+ * `:focus` rides along with `:hover` because the button's own CSS treats the two as one look — every rule it
+ * writes for hover it writes for focus in the same breath — so a preset that reached only `:hover` would leave
+ * a keyboard user on a button that never picks up the preset's border, radius or shadow.
+ *
+ * The repeated class is the weight, and it is load-bearing rather than a flourish. Preset\Css_Builder wraps a
+ * state rule's block-and-preset qualification in `:where()`, so this selector is the rule's ENTIRE specificity,
+ * and it has to land between two rules the button already writes:
+ *
+ *   - above `.kb-button:not(.kb-btn-global-inherit):hover` (three classes), the SCSS default that resets
+ *     box-shadow on hover and would otherwise silence a preset's shadow;
+ *   - below `.wp-block-kadence-advancedbtn .kb-btn<uid>.kb-button:hover` (four classes), the button's own
+ *     per-instance hover, so a hover the user set on the block still wins.
+ *
+ * Four classes ties that second one, and the tie breaks on source order: the preset CSS rides an enqueued
+ * handle and the per-instance CSS is printed after it, so the button's own value wins. Four also clears the
+ * per-instance RESTING rule (three classes), which is the point — a preset that says what hover looks like
+ * should say it even for a button carrying its own resting radius.
+ *
+ * On the front end `.wp-block-kadence-singlebtn` and `.kb-button` are the SAME element (the block renders
+ * through get_block_wrapper_attributes()), so the classes compound rather than descend.
+ *
+ * @var string
+ */
+$button_hover_state = '.kb-button.kb-button.kb-button:hover,.kb-button.kb-button.kb-button:focus';
+
+/**
+ * The same selector for the EDITOR canvas, where the button is a DESCENDANT: useBlockProps() puts
+ * `.wp-block-kadence-singlebtn` on a wrapper div and the button itself carries `.kt-button`. The leading `*`
+ * is how a suffix that would otherwise read as a compound asks for the descendant combinator.
+ *
+ * It spends one class less than its front-end twin because the editor spends one less on the rules it has to
+ * sit between: BackendStyles writes `.kb-single-btn-<uid> .kt-button-<uid>:hover` (three classes) where the
+ * front end writes four, and the editor SCSS has no hover reset to clear. Matching the front end's four would
+ * put a preset's hover ABOVE the block's own, so the canvas would disagree with the page it previews.
+ *
+ * @var string
+ */
+$button_hover_state_editor = '*.kt-button.kt-button:hover,*.kt-button.kt-button:focus';
+
 return [
 	'tokens'          => array_merge(
 		[
@@ -361,6 +403,15 @@ return [
 				'group' => __( 'Layout', 'kadence-blocks' ),
 			],
 			[
+				// The hover twin of the token above. A state binding needs a semantic of its own or a preset
+				// that set the resting radius would move the hover one with it; both ship resolving to the same
+				// value, so a column that never asked for a hover radius keeps the one it has.
+				'id'    => 'semantic.radius.column-hover',
+				'type'  => 'dimension',
+				'label' => __( 'Column Radius (Hover)', 'kadence-blocks' ),
+				'group' => __( 'Layout', 'kadence-blocks' ),
+			],
+			[
 				// Block-specific background defaults for the block-default CSS projector. Each aliases the
 				// transparent primitive (see baseline), so a fresh Row Layout / Column stays transparent — KB's
 				// own default — while a site owner can brand one block type's background by overriding its token,
@@ -378,9 +429,23 @@ return [
 				'group' => __( 'Layout', 'kadence-blocks' ),
 			],
 			[
+				// The hover twin of the token above; see semantic.radius.column-hover for why a state gets its
+				// own semantic rather than sharing the resting one.
+				'id'    => 'semantic.color.column-bg-hover',
+				'type'  => 'color',
+				'label' => __( 'Column Background (Hover)', 'kadence-blocks' ),
+				'group' => __( 'Layout', 'kadence-blocks' ),
+			],
+			[
 				'id'    => 'semantic.color.border',
 				'type'  => 'color',
 				'label' => __( 'Border', 'kadence-blocks' ),
+				'group' => __( 'Brand', 'kadence-blocks' ),
+			],
+			[
+				'id'    => 'semantic.color.border-hover',
+				'type'  => 'color',
+				'label' => __( 'Border (Hover)', 'kadence-blocks' ),
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
 			[
@@ -400,6 +465,12 @@ return [
 				'id'    => 'semantic.border-width.default',
 				'type'  => 'dimension',
 				'label' => __( 'Border Width', 'kadence-blocks' ),
+				'group' => __( 'Brand', 'kadence-blocks' ),
+			],
+			[
+				'id'    => 'semantic.border-width.default-hover',
+				'type'  => 'dimension',
+				'label' => __( 'Border Width (Hover)', 'kadence-blocks' ),
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
 			[
@@ -429,6 +500,12 @@ return [
 				'id'    => 'semantic.shadow.button',
 				'type'  => 'shadow',
 				'label' => __( 'Button Shadow', 'kadence-blocks' ),
+				'group' => __( 'Brand', 'kadence-blocks' ),
+			],
+			[
+				'id'    => 'semantic.shadow.button-hover',
+				'type'  => 'shadow',
+				'label' => __( 'Button Shadow (Hover)', 'kadence-blocks' ),
 				'group' => __( 'Brand', 'kadence-blocks' ),
 			],
 		],
@@ -561,6 +638,66 @@ return [
 				'button-shadow'       => [
 					'token'   => 'semantic.shadow.button',
 					'css_var' => 'kb-btn-shadow',
+				],
+
+				// The hover half of the same four properties. These take the css_state shape rather than the
+				// css_var shape their resting counterparts use, because a state has no variable of the block's
+				// own to point at: the button reads --kb-btn-radius and friends in its resting rules only and
+				// paints its hover look straight from its own attributes, so there is nothing for a preset to
+				// redirect. Preset\Css_Builder supplies the whole rule instead, and only for a preset that
+				// actually sets the property, so a button whose preset carries no hover keeps the hover it has.
+				//
+				// $button_hover_state / $button_hover_state_editor carry the selectors; the weight they spend is
+				// load-bearing, and the note above them says what it buys.
+				'button-radius-hover'       => [
+					'css_prop'         => 'border-radius',
+					'css_state'        => $button_hover_state,
+					'editor_css_state' => $button_hover_state_editor,
+					'control_attr'     => 'borderHoverRadius',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderHoverRadius',
+						'mobile' => 'mobileBorderHoverRadius',
+					],
+				],
+
+				// The hover border trio mirrors the resting one: three properties sharing ONE control_attr
+				// ('borderHoverStyle'), each declaring the axis it owns within that nested value. The KEY shape
+				// is what the Style Library's Border field derives its three paths from — it appends
+				// `-width`/`-style`/`-color` to its own path — so these read `button-border-hover-*` rather than
+				// the `button-border-*-hover` the resting trio's names would suggest.
+				'button-border-hover-width' => [
+					'token'            => 'semantic.border-width.default-hover',
+					'css_prop'         => 'border-width',
+					'css_state'        => $button_hover_state,
+					'editor_css_state' => $button_hover_state_editor,
+					'control_attr'     => 'borderHoverStyle',
+					'axis'             => 'border-width',
+				],
+				'button-border-hover-style' => [
+					'token'            => 'semantic.border-style.default-hover',
+					'css_prop'         => 'border-style',
+					'css_state'        => $button_hover_state,
+					'editor_css_state' => $button_hover_state_editor,
+					'control_attr'     => 'borderHoverStyle',
+					'axis'             => 'border-style',
+				],
+				'button-border-hover-color' => [
+					'token'            => 'semantic.color.border-hover',
+					'css_prop'         => 'border-color',
+					'css_state'        => $button_hover_state,
+					'editor_css_state' => $button_hover_state_editor,
+					'control_attr'     => 'borderHoverStyle',
+					'axis'             => 'border-color',
+				],
+
+				// No control_attr, matching button-shadow: the block's shadow control carries no indicator, and
+				// giving the hover one an attribute its resting twin does not have would make the pair read
+				// inconsistently in the inspector.
+				'button-shadow-hover'       => [
+					'token'            => 'semantic.shadow.button-hover',
+					'css_prop'         => 'box-shadow',
+					'css_state'        => $button_hover_state,
+					'editor_css_state' => $button_hover_state_editor,
 				],
 			],
 		],
@@ -779,6 +916,35 @@ return [
 						'mobile' => 'mobileBorderRadius',
 					],
 				],
+
+				// The hover half of the two properties above, in the css_state shape: the column paints its
+				// hover look from its own attributes and reads no variable there, so a preset has nothing to
+				// retarget and Preset\Css_Builder supplies the whole rule instead.
+				//
+				// The doubled class is the weight. A state rule's block-and-preset qualification is wrapped in
+				// `:where()`, so this selector is its ENTIRE specificity, and it has to clear the resting
+				// block-default rule above (two classes: `.wp-block-kadence-column > .kt-inside-inner-col`)
+				// without clearing the column's own per-instance hover (three classes:
+				// `.kadence-column<uid>:hover > .kt-inside-inner-col`). Three ties that second one, and the tie
+				// breaks on source order in the block's favor.
+				'backgroundHover'     => [
+					'token'            => 'semantic.color.column-bg-hover',
+					'css_prop'         => 'background-color',
+					'css_state'        => ':hover > .kt-inside-inner-col.kt-inside-inner-col',
+					'editor_css_state' => ':hover > .kadence-inner-column-inner.kadence-inner-column-inner',
+					'control_attr'     => 'backgroundHover',
+				],
+				'borderHoverRadius'   => [
+					'token'            => 'semantic.radius.column-hover',
+					'css_prop'         => 'border-radius',
+					'css_state'        => ':hover > .kt-inside-inner-col.kt-inside-inner-col',
+					'editor_css_state' => ':hover > .kadence-inner-column-inner.kadence-inner-column-inner',
+					'control_attr'     => 'borderHoverRadius',
+					'responsive_attrs' => [
+						'tablet' => 'tabletBorderHoverRadius',
+						'mobile' => 'mobileBorderHoverRadius',
+					],
+				],
 			],
 		],
 		[
@@ -819,14 +985,36 @@ return [
 				'label' => __( 'Icon', 'kadence-blocks' ),
 			],
 			'bindings'      => [
-				'color' => [
+				'color'       => [
 					'token'        => 'semantic.color.icon',
 					'css_prop'     => 'color',
 					'css_selector' => '*.kb-svg-icon-wrap',
 					'css_var'      => 'kb-icon-color',
 					'control_attr' => 'color',
 				],
-				'size'  => [
+				// The hover half of `color`, in the css_state shape: the icon paints its hover color from
+				// `hColor` alone and reads no variable there, so a preset has nothing to retarget and
+				// Preset\Css_Builder supplies the whole rule.
+				//
+				// The doubled class is the weight. A state rule's block-and-preset qualification is wrapped in
+				// `:where()`, so this selector is its ENTIRE specificity, and it has to clear the resting rule
+				// above (two classes) without clearing the icon's own per-instance hover (three classes:
+				// `.kt-svg-item-<uid>:hover .kb-svg-icon-wrap`). Three ties that second one, and the tie breaks
+				// on source order in the block's favor.
+				//
+				// The editor names a different element for the same reason `size` resolves to a pixel number
+				// there: the canvas renders GenIcon's own markup and has no `.kb-svg-icon-wrap` at all, so the
+				// front-end suffix would match nothing. `.kt-svg-icon` is the element the icon's own editor
+				// hover rule paints, and that rule carries `!important`, so an `hColor` set on the block still
+				// wins in the canvas exactly as it does on the page.
+				'color-hover' => [
+					'token'            => 'semantic.color.icon-hover',
+					'css_prop'         => 'color',
+					'css_state'        => ':hover *.kb-svg-icon-wrap.kb-svg-icon-wrap',
+					'editor_css_state' => ':hover *.kt-svg-icon.kt-svg-icon',
+					'control_attr'     => 'hColor',
+				],
+				'size'        => [
 					'token'            => 'semantic.icon-size.default',
 					'css_prop'         => 'font-size',
 					'css_selector'     => '*.kb-svg-icon-wrap',

--- a/src/blocks/column/edit.js
+++ b/src/blocks/column/edit.js
@@ -315,16 +315,25 @@ function SectionEdit(props) {
 		{ desktop: borderRadius, tablet: tabletBorderRadius },
 		borderRadiusPresetValue
 	);
-	// The hover corners cascade among themselves only. No preset value takes part: no preset can set a
-	// hover radius on any block, so naming the NORMAL state's preset here would report a size the hover
-	// state does not actually render.
-	const inheritedBorderHoverRadius = inheritedMeasureSlots(previewDevice, {
-		desktop: borderHoverRadius,
-		tablet: tabletBorderHoverRadius,
-	});
-	// The hover radius has no binding of its own, so its indicator is derived from the normal corner's:
-	// it reports "overridden" once the hover value diverges from what the preset set for normal, which is
-	// the only preset-relative statement that can be made about it.
+	// The hover corners cascade among themselves, then fall to the hover radius the active preset resolves
+	// — its own property, never the normal state's, which would report a size the hover state does not
+	// render. Undefined until a preset actually carries one, which leaves the chain exactly as it was.
+	const borderHoverRadiusPresetValue = presetValueForDevice(
+		tokenBinding.borderHoverRadius?.presetValue,
+		tokenBinding.borderHoverRadius?.responsive,
+		previewDevice
+	);
+	const inheritedBorderHoverRadius = inheritedMeasureSlots(
+		previewDevice,
+		{
+			desktop: borderHoverRadius,
+			tablet: tabletBorderHoverRadius,
+		},
+		borderHoverRadiusPresetValue
+	);
+	// Falls back to a derived indicator while the active preset carries no hover radius of its own: without
+	// a resolved value `usePresetBinding` makes no entry, and the derived one at least reports divergence
+	// from what the preset set for NORMAL, which is the only preset-relative statement left to make.
 	const borderHoverRadiusBinding = deriveStateBinding({
 		shared: tokenBinding.borderRadius,
 		kind: tokenBinding.borderRadius?.kind,
@@ -2824,13 +2833,23 @@ function SectionEdit(props) {
 												)}
 												{'gradient' !== backgroundHoverType && (
 													<>
-														<PopColorControl
+														<ColorControl
 															label={__('Background Color', 'kadence-blocks')}
 															value={backgroundHover ? backgroundHover : ''}
-															default={''}
-															onChange={(value) =>
-																setAttributes({ backgroundHover: value })
+															groups={colorGroups}
+															status={{
+																bound: !!tokenBinding.backgroundHover?.bound,
+																modified: !!tokenBinding.backgroundHover?.overridden,
+															}}
+															onReset={() => resetToken('backgroundHover')}
+															onPick={(alias) =>
+																setAttributes({ backgroundHover: alias })
 															}
+															onCustom={(literal) =>
+																setAttributes({ backgroundHover: literal })
+															}
+															onClear={() => setAttributes({ backgroundHover: '' })}
+															resolveLiteral={resolveColorLiteral}
 														/>
 														<KadenceBackgroundControl
 															label={__('Background Image', 'kadence-blocks')}
@@ -3428,13 +3447,18 @@ function SectionEdit(props) {
 														inherited={anyCornerInherited(
 															inheritedBorderHoverRadius.inherited
 														)}
-														state={borderHoverRadiusBinding}
-														// The kind is stated rather than looked up: no preset
-														// property binds `borderHoverRadius`, so `resetToken`
-														// would resolve `undefined` and clear the desktop
-														// attribute to a bare `''` -- leaving the tablet/mobile
-														// companions and the unit untouched, and storing a string
-														// where the block declares a four-side array.
+														state={
+															tokenBinding.borderHoverRadius ?? borderHoverRadiusBinding
+														}
+														// The kind is stated rather than looked up.
+														// `usePresetBinding` only makes an entry for a property
+														// the ACTIVE preset resolves, so `resetToken` reads
+														// `undefined` on every preset that carries no hover
+														// radius -- and on any site with the registry inactive.
+														// That clears the desktop attribute to a bare `''`,
+														// leaving the tablet/mobile companions and the unit
+														// untouched and storing a string where the block declares
+														// a four-side array.
 														onReset={() =>
 															resetAttr(
 																'borderHoverRadius',

--- a/src/blocks/single-icon/edit.js
+++ b/src/blocks/single-icon/edit.js
@@ -331,9 +331,10 @@ function KadenceSingleIcon(props) {
 								onChange={(value) => setAttributes({ style: value })}
 							/>
 							{/* One two-swatch control becomes two single-value ones, matching the Button's own
-							    icon pair. Only the base color is bound -- a preset can set the icon's color but
-							    not its hover -- so only it carries binding state; the hover swatch is an
-							    ordinary color field that still resolves palette picks to the design system. */}
+							    icon pair. Both are bound now that the icon's hover color is a preset property,
+							    so each carries its own binding state and its own reset -- the hover swatch's
+							    entry only appears once a preset actually resolves a hover color, which is what
+							    keeps its indicator silent until there is something to diverge from. */}
 							<ColorControlGroup>
 								<ColorControl
 									label={__('Icon Color', 'kadence-blocks')}
@@ -353,6 +354,11 @@ function KadenceSingleIcon(props) {
 									label={__('Hover Color', 'kadence-blocks')}
 									value={hColor ? hColor : ''}
 									groups={colorGroups}
+									status={{
+										bound: !!tokenBinding.hColor?.bound,
+										modified: !!tokenBinding.hColor?.overridden,
+									}}
+									onReset={() => resetToken('hColor')}
 									onPick={(alias) => setAttributes({ hColor: alias })}
 									onCustom={(literal) => setAttributes({ hColor: literal })}
 									onClear={() => setAttributes({ hColor: '' })}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -540,6 +540,12 @@ export default function KadenceButtonEdit(props) {
 	// Normal's `tokenBinding` entries directly here (as every call site once did) would report Normal's
 	// divergence on a field the user never opened, and its `onReset` would silently clear NORMAL's
 	// attributes while leaving this state's own untouched — see `deriveStateBinding`'s own docblock.
+	//
+	// Hover is the one state with preset properties of its own, so its two controls prefer their real
+	// binding entry and keep the derived one only as the fallback: `usePresetBinding` makes no entry for a
+	// property the ACTIVE preset does not resolve, and until a preset carries a hover value the derived
+	// answer is still the only preset-relative statement available. Transparent and Sticky have no bound
+	// counterparts at all and stay derived.
 	const borderHoverBorderForDevice = measureAttrsForDevice(
 		attributes,
 		'borderHoverStyle',
@@ -1261,7 +1267,10 @@ export default function KadenceButtonEdit(props) {
 															widthTokens={borderWidthPickableTokens}
 															defaultValue={borderWidthPresetValue}
 															renderColor={renderBorderColor}
-															state={borderHoverBorderBinding}
+															state={
+																tokenBinding.borderHoverStyle ??
+																borderHoverBorderBinding
+															}
 															onReset={resetBorderHoverBorder}
 														/>
 														<EditorBoxControl
@@ -1279,7 +1288,10 @@ export default function KadenceButtonEdit(props) {
 															inherited={anyCornerInherited(
 																inheritedBorderHoverRadius.inherited
 															)}
-															state={borderHoverRadiusBinding}
+															state={
+																tokenBinding.borderHoverRadius ??
+																borderHoverRadiusBinding
+															}
 															onReset={resetBorderHoverRadius}
 															isLinked={borderHoverRadiusIsLinked}
 															onToggleLink={toggleBorderHoverRadiusLink}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -316,6 +316,21 @@ export default function KadenceButtonEdit(props) {
 		previewDevice
 	);
 
+	// The same value for the HOVER width field, read from the hover property rather than the resting one.
+	// Falling straight through to `borderWidthPresetValue` would report the resting width on a preset that
+	// sets a different hover width -- the field would read 1px while the page rendered 2px. The resting
+	// value stays as the second step, because that is what the button really paints on hover when the
+	// preset carries no hover width: the state rule is only emitted for a property the preset resolves, so
+	// with none the button keeps its resting border through `:hover`.
+	const borderHoverWidthPresetValue =
+		presetPropertyValueForDevice(
+			'kadence/singlebtn',
+			'button-border-hover-width',
+			attributes,
+			undefined,
+			previewDevice
+		) ?? borderWidthPresetValue;
+
 	// Read directly: `button-shadow` declares no `control_attr`, so `usePresetBinding` skips it.
 	const shadowPresetValue = presetPropertyValueForDevice(
 		'kadence/singlebtn',
@@ -447,10 +462,20 @@ export default function KadenceButtonEdit(props) {
 		{ tablet: 'tabletBorderHoverRadius', mobile: 'mobileBorderHoverRadius' },
 		previewDevice
 	);
+	// The hover corners cascade among themselves, then fall to the preset's HOVER radius, and only then to
+	// its resting one. The hover step has to come first or a preset setting both would report the resting
+	// corners on a field the page renders the hover ones for; the resting step has to stay because a preset
+	// that sets no hover radius really does keep its resting corners through `:hover` -- the state rule is
+	// emitted only for a property the preset resolves.
+	const borderHoverRadiusPresetValue = presetValueForDevice(
+		tokenBinding.borderHoverRadius?.presetValue,
+		tokenBinding.borderHoverRadius?.responsive,
+		previewDevice
+	);
 	const inheritedBorderHoverRadius = inheritedMeasureSlots(
 		previewDevice,
 		{ desktop: borderHoverRadius, tablet: tabletBorderHoverRadius },
-		borderRadiusPresetValue
+		borderHoverRadiusPresetValue ?? borderRadiusPresetValue
 	);
 	const { isLinked: borderHoverRadiusIsLinked, toggleLink: toggleBorderHoverRadiusLink } = useLinkedMeasureState({
 		forDevice: borderHoverRadiusForDevice,
@@ -1265,7 +1290,7 @@ export default function KadenceButtonEdit(props) {
 															previewDevice={previewDevice}
 															onDeviceChange={setPreviewDevice}
 															widthTokens={borderWidthPickableTokens}
-															defaultValue={borderWidthPresetValue}
+															defaultValue={borderHoverWidthPresetValue}
 															renderColor={renderBorderColor}
 															state={
 																tokenBinding.borderHoverStyle ??


### PR DESCRIPTION
🎫  https://linear.app/nexcess/issue/SOFT-4264/let-a-preset-set-hover-state-properties-button-section

:video_camera: https://www.loom.com/share/bec2090b5ff74822908acd988cad6827

The Button's hover radius and border, the Section's hover background and radius, and the Icon's hover color are all token-pickable in the inspector now, but none was a preset property — so nothing carried a binding, and each control borrowed its indicator from the resting state's entry or went without one.

Declares the eight bindings in the `css_state` shape. None of these blocks reads a variable in its hover rules, so there is nothing for a preset to retarget and `Preset\Css_Builder` supplies the whole rule instead, front end and editor both, and only for a preset that resolves the property.

Each state gets its own semantic rather than sharing its resting twin's: bound to `semantic.color.icon`, an override meant for the icon's hover color would have moved its resting color with it. Every one ships resolving to the same value its resting counterpart does, so nothing changes look until someone sets a hover.

No preset-screen fields are added — the bindings exist because the inspector controls need them, not to grow the Style Library's surface.

The controls prefer their real binding entry and keep the derived indicator as a fallback, since `usePresetBinding` makes no entry for a property the active preset does not resolve. The Section's hover background moves to `ColorControl` for the status and reset the binding supports, matching its resting sibling.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preset support for hover styling across buttons, columns, and icons.
  * Added hover controls for borders, radius, backgrounds, icon colors, and button shadows.
  * Added responsive hover styling options for buttons.
  * Added reset and clear options for hover color and style settings.

* **Bug Fixes**
  * Improved fallback behavior when hover presets are unavailable.
  * Corrected hover controls to reflect active preset bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
