### PR TITLE
[DTM] SOFT-4266 [1/6]: bind a picked shadow token instead of freezing it to a literal

### DIFF
--- a/src/extension/design-tokens/__tests__/shadow-token.test.js
+++ b/src/extension/design-tokens/__tests__/shadow-token.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+/**
+ * Internal dependencies
+ */
+import { SHADOW_TOKEN_KEY, boundShadowToken } from '../shadow-token';
+
+describe('boundShadowToken', () => {
+	/**
+	 * An item carrying a well-formed alias reports it, which is what every reader keys off.
+	 *
+	 * @return {void}
+	 */
+	it('reports a well-formed binding', () => {
+		expect(boundShadowToken({ [SHADOW_TOKEN_KEY]: '{semantic.shadow.card}' })).toBe('{semantic.shadow.card}');
+	});
+
+	/**
+	 * A value that is not alias-shaped is not a binding — the fixed "None" sentinel's literal shorthand
+	 * is the case this guards, since binding it would point at a token that was never registered.
+	 *
+	 * @return {void}
+	 */
+	it('rejects a non-alias value', () => {
+		expect(boundShadowToken({ [SHADOW_TOKEN_KEY]: '0px 0px 0px 0px transparent' })).toBeNull();
+	});
+
+	/**
+	 * An item with no binding key, and no item at all, both report nothing rather than throwing.
+	 *
+	 * @return {void}
+	 */
+	it('reports nothing for an unbound or missing item', () => {
+		expect(boundShadowToken({ blur: 8 })).toBeNull();
+		expect(boundShadowToken(undefined)).toBeNull();
+	});
+});

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -46,7 +46,7 @@
 /**
  * Internal dependencies
  */
-import { BoxShadowControl, DEFAULT_COMPOSITE, parseResolvedShadow } from '../../../token-controls';
+import { BoxShadowControl, DEFAULT_COMPOSITE, findTokenEntry, parseResolvedShadow } from '../../../token-controls';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 import { isTokenAlias } from '../alias';
 import { SHADOW_TOKEN_KEY, boundShadowToken } from '../shadow-token';
