### PR TITLE
[DTM] SOFT-4269 [1/4]: forget a library's cached store state

### DIFF
--- a/src/style-library/store/actions.js
+++ b/src/style-library/store/actions.js
@@ -59,6 +59,25 @@ export function receiveDesignTokensFeed(slug, feed) {
 }
 
 /**
+ * Forget every cached entry addressed to one library: its block presets, its palette listing, its
+ * pending optimistic overlays, and its busy flags.
+ *
+ * Dispatched after a library is deleted or reset, so the screens stop rendering values the server
+ * no longer holds. The feeds slice is deliberately untouched — the flow that dispatches this is
+ * about to replace the feed it lands on, and blanking it first would drop the whole app to its
+ * loading skeleton for a tick.
+ *
+ * @param {string} slug Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {Object} The action object.
+ */
+export function forgetLibrary(slug) {
+	return { type: 'FORGET_LIBRARY', slug };
+}
+
+/**
  * Patch a swatch's label and/or value in the optimistic overlay, ahead of its write's response.
  *
  * @param {string} key   The palette listing key (`paletteListingKey(namespace, slug)`).

--- a/src/style-library/store/constants.js
+++ b/src/style-library/store/constants.js
@@ -12,6 +12,14 @@
 export const STORE_NAME = 'kadence-blocks/style-library';
 
 /**
+ * The separator every key builder below joins its segments with. Named rather than inlined
+ * because the predicates further down split keys back apart on it — the two must never drift.
+ *
+ * @since TBD
+ */
+const KEY_SEPARATOR = '::';
+
+/**
  * Build the state key for a block's preset collection.
  *
  * @param {string} namespace REST namespace.
@@ -23,7 +31,7 @@ export const STORE_NAME = 'kadence-blocks/style-library';
  * @return {string} The state key.
  */
 export function presetsKey(namespace, block, slug) {
-	return `${namespace}::${block}::${slug}`;
+	return [namespace, block, slug].join(KEY_SEPARATOR);
 }
 
 /**
@@ -37,7 +45,7 @@ export function presetsKey(namespace, block, slug) {
  * @return {string} The state key.
  */
 export function paletteListingKey(namespace, slug) {
-	return `${namespace}::${slug}`;
+	return [namespace, slug].join(KEY_SEPARATOR);
 }
 
 /**
@@ -55,7 +63,43 @@ export function paletteListingKey(namespace, slug) {
  * @return {string} The state key.
  */
 export function paletteEditKey(namespace, slug, paletteId) {
-	return `${paletteListingKey(namespace, slug)}::${paletteId}`;
+	return [paletteListingKey(namespace, slug), paletteId].join(KEY_SEPARATOR);
+}
+
+/**
+ * Whether a key built by `paletteListingKey()` or `paletteEditKey()` addresses the given library.
+ * One predicate serves both (and the palette-busy slice, which is keyed by `paletteListingKey()`)
+ * because all three put the slug in the second segment.
+ *
+ * Compares one segment rather than testing a prefix or suffix: a slug is a slugified title and a
+ * namespace is a REST path, so a naive `startsWith`/`endsWith` would match a library whose slug is
+ * merely a prefix of another's.
+ *
+ * @param {string} key  A key built by `paletteListingKey()` or `paletteEditKey()`.
+ * @param {string} slug Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the key addresses that library.
+ */
+export function isLibraryScopedKey(key, slug) {
+	return key.split(KEY_SEPARATOR)[1] === slug;
+}
+
+/**
+ * Whether a key built by `presetsKey()` addresses the given library. Its own predicate because a
+ * presets key carries the block name in the second segment, so the slug sits one place later than
+ * in every other key this module builds.
+ *
+ * @param {string} key  A key built by `presetsKey()`.
+ * @param {string} slug Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the key addresses that library.
+ */
+export function isPresetsKeyForLibrary(key, slug) {
+	return key.split(KEY_SEPARATOR)[2] === slug;
 }
 
 /**

--- a/src/style-library/store/reducer.js
+++ b/src/style-library/store/reducer.js
@@ -6,13 +6,57 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { EMPTY_OPTIMISTIC_SWATCH_EDIT, EMPTY_OPTIMISTIC_SCALE_EDIT } from './constants';
+import {
+	EMPTY_OPTIMISTIC_SWATCH_EDIT,
+	EMPTY_OPTIMISTIC_SCALE_EDIT,
+	isLibraryScopedKey,
+	isPresetsKeyForLibrary,
+} from './constants';
+
+/**
+ * Drop every entry of a keyed slice whose key addresses `slug`.
+ *
+ * Returns the original `state` by reference when nothing matched, so forgetting a library that
+ * has no entry in a given slice cannot make `useSelect` see a changed result and re-render every
+ * consumer of that slice for nothing.
+ *
+ * @param {Object}   state   The slice.
+ * @param {string}   slug    Token library slug.
+ * @param {Function} matches `(key, slug) => boolean`, the predicate for this slice's key shape.
+ *
+ * @since TBD
+ *
+ * @return {Object} The slice without the matching entries, or `state` itself when none matched.
+ */
+function omitLibraryEntries(state, slug, matches) {
+	const kept = Object.fromEntries(Object.entries(state).filter(([key]) => !matches(key, slug)));
+
+	return Object.keys(kept).length === Object.keys(state).length ? state : kept;
+}
+
+/**
+ * The predicate for the slices keyed by the slug alone (`optimisticScaleEdits`, `scaleBusy`).
+ *
+ * @param {string} key  The state key.
+ * @param {string} slug Token library slug.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the key addresses that library.
+ */
+function isBareLibraryKey(key, slug) {
+	return key === slug;
+}
 
 function libraries(state = [], action) {
 	return action.type === 'RECEIVE_LIBRARIES' ? action.rows : state;
 }
 
 function presets(state = {}, action) {
+	if (action.type === 'FORGET_LIBRARY') {
+		return omitLibraryEntries(state, action.slug, isPresetsKeyForLibrary);
+	}
+
 	if (action.type !== 'RECEIVE_BLOCK_PRESETS') {
 		return state;
 	}
@@ -21,6 +65,10 @@ function presets(state = {}, action) {
 }
 
 function paletteListings(state = {}, action) {
+	if (action.type === 'FORGET_LIBRARY') {
+		return omitLibraryEntries(state, action.slug, isLibraryScopedKey);
+	}
+
 	if (action.type !== 'RECEIVE_PALETTE_LISTING') {
 		return state;
 	}
@@ -72,6 +120,8 @@ function optimisticSwatchEdits(state = {}, action) {
 				[action.key]: { ...current, [listKey]: current[listKey].filter((entry) => entry[idKey] !== action.id) },
 			};
 		}
+		case 'FORGET_LIBRARY':
+			return omitLibraryEntries(state, action.slug, isLibraryScopedKey);
 		default:
 			return state;
 	}