@@ -223,6 +223,13 @@ function axisToNative(slot) {
  * Resolve a picked token alias to its literal composite value, via the same `tokens` list
  * `BoxShadowControl` already offers for its trigger label.
  *
+ * Uses `findTokenEntry()` rather than a plain `entry.alias === alias` scan. The only string this
+ * function ever receives that is not a real `{dot.alias}` is `toNativeShadow()`'s fixed "None"
+ * sentinel, `0px 0px 0px 0px transparent` — that matches a `fixed: true` entry on alias equality,
+ * which `findTokenEntry()`'s guard (`entry.fixed || isTokenAlias(value)`) also accepts. Its
+ * legacy-slug fallback is inert here: it only matches a `primitive.dimension.*` entry, and a
+ * shadow-role pool holds none.
+ *
  * @param {string} alias  The picked token alias.
  * @param {Array}  tokens Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
  *
@@ -231,7 +238,7 @@ function axisToNative(slot) {
  * @return {?Object} The resolved composite, or `null` when the alias matches no pickable token.
  */
 function resolveShadowAlias(alias, tokens) {
-	const entry = (tokens || []).find((token) => token.alias === alias);
+	const entry = findTokenEntry(tokens || [], alias);
 
 	return entry ? parseResolvedShadow(entry.value) : null;
 }

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -49,7 +49,7 @@
 import { BoxShadowControl, DEFAULT_COMPOSITE, parseResolvedShadow } from '../../../token-controls';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
 import { isTokenAlias } from '../alias';
-import { SHADOW_TOKEN_KEY } from '../shadow-token';
+import { SHADOW_TOKEN_KEY, boundShadowToken } from '../shadow-token';
 
 /**
  * A CSS `rgba(r, g, b, a)` string, matching `hexToRGBA`'s own output format exactly (comma-space
@@ -237,6 +237,19 @@ function resolveShadowAlias(alias, tokens) {
 }
 
 /**
+ * The shadow token a stored native value is bound to.
+ *
+ * @param {?Array} native The stored native shadow attribute value.
+ *
+ * @since TBD
+ *
+ * @return {?string} The bound `{dot.alias}`, or null when the value carries no binding.
+ */
+export function shadowTokenOf(native) {
+	return boundShadowToken(native?.[0]);
+}
+
+/**
  * Convert the native `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` attribute value to
  * the composite `BoxShadowControl` edits.
  *
@@ -357,6 +370,12 @@ export function isUnsetShadow(native, defaultValue) {
 		return true;
 	}
 
+	// A binding, not the geometry, decides here: a token that resolves to a subtle or zero-offset
+	// shadow is still a deliberate pick, and reading it as unset would drop its name from the trigger.
+	if (shadowTokenOf(native)) {
+		return false;
+	}
+
 	// A preset shadow behind it makes an invisible shadow a deliberate suppression, not an absence.
 	if (defaultValue !== undefined && defaultValue !== null && defaultValue !== '') {
 		return false;
@@ -375,7 +394,8 @@ export function isUnsetShadow(native, defaultValue) {
  *
  * @param {Object}    props               The component props.
  * @param {string}    props.label         The control's label.
- * @param {?Array}    props.value         The native shadow attribute value.
+ * @param {?Array}    props.value         The native shadow attribute value, optionally carrying a
+ *                                        `shadowToken` binding.
  * @param {Function}  props.onChange      Called with the next native shadow attribute value.
  * @param {Array}     [props.tokens]      Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
  * @param {*}         [props.defaultValue] The active preset's own resolved shadow, or nothing when it
@@ -398,11 +418,16 @@ export function EditorShadowControl({
 	renderColor,
 	disabled = false,
 }) {
+	// A bound value goes down as the bare alias string, which is the shape `BoxShadowControl` already
+	// recognizes as a token: it names the token on the trigger, opens on the Style Library tab, and
+	// previews the token's own shadow. The stored legs stay untouched behind it.
+	const bound = shadowTokenOf(value);
+
 	return (
 		<TokenControlRow stacked>
 			<BoxShadowControl
 				label={label}
-				value={isUnsetShadow(value, defaultValue) ? '' : fromNativeShadow(value)}
+				value={isUnsetShadow(value, defaultValue) ? '' : bound || fromNativeShadow(value)}
 				onChange={(next) => onChange(toNativeShadow(next, tokens))}
 				tokens={tokens}
 				defaultValue={defaultValue}

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -26,14 +26,12 @@
  * inspecting the shadow value's own axes (an all-zero value, including the fixed "None" pick, emits
  * nothing), both on the front end and in the editor-canvas live preview.
  *
- * A whole-shadow token pick (the Style Library tab) has no home in the native item's existing keys —
- * unlike border, where an alias replaces a single side's width slot, a shadow alias would replace the
- * *entire* value. Rather than invent a spot to carry a live alias, a pick resolves to its literal
- * composite value immediately, at pick time, using the same `tokens` list `BoxShadowControl` already
- * offers for its trigger label (`[{ id, alias, label, value, type, role }]`). `toNativeShadow` looks
- * up the picked alias's resolved `value` (the feed's `box-shadow` shorthand string) and writes the
- * parsed composite straight into the native item's plain fields — no alias key, no live link back to
- * the token, matching how a per-instance color pick is already handled everywhere else in this plan.
+ * A whole-shadow token pick (the Style Library tab) is carried on the item's own optional
+ * `shadowToken` key. Unlike border, where an alias replaces a single side's width slot, a shadow alias
+ * would replace the *entire* value, so it gets a key of its own rather than displacing a leg. The
+ * legs are still written with the token's resolved value at pick time: they keep the item a valid
+ * literal shadow for readers that do not know the binding key, and they are the fallback a render uses
+ * when the bound token is no longer in the active library.
  *
  * Color is out of scope for redesign here, exactly as in `EditorBorderControl` — this component
  * neither builds nor intercepts a color field, it only wires the caller's EXISTING one back in via
@@ -50,6 +48,8 @@
  */
 import { BoxShadowControl, DEFAULT_COMPOSITE, parseResolvedShadow } from '../../../token-controls';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
+import { isTokenAlias } from '../alias';
+import { SHADOW_TOKEN_KEY } from '../shadow-token';
 
 /**
  * A CSS `rgba(r, g, b, a)` string, matching `hexToRGBA`'s own output format exactly (comma-space
@@ -267,10 +267,11 @@ export function fromNativeShadow(native) {
  * Convert `BoxShadowControl`'s value back to the native
  * `[{ color, opacity, hOffset, vOffset, blur, spread, inset }]` attribute shape.
  *
- * A token alias string (a pick from the Style Library tab) resolves to its literal composite value
- * immediately, through `tokens`, rather than being stored as a live link back to the token — an
- * alias that resolves to nothing (a stale or unmapped id) falls back to the composite default so the
- * write never corrupts the attribute.
+ * A token alias string (a pick from the Style Library tab) is recorded on the item's `shadowToken` key
+ * AND resolved through `tokens` onto the numeric legs, so the item carries both a live link to the
+ * token and the literal that link resolved to at pick time. An alias that resolves to nothing (a stale
+ * or unmapped id) still records the binding — the token may come back — and falls the legs back to the
+ * composite default so the write never corrupts the attribute.
  *
  * @param {string|Object} value    The value `BoxShadowControl` reports through `onChange`.
  * @param {Array}         [tokens] Pickable `shadow`-type tokens, `[{id, label, value, alias}]`, used
@@ -285,17 +286,20 @@ export function toNativeShadow(value, tokens = []) {
 
 	const { color, opacity } = splitColorOpacity(composite?.color);
 
-	return [
-		{
-			color: color || DEFAULT_COMPOSITE.color,
-			opacity,
-			hOffset: axisToNative(composite?.offsetX),
-			vOffset: axisToNative(composite?.offsetY),
-			blur: axisToNative(composite?.blur),
-			spread: axisToNative(composite?.spread),
-			inset: composite?.inset === true,
-		},
-	];
+	const item = {
+		color: color || DEFAULT_COMPOSITE.color,
+		opacity,
+		hOffset: axisToNative(composite?.offsetX),
+		vOffset: axisToNative(composite?.offsetY),
+		blur: axisToNative(composite?.blur),
+		spread: axisToNative(composite?.spread),
+		inset: composite?.inset === true,
+	};
+
+	// Only a real `{dot.alias}` binds. The Style Library tab's fixed "None" sentinel arrives here as a
+	// literal shorthand string, not an alias, and must stay a plain zero value — binding it would point
+	// the item at a token that was never registered.
+	return [isTokenAlias(value) ? { ...item, [SHADOW_TOKEN_KEY]: value } : item];
 }
 
 /**

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -433,6 +433,9 @@ export function EditorShadowControl({
 				defaultValue={defaultValue}
 				renderColor={renderColor}
 				disabled={disabled}
+				// The stored legs are the fallback for a binding whose token has since been deleted — the
+				// same snapshot the renderers already fall back to when a binding no longer resolves.
+				fallbackShadow={bound ? fromNativeShadow(value) : undefined}
 			/>
 		</TokenControlRow>
 	);

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -13,6 +13,23 @@ import {
 	isUnsetShadow,
 } from '../EditorShadowControl';
 import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
+import { SHADOW_TOKEN_KEY } from '../../shadow-token';
+
+/**
+ * A pickable shadow token, shaped like one entry of `pickableTokensForKey()`'s output.
+ *
+ * @since TBD
+ *
+ * @type {Object}
+ */
+const SHADOW_TOKEN = {
+	id: 'semantic.shadow.card',
+	alias: '{semantic.shadow.card}',
+	label: 'Medium',
+	value: '0px 2px 8px 0px rgba(23, 23, 23, 0.12)',
+	type: 'shadow',
+	role: 'shadow',
+};
 
 /**
  * A representative native shadow value — every field a different, distinguishable number/string, so a
@@ -181,39 +198,86 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 	});
 
 	/**
-	 * Picking a token alias in the Style Library tab resolves it to its literal composite value
-	 * immediately, via the `tokens` list, and writes that literal into the native item — no `alias`
-	 * key, no live link back to the token.
+	 * A picked token alias is recorded on the item's own `shadowToken` key, so the value stays linked to
+	 * the token instead of freezing to whatever the token resolved to at pick time.
 	 *
 	 * @return {void}
 	 */
-	it('resolves a picked token alias to its literal composite value, not an alias marker', () => {
-		const { shadowControl, onChange } = renderEditorShadowControl({
-			tokens: [
-				{
-					id: 'primitive.shadow.md',
-					alias: 'primitive.shadow.md',
-					label: 'Medium',
-					value: '2px 3px 4px 5px #111111',
-					type: 'shadow',
-				},
-			],
+	it('records a picked token alias on shadowToken', () => {
+		const native = toNativeShadow(SHADOW_TOKEN.alias, [SHADOW_TOKEN]);
+
+		expect(native[0][SHADOW_TOKEN_KEY]).toBe('{semantic.shadow.card}');
+	});
+
+	/**
+	 * The token's resolved value is splayed across the legs alongside the alias, so a reader that has not
+	 * learned about `shadowToken` — and a render that finds the token deleted — still has a real shadow.
+	 *
+	 * @return {void}
+	 */
+	it('keeps the resolved literal on the legs alongside the alias', () => {
+		const native = toNativeShadow(SHADOW_TOKEN.alias, [SHADOW_TOKEN]);
+
+		expect(native[0]).toMatchObject({
+			hOffset: 0,
+			vOffset: 2,
+			blur: 8,
+			spread: 0,
+			color: '#171717',
+			opacity: 0.12,
+			inset: false,
 		});
+	});
 
-		shadowControl.props.onChange('primitive.shadow.md');
+	/**
+	 * A Custom-tab edit reports a composite object, which carries no alias — the rebuilt item must drop
+	 * `shadowToken` so touching a leg breaks the binding rather than leaving a stale one behind.
+	 *
+	 * @return {void}
+	 */
+	it('drops shadowToken when a composite edit replaces the pick', () => {
+		const bound = toNativeShadow(SHADOW_TOKEN.alias, [SHADOW_TOKEN]);
+		const edited = toNativeShadow({ ...fromNativeShadow(bound), blur: '9px' }, [SHADOW_TOKEN]);
 
-		expect(onChange).toHaveBeenCalledWith([
-			{
-				color: '#111111',
-				opacity: 1,
-				hOffset: 2,
-				vOffset: 3,
-				blur: 4,
-				spread: 5,
-				inset: false,
-			},
-		]);
-		expect(onChange.mock.calls[0][0][0]).not.toHaveProperty('alias');
+		expect(edited[0]).not.toHaveProperty(SHADOW_TOKEN_KEY);
+		expect(edited[0].blur).toBe(9);
+	});
+
+	/**
+	 * The fixed "None" sentinel's own value is a literal shorthand, not an alias, so it must resolve to
+	 * the zero composite with no binding — binding it would point at a token that does not exist.
+	 *
+	 * @return {void}
+	 */
+	it('does not bind the fixed None sentinel', () => {
+		const none = {
+			id: 'ss-none-shadow',
+			alias: '0px 0px 0px 0px transparent',
+			label: 'None',
+			value: '0px 0px 0px 0px transparent',
+			fixed: true,
+			type: 'shadow',
+			role: 'shadow',
+		};
+
+		const native = toNativeShadow(none.alias, [none]);
+
+		expect(native[0]).not.toHaveProperty(SHADOW_TOKEN_KEY);
+		expect(native[0]).toMatchObject({ hOffset: 0, vOffset: 0, blur: 0, spread: 0 });
+	});
+
+	/**
+	 * An alias that matches no pickable token — a token deleted between the pick and this write — still
+	 * records the binding, so a token that later comes back re-links, and falls the legs back to the
+	 * composite default rather than corrupting them.
+	 *
+	 * @return {void}
+	 */
+	it('records the binding even when the alias matches no pickable token', () => {
+		const native = toNativeShadow('{semantic.shadow.does-not-exist}', [SHADOW_TOKEN]);
+
+		expect(native[0][SHADOW_TOKEN_KEY]).toBe('{semantic.shadow.does-not-exist}');
+		expect(native[0]).toMatchObject({ hOffset: 0, vOffset: 0, blur: 0, spread: 0 });
 	});
 
 	/**

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -525,6 +525,58 @@ describe('isUnsetShadow', () => {
 	});
 });
 
+describe('EditorShadowControl token binding read-back', () => {
+	/**
+	 * A bound item hands `BoxShadowControl` the alias string, which is what makes its trigger name the
+	 * token, open on the Style Library tab, and preview the token's own shadow.
+	 *
+	 * @return {void}
+	 */
+	it('passes the bound alias down instead of the composite', () => {
+		const { shadowControl } = renderEditorShadowControl({
+			value: toNativeShadow(SHADOW_TOKEN.alias, [SHADOW_TOKEN]),
+			tokens: [SHADOW_TOKEN],
+		});
+
+		expect(shadowControl.props.value).toBe('{semantic.shadow.card}');
+	});
+
+	/**
+	 * A bound item whose legs are all zero is still bound, not unset — the binding, not the geometry,
+	 * decides. Without this guard a token that resolves to a subtle or zero-offset shadow would read as
+	 * an untouched field and lose its name on the trigger.
+	 *
+	 * @return {void}
+	 */
+	it('reads a bound item with zero legs as set', () => {
+		const zeroBound = [
+			{
+				color: 'transparent',
+				opacity: 1,
+				hOffset: 0,
+				vOffset: 0,
+				blur: 0,
+				spread: 0,
+				inset: false,
+				[SHADOW_TOKEN_KEY]: '{semantic.shadow.card}',
+			},
+		];
+
+		expect(isUnsetShadow(zeroBound, undefined)).toBe(false);
+	});
+
+	/**
+	 * An unbound item is unaffected: it still bridges to the composite shape.
+	 *
+	 * @return {void}
+	 */
+	it('still passes a composite down for an unbound item', () => {
+		const { shadowControl } = renderEditorShadowControl();
+
+		expect(shadowControl.props.value).toMatchObject({ offsetX: '2px', offsetY: '3px' });
+	});
+});
+
 describe('EditorShadowControl unset rendering', () => {
 	const INVISIBLE = [{ color: 'transparent', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0, inset: false }];
 

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -379,6 +379,33 @@ describe('EditorShadowControl always renders, with no enable toggle', () => {
 	});
 });
 
+describe('EditorShadowControl fallbackShadow wiring', () => {
+	/**
+	 * A bound value passes the stored legs down as `fallbackShadow`, so `BoxShadowControl`'s Custom tab
+	 * can seed from them if the bound token is later deleted and the alias stops resolving.
+	 *
+	 * @return {void}
+	 */
+	it('passes the stored legs as fallbackShadow for a value with a shadowToken binding', () => {
+		const bound = toNativeShadow(SHADOW_TOKEN.alias, [SHADOW_TOKEN]);
+		const { shadowControl } = renderEditorShadowControl({ value: bound, tokens: [SHADOW_TOKEN] });
+
+		expect(shadowControl.props.fallbackShadow).toEqual(fromNativeShadow(bound));
+	});
+
+	/**
+	 * An unbound (plain composite) value has no binding to fall back FROM, so `fallbackShadow` stays
+	 * undefined rather than shadowing `BoxShadowControl`'s own default-composite behavior.
+	 *
+	 * @return {void}
+	 */
+	it('leaves fallbackShadow undefined for a value with no shadowToken binding', () => {
+		const { shadowControl } = renderEditorShadowControl();
+
+		expect(shadowControl.props.fallbackShadow).toBeUndefined();
+	});
+});
+
 describe('EditorShadowControl renderColor wiring', () => {
 	/**
 	 * `renderColor` is passed straight through to `BoxShadowControl` untouched — this component neither

--- a/src/extension/design-tokens/shadow-token.js
+++ b/src/extension/design-tokens/shadow-token.js
@@ -1,0 +1,40 @@
+/**
+ * The native shadow item's optional binding key, and the one function that reads it.
+ *
+ * A whole-shadow token pick has no home among the item's existing keys — unlike border, where an alias
+ * replaces a single side's width slot, a shadow alias would replace the entire value — so it gets a key
+ * of its own. The numeric legs are still written with the token's resolved value at pick time: they
+ * keep the item a valid literal shadow for readers that do not know this key, and they are what a
+ * render falls back to when the bound token is no longer in the active library.
+ *
+ * This lives apart from `components/EditorShadowControl.js` because the editor-canvas style builder
+ * needs the key too, and must not pull a React component, its SCSS, and the `token-controls` barrel
+ * into a module that only builds strings.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { isTokenAlias } from './alias';
+
+/**
+ * The shadow item key that carries a whole-shadow token binding.
+ *
+ * @since TBD
+ */
+export const SHADOW_TOKEN_KEY = 'shadowToken';
+
+/**
+ * The shadow token one stored shadow item is bound to.
+ *
+ * @param {?Object} shadowItem One `shadow[0]`-shaped item.
+ *
+ * @since TBD
+ *
+ * @return {?string} The bound `{dot.alias}`, or null when the item carries no binding.
+ */
+export function boundShadowToken(shadowItem) {
+	const alias = shadowItem?.[SHADOW_TOKEN_KEY];
+
+	return isTokenAlias(alias) ? alias : null;
+}

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -570,6 +570,24 @@ describe('BoxShadowControl Style Library tab', () => {
 
 describe('BoxShadowControl Custom tab', () => {
 	/**
+	 * An aliased value seeds the Custom tab from the bound token's own resolved shorthand, not the
+	 * all-zero default composite — switching to Custom must show the token's real legs so editing one
+	 * of them does not silently discard the rest.
+	 *
+	 * @return {void}
+	 */
+	it('seeds the Custom tab’s fields from the bound token’s resolved value for an aliased value', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		click(container.querySelector('[data-testid="tab-custom"]'));
+
+		expect(numberInput('X').value).toBe('0');
+		expect(numberInput('Y').value).toBe('2');
+		expect(numberInput('Blur').value).toBe('8');
+		expect(numberInput('Spread').value).toBe('0');
+	});
+
+	/**
 	 * Editing an axis writes the full composite object with only that axis changed, serialized as a
 	 * px dimension string, and the rest of the value preserved.
 	 *

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -588,6 +588,66 @@ describe('BoxShadowControl Custom tab', () => {
 	});
 
 	/**
+	 * A stale alias — no entry in `tokens` resolves it, because the token was deleted after the binding
+	 * was saved — seeds the Custom tab from the host's `fallbackShadow` prop instead of the all-zero
+	 * default, so switching to Custom does not silently discard the stored legs.
+	 *
+	 * @return {void}
+	 */
+	it('seeds the Custom tab’s fields from fallbackShadow for a stale alias', () => {
+		renderControl({
+			value: '{primitive.shadow.deleted}',
+			fallbackShadow: { color: '#222222', offsetX: '3px', offsetY: '5px', blur: '10px', spread: '1px' },
+		});
+
+		click(container.querySelector('[data-testid="tab-custom"]'));
+
+		expect(numberInput('X').value).toBe('3');
+		expect(numberInput('Y').value).toBe('5');
+		expect(numberInput('Blur').value).toBe('10');
+		expect(numberInput('Spread').value).toBe('1');
+	});
+
+	/**
+	 * A stale alias with no `fallbackShadow` supplied still seeds the Custom tab from the plain default
+	 * composite (all-zero) — the Style Library host never passes this prop, so it must see unchanged
+	 * behavior.
+	 *
+	 * @return {void}
+	 */
+	it('seeds the Custom tab’s fields from the default composite for a stale alias with no fallbackShadow', () => {
+		renderControl({ value: '{primitive.shadow.deleted}' });
+
+		click(container.querySelector('[data-testid="tab-custom"]'));
+
+		expect(numberInput('X').value).toBe('0');
+		expect(numberInput('Y').value).toBe('0');
+		expect(numberInput('Blur').value).toBe('0');
+		expect(numberInput('Spread').value).toBe('0');
+	});
+
+	/**
+	 * An alias that DOES resolve against `tokens` still seeds from that token entry, even when a
+	 * `fallbackShadow` is also supplied — the fallback only applies to a stale alias, never overriding a
+	 * live resolution.
+	 *
+	 * @return {void}
+	 */
+	it('prefers the resolved token entry over fallbackShadow when the alias resolves', () => {
+		renderControl({
+			value: '{primitive.shadow.md}',
+			fallbackShadow: { color: '#222222', offsetX: '3px', offsetY: '5px', blur: '10px', spread: '1px' },
+		});
+
+		click(container.querySelector('[data-testid="tab-custom"]'));
+
+		expect(numberInput('X').value).toBe('0');
+		expect(numberInput('Y').value).toBe('2');
+		expect(numberInput('Blur').value).toBe('8');
+		expect(numberInput('Spread').value).toBe('0');
+	});
+
+	/**
 	 * Editing an axis writes the full composite object with only that axis changed, serialized as a
 	 * px dimension string, and the rest of the value preserved.
 	 *

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -566,6 +566,40 @@ describe('BoxShadowControl Style Library tab', () => {
 
 		expect(preview().style.boxShadow).toBe('none');
 	});
+
+	/**
+	 * A stale alias (deleted after the binding was saved) still previews the same shadow the Custom
+	 * tab's `fallbackShadow`-seeded fields show, instead of falling shadow-less while the tab above it
+	 * shows real legs.
+	 *
+	 * @return {void}
+	 */
+	it('previews the fallback shadow for a stale alias with a fallbackShadow', () => {
+		renderControl({
+			value: '{primitive.shadow.deleted}',
+			fallbackShadow: { color: '#222222', offsetX: '3px', offsetY: '5px', blur: '10px', spread: '1px' },
+		});
+
+		const preview = container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+
+		expect(preview).not.toBeNull();
+		expect(preview.style.boxShadow).toBe('3px 5px 10px 1px #222222');
+	});
+
+	/**
+	 * An alias that still resolves against `tokens` previews that token entry's own resolved value,
+	 * not the composite shorthand — a resolving alias is unaffected by the stale-alias fallback path.
+	 *
+	 * @return {void}
+	 */
+	it('previews the resolved token entry’s own value for a resolving alias', () => {
+		renderControl({ value: '{primitive.shadow.md}' });
+
+		const preview = container.querySelector('.kadence-token-field__preview .kb-box-shadow-control__preview');
+
+		expect(preview).not.toBeNull();
+		expect(preview.style.boxShadow).toBe('0px 2px 8px 0px #1717171f');
+	});
 });
 
 describe('BoxShadowControl Custom tab', () => {

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -58,7 +58,14 @@ import { __ } from '@wordpress/i18n';
  */
 import { ControlShell } from '../templates/ControlShell';
 import { TokenPopover } from '../molecules/TokenPopover';
-import { defaultSummary, fieldSummary, hasValue, isTokenAlias, resolveDefaultValue } from '../helpers/token-summary';
+import {
+	defaultSummary,
+	fieldSummary,
+	findTokenEntry,
+	hasValue,
+	isTokenAlias,
+	resolveDefaultValue,
+} from '../helpers/token-summary';
 import { DEFAULT_COMPOSITE, parseResolvedShadow } from '../helpers/shadow-shorthand';
 import '../styles/token-controls.scss';
 
@@ -114,13 +121,16 @@ function matchFixedEntry(shadow, tokens) {
 
 /**
  * Resolve the current slot value into `box-shadow` CSS for the Style Library tab's preview square: a
- * bound token's own resolved value string when aliased, or the composite's own shorthand (matching
- * the dimension order and literal `inset` keyword `Css_Renderer`/`shadowCss()` emit) when a literal
- * composite is set. Empty when nothing is set yet, so the preview renders a plain, shadow-less box.
+ * bound token's own resolved value string when aliased and resolving, or the composite's own
+ * shorthand (matching the dimension order and literal `inset` keyword `Css_Renderer`/`shadowCss()`
+ * emit) otherwise — for a literal composite value, and also for an alias that no longer resolves
+ * against `tokens`, where `shadow` carries the caller's `fallbackShadow` legs. Empty when nothing is
+ * set yet, so the preview renders a plain, shadow-less box.
  *
  * @param {*}      value  The current slot value (alias string, composite object, or empty).
  * @param {Array}  tokens The pickable-token list, used to resolve an alias.
- * @param {Object} shadow The composite value with defaults already filled (ignored for an alias).
+ * @param {Object} shadow The composite value with defaults already filled — used both for a literal
+ *                        composite and as the stale-alias fallback.
  *
  * @since TBD
  *
@@ -128,9 +138,16 @@ function matchFixedEntry(shadow, tokens) {
  */
 function resolvePreviewCss(value, tokens, shadow) {
 	if (isTokenAlias(value)) {
-		const entry = tokens.find((candidate) => candidate.alias === value);
+		const entry = findTokenEntry(tokens || [], value);
 
-		return entry ? entry.value : '';
+		if (entry) {
+			return entry.value;
+		}
+
+		// Falls through rather than returning '': a stale binding (the token was deleted after the
+		// alias was saved) has no entry to resolve, but `shadow` was already seeded from the host's
+		// `fallbackShadow` legs by the caller, so the composite shorthand below still renders the same
+		// shadow the Custom tab shows, instead of leaving the preview shadow-less while the tab is not.
 	}
 
 	if (!hasValue(value)) {
@@ -261,7 +278,7 @@ export function BoxShadowControl({
 	// An alias carries no legs of its own, so the Custom tab has nothing to seed from unless it borrows
 	// the bound token's own resolved shorthand here — without this, switching to Custom tab reads as
 	// an all-zero, transparent shadow and editing one leg discards the token's real value.
-	const aliasedEntry = aliased ? (tokens || []).find((entry) => entry.alias === value) : null;
+	const aliasedEntry = aliased ? findTokenEntry(tokens || [], value) : null;
 	// A stale alias (the token was deleted after the binding was saved) has no entry to resolve, but the
 	// host still stores the legs it was resolved to at save time — that snapshot is what the other
 	// renderers already fall back to for a stale binding, so the Custom tab seeds from it here too,

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -231,12 +231,27 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
  *                                        shadow to name is unchanged.
  * @param {Function}  [props.renderColor] `({ value, onChange }) => Element` for the color sub-field.
  * @param {boolean}   [props.disabled]    Whether the control is read-only.
+ * @param {Object}    [props.fallbackShadow] The host's stored composite legs, used to seed the Custom
+ *                                        tab only when `value` is a token alias that no longer resolves
+ *                                        against `tokens` (the token was deleted after the alias was
+ *                                        saved). Without one, a stale alias falls back to the plain
+ *                                        default composite, so a host that never binds a token (the
+ *                                        Style Library) is unaffected.
  *
  * @since TBD
  *
  * @return {JSX.Element} The rendered control.
  */
-export function BoxShadowControl({ value, onChange, label, tokens = [], defaultValue, renderColor, disabled = false }) {
+export function BoxShadowControl({
+	value,
+	onChange,
+	label,
+	tokens = [],
+	defaultValue,
+	renderColor,
+	disabled = false,
+	fallbackShadow,
+}) {
 	const aliased = isTokenAlias(value);
 	// Only a real object is spread. A shadow can also arrive as a rendered STRING — the editor's capture
 	// flow writes one — and spreading a string splays it into indexed character keys, which the Custom
@@ -247,8 +262,13 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], defaultV
 	// the bound token's own resolved shorthand here — without this, switching to Custom tab reads as
 	// an all-zero, transparent shadow and editing one leg discards the token's real value.
 	const aliasedEntry = aliased ? (tokens || []).find((entry) => entry.alias === value) : null;
+	// A stale alias (the token was deleted after the binding was saved) has no entry to resolve, but the
+	// host still stores the legs it was resolved to at save time — that snapshot is what the other
+	// renderers already fall back to for a stale binding, so the Custom tab seeds from it here too,
+	// rather than from the all-zero default.
+	const resolvedAliasShadow = aliasedEntry ? parseResolvedShadow(aliasedEntry.value) : fallbackShadow;
 	const shadow = aliased
-		? { ...DEFAULT_COMPOSITE, ...(aliasedEntry ? parseResolvedShadow(aliasedEntry.value) : {}) }
+		? { ...DEFAULT_COMPOSITE, ...(resolvedAliasShadow || {}) }
 		: { ...DEFAULT_COMPOSITE, ...custom };
 	// A fixed pick keeps no live alias, so a sentinel is recognized after the fact by its shorthand.
 	const fixedMatch = !aliased && hasValue(value) ? matchFixedEntry(shadow, tokens) : null;

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -59,7 +59,7 @@ import { __ } from '@wordpress/i18n';
 import { ControlShell } from '../templates/ControlShell';
 import { TokenPopover } from '../molecules/TokenPopover';
 import { defaultSummary, fieldSummary, hasValue, isTokenAlias, resolveDefaultValue } from '../helpers/token-summary';
-import { DEFAULT_COMPOSITE } from '../helpers/shadow-shorthand';
+import { DEFAULT_COMPOSITE, parseResolvedShadow } from '../helpers/shadow-shorthand';
 import '../styles/token-controls.scss';
 
 /**
@@ -243,7 +243,13 @@ export function BoxShadowControl({ value, onChange, label, tokens = [], defaultV
 	// tab would then write back as a shadow whose sub-fields are `0`, `p`, `x`. Degrading to the default
 	// shape reads as unset, which is wrong but harmless where the alternative cannot be saved at all.
 	const custom = typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
-	const shadow = { ...DEFAULT_COMPOSITE, ...(aliased ? {} : custom) };
+	// An alias carries no legs of its own, so the Custom tab has nothing to seed from unless it borrows
+	// the bound token's own resolved shorthand here — without this, switching to Custom tab reads as
+	// an all-zero, transparent shadow and editing one leg discards the token's real value.
+	const aliasedEntry = aliased ? (tokens || []).find((entry) => entry.alias === value) : null;
+	const shadow = aliased
+		? { ...DEFAULT_COMPOSITE, ...(aliasedEntry ? parseResolvedShadow(aliasedEntry.value) : {}) }
+		: { ...DEFAULT_COMPOSITE, ...custom };
 	// A fixed pick keeps no live alias, so a sentinel is recognized after the fact by its shorthand.
 	const fixedMatch = !aliased && hasValue(value) ? matchFixedEntry(shadow, tokens) : null;
 	// Display only — `onChange` still sees the real underlying value.


### PR DESCRIPTION
Picking a shadow token in the block editor wrote the token's resolved value into the block's plain numeric fields (`hOffset`, `vOffset`, `blur`, `spread`, `color`, `opacity`). The control then read that back as "Custom", and the value stopped tracking the token — editing the token later did not move the button.

This slice adds the data model and the control behavior. Nothing renders differently yet; the two renderers follow in later slices of this stack.

## What changed

**A new `shadowToken` key on the shadow item.** `src/extension/design-tokens/shadow-token.js` holds the key and `boundShadowToken()`, the one function that reads it. It is a module of its own, depending only on `./alias`, because the editor-canvas style builder needs the key too and must not pull a React component, its SCSS, and the `token-controls` barrel into a module that only builds strings.

**The write path.** `toNativeShadow()` records the picked `{dot.alias}` on `shadowToken` **and** still splays the token's resolved value across the numeric legs. Keeping both is deliberate:

- the item stays a valid literal shadow for every reader that does not know the new key, and
- they seed the control's Custom tab, so switching a bound shadow to Custom starts from real values.

The two are not a second opinion: when the binding is present and backed by the active library it wins outright and the legs are never read, and when the token has been deleted the renderers fall back to the block's default CSS rather than to the legs. The legs are a frozen snapshot the inspector reads, not a rendering fallback.

Only a real `{dot.alias}` binds. The Style Library's fixed "None" sentinel arrives as the literal string `0px 0px 0px 0px transparent`, which is not alias-shaped, so it keeps resolving to a plain zero item with no binding. Any Custom-tab edit reports a composite object, which carries no alias, so touching a leg breaks the binding — the value is then the user's, not the token's.

**The read path.** `EditorShadowControl` hands `BoxShadowControl` the bare alias string when a binding is present, which is the shape it already recognizes: the trigger names the token, the popover opens on the Style Library tab, and the preview square shows the token's own shadow. `isUnsetShadow()` treats a bound item as set even when every leg is zero, since some registered shadow tokens genuinely resolve to an all-zero transparent shadow and reading those as "unset" would drop the token's name from the trigger.

**Two fixes in `BoxShadowControl`.** With an alias value, the Custom tab previously seeded from the all-zero `DEFAULT_COMPOSITE`, so switching to it on a bound token showed zeros and editing one leg discarded the token's real value. It now seeds from the bound token's own resolved shorthand, resolving from `tokens` because the token's current value is what is actually rendering. When the alias matches no entry — a token deleted after saving — an optional `fallbackShadow` prop seeds it from the host's stored legs instead, and the preview square above the tab falls through to the same composite so the two agree. This also fixes the Style Library host, which uses the same control and passes no `fallbackShadow`.

The three hand-rolled `entry.alias === value` lookups this area had are now single calls to the existing `findTokenEntry()`.

## No deprecation needed

`kadence/singlebtn` is fully dynamic — `save()` returns `null`, so Gutenberg's markup validation trivially passes and never reaches `deprecated`. `shadowToken` is a new optional key: absent on all existing content, and absent means "no token bound", which is exactly today's behavior. There is no schema change either — `shadow` is declared `{ "type": "array" }` with a default and no `items` schema.

## Test plan

- `npm test -- src/extension/design-tokens src/token-controls`
- The write path is covered for: a pick recording the alias, the resolved legs surviving alongside it, a Custom-tab edit dropping the binding, the fixed "None" sentinel *not* binding, and an alias matching no pickable token still recording the binding while falling the legs back to the default shape.
- The read path is covered for: the bound alias being handed down instead of the composite, a bound item with all-zero legs reading as set, and an unbound item still bridging to the composite.
- `BoxShadowControl`'s existing alias-label tests prove the half of the bridge this slice does not write, and are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shadow selections retain their design-token bindings while preserving resolved shadow values.
  - Edit and preview shadows when token aliases are stale or unavailable, using saved fallback values.
  - Live token values take priority when available.

- **Bug Fixes**
  - Improved handling of zero-value shadows, unknown aliases, missing tokens, and the fixed “None” option.
  - Composite shadow edits now remove outdated token bindings and preserve accurate visual previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->