@@ -116,12 +166,18 @@ function optimisticScaleEdits(state = {}, action) {
 					addedTokens: current.addedTokens.filter((entry) => entry.id !== action.tokenId),
 				},
 			};
+		case 'FORGET_LIBRARY':
+			return omitLibraryEntries(state, action.slug, isBareLibraryKey);
 		default:
 			return state;
 	}
 }
 
 function paletteBusy(state = {}, action) {
+	if (action.type === 'FORGET_LIBRARY') {
+		return omitLibraryEntries(state, action.slug, isLibraryScopedKey);
+	}
+
 	if (action.type !== 'SET_PALETTE_BUSY') {
 		return state;
 	}
@@ -130,6 +186,10 @@ function paletteBusy(state = {}, action) {
 }
 
 function scaleBusy(state = {}, action) {
+	if (action.type === 'FORGET_LIBRARY') {
+		return omitLibraryEntries(state, action.slug, isBareLibraryKey);
+	}
+
 	if (action.type !== 'SET_SCALE_BUSY') {
 		return state;
 	}

--- a/src/style-library/store/reducer.test.js
+++ b/src/style-library/store/reducer.test.js
@@ -17,6 +17,7 @@ import {
 	clearOptimisticScaleDeletion,
 	setPaletteBusy,
 	setScaleBusy,
+	forgetLibrary,
 } from './actions';
 import { EMPTY_OPTIMISTIC_SWATCH_EDIT, EMPTY_OPTIMISTIC_SCALE_EDIT } from './constants';
 
@@ -230,5 +231,75 @@ describe('reducer', () => {
 		state = reducer(state, setScaleBusy('default', false));
 
 		expect(state.scaleBusy).toEqual({ default: false });
+	});
+
+	describe('FORGET_LIBRARY', () => {
+		/**
+		 * Build a state with two libraries' worth of entries in every slug-keyed slice, so each
+		 * assertion can prove the sibling library survived rather than only that the target went.
+		 *
+		 * @return {Object} A populated store state.
+		 */
+		const populated = () => {
+			let state = reducer(
+				undefined,
+				receiveBlockPresets('kb-design-tokens/v1::kadence/singlebtn::default', { a: 1 })
+			);
+			state = reducer(state, receiveBlockPresets('kb-design-tokens/v1::kadence/singlebtn::brand', { b: 2 }));
+			state = reducer(state, receivePaletteListing('kb-design-tokens/v1::default', [{ id: 'p1' }]));
+			state = reducer(state, receivePaletteListing('kb-design-tokens/v1::brand', [{ id: 'p2' }]));
+			state = reducer(
+				state,
+				setOptimisticSwatchPatch('kb-design-tokens/v1::default::p1', 'color.brand', { value: '#000' })
+			);
+			state = reducer(
+				state,
+				setOptimisticSwatchPatch('kb-design-tokens/v1::brand::p2', 'color.brand', { value: '#fff' })
+			);
+			state = reducer(state, setOptimisticScalePatch('default', 'size.md', { value: '1rem' }));
+			state = reducer(state, setOptimisticScalePatch('brand', 'size.md', { value: '2rem' }));
+			state = reducer(state, setPaletteBusy('kb-design-tokens/v1::default', true));
+			state = reducer(state, setPaletteBusy('kb-design-tokens/v1::brand', true));
+			state = reducer(state, setScaleBusy('default', true));
+			state = reducer(state, setScaleBusy('brand', true));
+
+			return state;
+		};
+
+		it('drops every slug-keyed entry for the named library and leaves its siblings intact', () => {
+			const state = reducer(populated(), forgetLibrary('default'));
+
+			expect(state.presets).toEqual({ 'kb-design-tokens/v1::kadence/singlebtn::brand': { b: 2 } });
+			expect(state.paletteListings).toEqual({ 'kb-design-tokens/v1::brand': [{ id: 'p2' }] });
+			expect(Object.keys(state.optimisticSwatchEdits)).toEqual(['kb-design-tokens/v1::brand::p2']);
+			expect(Object.keys(state.optimisticScaleEdits)).toEqual(['brand']);
+			expect(state.paletteBusy).toEqual({ 'kb-design-tokens/v1::brand': true });
+			expect(state.scaleBusy).toEqual({ brand: true });
+		});
+
+		it('leaves the feeds slice alone, because the delete flow overwrites the feed it lands on', () => {
+			const before = reducer(populated(), receiveDesignTokensFeed('default', { slug: 'default' }));
+			const after = reducer(before, forgetLibrary('default'));
+
+			expect(after.feeds).toBe(before.feeds);
+		});
+
+		it('returns the identical slice objects when no key matches, so nothing re-renders', () => {
+			const before = populated();
+			const after = reducer(before, forgetLibrary('nonexistent'));
+
+			expect(after.presets).toBe(before.presets);
+			expect(after.paletteListings).toBe(before.paletteListings);
+			expect(after.optimisticSwatchEdits).toBe(before.optimisticSwatchEdits);
+			expect(after.optimisticScaleEdits).toBe(before.optimisticScaleEdits);
+			expect(after.paletteBusy).toBe(before.paletteBusy);
+			expect(after.scaleBusy).toBe(before.scaleBusy);
+		});
+
+		it('does not mistake a block name for a slug in a presets key', () => {
+			const state = reducer(populated(), forgetLibrary('kadence/singlebtn'));
+
+			expect(Object.keys(state.presets)).toHaveLength(2);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Deleting or resetting a token library leaves the Style Library app holding that library's cached state: nothing in the store ever removes a keyed cache entry, so the palette and preset screens keep serving pre-delete data. This slice adds the store action that drops it. Nothing calls it yet — the wiring lands further up the stack.

`forgetLibrary(slug)` removes every entry addressed to a library across the six slug-keyed slices:

| Slice | Key shape | Slug position |
| --- | --- | --- |
| `presets` | `namespace::block::slug` | segment 2 |
| `paletteListings` | `namespace::slug` | segment 1 |
| `optimisticSwatchEdits` | `namespace::slug::paletteId` | segment 1 |
| `paletteBusy` | `namespace::slug` | segment 1 |
| `optimisticScaleEdits` | `slug` | whole key |
| `scaleBusy` | `slug` | whole key |

Two predicates read the slug back out by segment rather than by prefix or suffix, so a library whose slug is a prefix of another's can't be mistaken for it. The three key builders now join on a shared `KEY_SEPARATOR` so the builders and the predicates can't drift apart; the strings they produce are unchanged.

`state.feeds` is deliberately left alone. The delete flow replaces the feed it lands on moments later, and blanking it first would drop `feed.isReady` to false for a tick, which swaps the whole app for its loading skeleton and unmounts the delete modal mid-request. A dead entry for a removed slug can never be served: `useDesignTokensFeed` only advances its `slug` after a fresh fetch resolves.

`omitLibraryEntries` returns the original slice by reference when nothing matched, so forgetting a library with no entry in a given slice doesn't make `useSelect` see a changed result and re-render its consumers for nothing.

## Test plan

- `npm test -- src/style-library/store/reducer.test.js` — 22 passing, including four new cases: sibling libraries survive, `feeds` is untouched, unmatched slices come back by reference, and a block name is never mistaken for a slug.
- Full JS suite green (116 suites, 1730 tests).

## Stack

1. **This PR** — the store action
2. `library-reset/slice-2-workspace-reset-helper` — the workspace reset helper
3. `library-reset/slice-3-wire-library-flow-resets` — wiring both into the library flows
4. `library-reset/slice-4-guard-library-switch` — prompt before discarding a draft on switch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to clear cached style-library data for a specific library.
  - Related feed data remains available after clearing the library cache.

- **Bug Fixes**
  - Improved cleanup of library-specific palettes, presets, editing states, and loading indicators.
  - Ensured data for other libraries remains unaffected.

- **Tests**
  - Added coverage for cache removal, sibling-library preservation, unchanged feeds, and library-name edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->