### PR TITLE
[DTM] SOFT-4266 [2/6]: resolve a bound shadow token in the editor canvas

### DIFF
--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -176,16 +176,17 @@ describe('shadowCss', () => {
 	});
 
 	/**
-	 * A binding the active library no longer backs falls back to the legs, which still hold the value
-	 * the token had when it was picked — a real value, unlike the per-leg case where the alias replaced
-	 * the number and there is nothing left to fall back to.
+	 * A binding the active library no longer backs renders nothing, so the block falls back to its
+	 * default CSS the same way every other block does when a token is deleted — the stored legs hold
+	 * the value the token had when it was picked, but that value is stale and the renderer no longer
+	 * reads it.
 	 *
 	 * @return {void}
 	 */
-	it('falls back to the stored legs for an unbacked binding', () => {
+	it('returns an empty string for an unbacked binding', () => {
 		window.kadenceDesignTokensPickable = { values: { default: {} } };
 
-		expect(shadowCss(BOUND_ITEM, 14)).toBe('0px 2px 8px 0px #00ff00');
+		expect(shadowCss(BOUND_ITEM, 14)).toBe('');
 	});
 
 	/**
@@ -220,9 +221,14 @@ describe('shadowCss', () => {
 });
 
 describe('hasVisibleShadow with a binding', () => {
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+		delete window.kadenceDesignTokensPickable;
+	});
+
 	/**
-	 * A bound item counts as visible whatever its legs say — the token's own value is unknown to this
-	 * gate, and reading it as invisible would let the base rule's `box-shadow: none` erase it.
+	 * A backed bound item counts as visible whatever its legs say — the token's own value is unknown to
+	 * this gate, and reading it as invisible would let the base rule's `box-shadow: none` erase it.
 	 *
 	 * @return {void}
 	 */
@@ -239,5 +245,29 @@ describe('hasVisibleShadow with a binding', () => {
 				shadowToken: '{semantic.shadow.card}',
 			})
 		).toBe(true);
+	});
+
+	/**
+	 * An unbacked binding is not visible — it takes exactly the path an item with no shadow already
+	 * takes, so the caller's `box-shadow: none` reset fires instead of holding the stale frozen legs.
+	 *
+	 * @return {void}
+	 */
+	it('is false for an unbacked binding', () => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = { values: { default: {} } };
+
+		expect(
+			hasVisibleShadow({
+				color: '#00ff00',
+				opacity: 1,
+				hOffset: 0,
+				vOffset: 2,
+				blur: 8,
+				spread: 0,
+				inset: false,
+				shadowToken: '{semantic.shadow.card}',
+			})
+		).toBe(false);
 	});
 });

--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -10,7 +10,7 @@
 /**
  * Internal dependencies
  */
-import { hasVisibleShadow, shadowAxisPx } from '../index';
+import { hasVisibleShadow, shadowAxisPx, shadowCss } from '../index';
 
 // `backend-styles/index.js` imports the `@kadence/helpers` barrel, which eagerly pulls in a
 // REST-fetch helper that has no `@wordpress/api-fetch` module to resolve under Jest (the same
@@ -20,7 +20,9 @@ import { hasVisibleShadow, shadowAxisPx } from '../index';
 jest.mock('@kadence/helpers', () => ({
 	KadenceBlocksCSS: jest.fn(),
 	getPreviewSize: jest.fn(),
-	KadenceColorOutput: jest.fn(),
+	KadenceColorOutput: jest.fn((color, opacity) =>
+		undefined === opacity || 1 === opacity ? color : `rgba(${color}, ${opacity})`
+	),
 	typographyStyle: jest.fn(),
 	getBorderStyle: jest.fn(),
 	getBorderColor: jest.fn(),
@@ -129,5 +131,113 @@ describe('shadowAxisPx', () => {
 		expect(shadowAxisPx(0, 14)).toBe(0);
 		expect(shadowAxisPx(undefined, 14)).toBe(14);
 		expect(shadowAxisPx(null, 14)).toBe(14);
+	});
+});
+
+/**
+ * A shadow item bound to a backed token, plus the localized pool that backs it.
+ *
+ * @since TBD
+ *
+ * @type {Object}
+ */
+const BOUND_ITEM = {
+	color: '#00ff00',
+	opacity: 1,
+	hOffset: 0,
+	vOffset: 2,
+	blur: 8,
+	spread: 0,
+	inset: false,
+	shadowToken: '{semantic.shadow.card}',
+};
+
+describe('shadowCss', () => {
+	beforeEach(() => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = {
+			values: { default: { 'semantic.shadow.card': '0px 2px 8px 0px rgba(23, 23, 23, 0.12)' } },
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+		delete window.kadenceDesignTokensPickable;
+	});
+
+	/**
+	 * A backed binding resolves to the token's custom property, so editing the token moves the button
+	 * without the post being re-saved.
+	 *
+	 * @return {void}
+	 */
+	it('emits the token var for a backed binding', () => {
+		expect(shadowCss(BOUND_ITEM, 14)).toBe('var(--kb-token--semantic--shadow--card)');
+	});
+
+	/**
+	 * A binding the active library no longer backs falls back to the legs, which still hold the value
+	 * the token had when it was picked — a real value, unlike the per-leg case where the alias replaced
+	 * the number and there is nothing left to fall back to.
+	 *
+	 * @return {void}
+	 */
+	it('falls back to the stored legs for an unbacked binding', () => {
+		window.kadenceDesignTokensPickable = { values: { default: {} } };
+
+		expect(shadowCss(BOUND_ITEM, 14)).toBe('0px 2px 8px 0px #00ff00');
+	});
+
+	/**
+	 * An unbound item renders its legs exactly as the hand-rolled builders did, inset prefix included.
+	 *
+	 * @return {void}
+	 */
+	it('builds the literal shorthand for an unbound item', () => {
+		expect(shadowCss({ ...BOUND_ITEM, shadowToken: undefined, inset: true }, 14)).toBe(
+			'inset 0px 2px 8px 0px #00ff00'
+		);
+	});
+
+	/**
+	 * A missing axis falls back to the caller's own default, which is 14 for blur and 0 elsewhere —
+	 * the historic per-leg defaults this block has always applied.
+	 *
+	 * @return {void}
+	 */
+	it('applies the historic per-leg defaults for missing axes', () => {
+		expect(shadowCss({ color: '#000000', opacity: 1 }, 14)).toBe('0px 0px 14px 0px #000000');
+	});
+
+	/**
+	 * An absent item produces no declaration rather than a shorthand of defaults.
+	 *
+	 * @return {void}
+	 */
+	it('returns an empty string for a missing item', () => {
+		expect(shadowCss(undefined, 14)).toBe('');
+	});
+});
+
+describe('hasVisibleShadow with a binding', () => {
+	/**
+	 * A bound item counts as visible whatever its legs say — the token's own value is unknown to this
+	 * gate, and reading it as invisible would let the base rule's `box-shadow: none` erase it.
+	 *
+	 * @return {void}
+	 */
+	it('counts a bound item with zero legs as visible', () => {
+		expect(
+			hasVisibleShadow({
+				color: 'transparent',
+				opacity: 1,
+				hOffset: 0,
+				vOffset: 0,
+				blur: 0,
+				spread: 0,
+				inset: false,
+				shadowToken: '{semantic.shadow.card}',
+			})
+		).toBe(true);
 	});
 });

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -112,6 +112,12 @@ export function shadowAxisPx(raw, fallback) {
  * render nothing regardless of color, matching the value the "None" pick now writes and mirroring
  * the PHP renderer's `has_visible_shadow()`.
  *
+ * A `shadowToken` binding backed by the active library is visible outright — its real value lives
+ * in the token, which this gate cannot read, so reading it as invisible would let the base rule's
+ * `box-shadow: none` reset erase a shadow the token does paint. A binding the library no longer
+ * backs takes the same path as an item with no shadow at all: the stored legs are the value frozen
+ * at pick time, not the current one, so they are not consulted.
+ *
  * @param {?Object} shadowItem One `shadow[0]`-shaped item.
  *
  * @since TBD
@@ -123,11 +129,10 @@ export function hasVisibleShadow(shadowItem) {
 		return false;
 	}
 
-	// A bound item's real value lives in the token, which this gate cannot read. Counting it as visible
-	// keeps the base rule's `box-shadow: none` reset from erasing a shadow the token does paint —
-	// the same reasoning the per-leg alias branch below uses. Mirrors the PHP gate.
-	if (boundShadowToken(shadowItem)) {
-		return true;
+	const bound = boundShadowToken(shadowItem);
+
+	if (bound) {
+		return isBackedToken(pathOfAlias(bound));
 	}
 
 	return ['hOffset', 'vOffset', 'blur', 'spread'].some((axis) => {
@@ -151,9 +156,11 @@ export function hasVisibleShadow(shadowItem) {
  *
  * A `shadowToken` binding backed by the active library wins outright and the stored legs are never
  * read — that is what keeps the value tracking the token. A binding the library no longer backs (a
- * token deleted after the post was saved) falls back to those legs, which still hold the value the
- * token resolved to when it was picked. That differs on purpose from an unbacked PER-LEG alias, which
- * `shadowAxisPx()` cannot fall back for because the alias replaced the number outright.
+ * token deleted after the post was saved) renders nothing: the block falls back to its default CSS
+ * the same way every other block does when a token disappears, rather than the legs that still hold
+ * the value the token resolved to when it was picked — those legs stay stored for readers that do
+ * not know the binding key and to seed the Custom tab, but the renderer no longer reads them. An
+ * unbound item still builds its literal shorthand from the legs below.
  *
  * @param {?Object} shadowItem   One `shadow[0]`-shaped item.
  * @param {number}  blurFallback What `blur` defaults to when unset — 14 on every current caller,
@@ -162,7 +169,8 @@ export function hasVisibleShadow(shadowItem) {
  *
  * @since TBD
  *
- * @return {string} The `box-shadow` value, or '' when there is no item to render.
+ * @return {string} The `box-shadow` value, or '' when there is no item to render or the item's
+ *                   binding is no longer backed by the active library.
  */
 export function shadowCss(shadowItem, blurFallback) {
 	if (!shadowItem) {
@@ -171,8 +179,8 @@ export function shadowCss(shadowItem, blurFallback) {
 
 	const bound = boundShadowToken(shadowItem);
 
-	if (bound && isBackedToken(pathOfAlias(bound))) {
-		return resolveTokenAlias(bound);
+	if (bound) {
+		return isBackedToken(pathOfAlias(bound)) ? resolveTokenAlias(bound) : '';
 	}
 
 	return (

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -773,40 +773,12 @@ export default function BackendStyles(props) {
 		undefined !== shadowHover?.[0].inset &&
 		false === shadowHover?.[0].inset
 	) {
-		btnBox = `${
-			(undefined !== shadowHover?.[0].inset && shadowHover[0].inset ? 'inset ' : '') +
-			(undefined !== shadowHover?.[0].hOffset ? shadowHover[0].hOffset : 0) +
-			'px ' +
-			(undefined !== shadowHover?.[0].vOffset ? shadowHover[0].vOffset : 0) +
-			'px ' +
-			(undefined !== shadowHover?.[0].blur ? shadowHover[0].blur : 14) +
-			'px ' +
-			(undefined !== shadowHover?.[0].spread ? shadowHover[0].spread : 0) +
-			'px ' +
-			KadenceColorOutput(
-				undefined !== shadowHover?.[0].color ? shadowHover[0].color : '#000000',
-				undefined !== shadowHover?.[0].opacity ? shadowHover[0].opacity : 1
-			)
-		}`;
+		btnBox = shadowCss(shadowHover[0], 14);
 		btnBox2 = 'none';
 		btnRad = '0';
 	}
 	if (hasVisibleShadow(shadowHover?.[0]) && undefined !== shadowHover?.[0].inset && true === shadowHover?.[0].inset) {
-		btnBox2 = `${
-			(undefined !== shadowHover?.[0].inset && shadowHover[0].inset ? 'inset ' : '') +
-			(undefined !== shadowHover?.[0].hOffset ? shadowHover[0].hOffset : 0) +
-			'px ' +
-			(undefined !== shadowHover?.[0].vOffset ? shadowHover[0].vOffset : 0) +
-			'px ' +
-			(undefined !== shadowHover?.[0].blur ? shadowHover[0].blur : 14) +
-			'px ' +
-			(undefined !== shadowHover?.[0].spread ? shadowHover[0].spread : 0) +
-			'px ' +
-			KadenceColorOutput(
-				undefined !== shadowHover?.[0].color ? shadowHover[0].color : '#000000',
-				undefined !== shadowHover?.[0].opacity ? shadowHover[0].opacity : 1
-			)
-		}`;
+		btnBox2 = shadowCss(shadowHover[0], 14);
 		btnRad = undefined !== borderRadius ? borderRadius : '3';
 		btnBox = 'none';
 	}
@@ -824,21 +796,7 @@ export default function BackendStyles(props) {
 		undefined !== shadowTransparentHover?.[0].inset &&
 		false === shadowTransparentHover?.[0].inset
 	) {
-		btnBoxTransparent = `${
-			(undefined !== shadowTransparentHover?.[0].inset && shadowTransparentHover[0].inset ? 'inset ' : '') +
-			(undefined !== shadowTransparentHover?.[0].hOffset ? shadowTransparentHover[0].hOffset : 0) +
-			'px ' +
-			(undefined !== shadowTransparentHover?.[0].vOffset ? shadowTransparentHover[0].vOffset : 0) +
-			'px ' +
-			(undefined !== shadowTransparentHover?.[0].blur ? shadowTransparentHover[0].blur : 14) +
-			'px ' +
-			(undefined !== shadowTransparentHover?.[0].spread ? shadowTransparentHover[0].spread : 0) +
-			'px ' +
-			KadenceColorOutput(
-				undefined !== shadowTransparentHover?.[0].color ? shadowTransparentHover[0].color : '#000000',
-				undefined !== shadowTransparentHover?.[0].opacity ? shadowTransparentHover[0].opacity : 1
-			)
-		}`;
+		btnBoxTransparent = shadowCss(shadowTransparentHover[0], 14);
 		btnBox2Transparent = 'none';
 		btnRadTransparent = '0';
 	}
@@ -847,21 +805,7 @@ export default function BackendStyles(props) {
 		undefined !== shadowTransparentHover?.[0].inset &&
 		true === shadowTransparentHover?.[0].inset
 	) {
-		btnBox2Transparent = `${
-			(undefined !== shadowTransparentHover?.[0].inset && shadowTransparentHover[0].inset ? 'inset ' : '') +
-			(undefined !== shadowTransparentHover?.[0].hOffset ? shadowTransparentHover[0].hOffset : 0) +
-			'px ' +
-			(undefined !== shadowTransparentHover?.[0].vOffset ? shadowTransparentHover[0].vOffset : 0) +
-			'px ' +
-			(undefined !== shadowTransparentHover?.[0].blur ? shadowTransparentHover[0].blur : 14) +
-			'px ' +
-			(undefined !== shadowTransparentHover?.[0].spread ? shadowTransparentHover[0].spread : 0) +
-			'px ' +
-			KadenceColorOutput(
-				undefined !== shadowTransparentHover?.[0].color ? shadowTransparentHover[0].color : '#000000',
-				undefined !== shadowTransparentHover?.[0].opacity ? shadowTransparentHover[0].opacity : 1
-			)
-		}`;
+		btnBox2Transparent = shadowCss(shadowTransparentHover[0], 14);
 		btnRadTransparent = undefined !== borderTransparentRadius ? borderTransparentRadius : '3';
 		btnBoxTransparent = 'none';
 	}
@@ -877,21 +821,7 @@ export default function BackendStyles(props) {
 		undefined !== shadowStickyHover?.[0].inset &&
 		false === shadowStickyHover?.[0].inset
 	) {
-		btnBoxSticky = `${
-			(undefined !== shadowStickyHover?.[0].inset && shadowStickyHover[0].inset ? 'inset ' : '') +
-			(undefined !== shadowStickyHover?.[0].hOffset ? shadowStickyHover[0].hOffset : 0) +
-			'px ' +
-			(undefined !== shadowStickyHover?.[0].vOffset ? shadowStickyHover[0].vOffset : 0) +
-			'px ' +
-			(undefined !== shadowStickyHover?.[0].blur ? shadowStickyHover[0].blur : 14) +
-			'px ' +
-			(undefined !== shadowStickyHover?.[0].spread ? shadowStickyHover[0].spread : 0) +
-			'px ' +
-			KadenceColorOutput(
-				undefined !== shadowStickyHover?.[0].color ? shadowStickyHover[0].color : '#000000',
-				undefined !== shadowStickyHover?.[0].opacity ? shadowStickyHover[0].opacity : 1
-			)
-		}`;
+		btnBoxSticky = shadowCss(shadowStickyHover[0], 14);
 		btnBox2Sticky = 'none';
 		btnRadSticky = '0';
 	}
@@ -900,21 +830,7 @@ export default function BackendStyles(props) {
 		undefined !== shadowStickyHover?.[0].inset &&
 		true === shadowStickyHover?.[0].inset
 	) {
-		btnBox2Sticky = `${
-			(undefined !== shadowStickyHover?.[0].inset && shadowStickyHover[0].inset ? 'inset ' : '') +
-			(undefined !== shadowStickyHover?.[0].hOffset ? shadowStickyHover[0].hOffset : 0) +
-			'px ' +
-			(undefined !== shadowStickyHover?.[0].vOffset ? shadowStickyHover[0].vOffset : 0) +
-			'px ' +
-			(undefined !== shadowStickyHover?.[0].blur ? shadowStickyHover[0].blur : 14) +
-			'px ' +
-			(undefined !== shadowStickyHover?.[0].spread ? shadowStickyHover[0].spread : 0) +
-			'px ' +
-			KadenceColorOutput(
-				undefined !== shadowStickyHover?.[0].color ? shadowStickyHover[0].color : '#000000',
-				undefined !== shadowStickyHover?.[0].opacity ? shadowStickyHover[0].opacity : 1
-			)
-		}`;
+		btnBox2Sticky = shadowCss(shadowStickyHover[0], 14);
 		btnRadSticky = undefined !== borderStickyRadius ? borderStickyRadius : '3';
 		btnBoxSticky = 'none';
 	}
@@ -1058,24 +974,7 @@ export default function BackendStyles(props) {
 	const hasExplicitShadow = hasVisibleShadow(shadow?.[0]);
 
 	if (hasExplicitShadow || !hasPresetShadow) {
-		css.add_property(
-			'box-shadow',
-			hasExplicitShadow
-				? (undefined !== shadow[0].inset && shadow[0].inset ? 'inset ' : '') +
-						shadowAxisPx(shadow[0].hOffset, 0) +
-						'px ' +
-						shadowAxisPx(shadow[0].vOffset, 0) +
-						'px ' +
-						shadowAxisPx(shadow[0].blur, 14) +
-						'px ' +
-						shadowAxisPx(shadow[0].spread, 0) +
-						'px ' +
-						KadenceColorOutput(
-							undefined !== shadow[0].color ? shadow[0].color : '#000000',
-							undefined !== shadow[0].opacity ? shadow[0].opacity : 1
-						)
-				: 'none'
-		);
+		css.add_property('box-shadow', hasExplicitShadow ? shadowCss(shadow[0], 14) : 'none');
 	}
 
 	css.set_selector(`.kb-single-btn-${uniqueID} .kt-button-${uniqueID} .kt-button-text`);
@@ -1192,22 +1091,7 @@ export default function BackendStyles(props) {
 		}
 		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
 		if (hasVisibleShadow(shadowTransparent?.[0])) {
-			css.add_property(
-				'box-shadow',
-				(undefined !== shadowTransparent[0].inset && shadowTransparent[0].inset ? 'inset ' : '') +
-					shadowAxisPx(shadowTransparent[0].hOffset, 0) +
-					'px ' +
-					shadowAxisPx(shadowTransparent[0].vOffset, 0) +
-					'px ' +
-					shadowAxisPx(shadowTransparent[0].blur, 14) +
-					'px ' +
-					shadowAxisPx(shadowTransparent[0].spread, 0) +
-					'px ' +
-					KadenceColorOutput(
-						undefined !== shadowTransparent[0].color ? shadowTransparent[0].color : '#000000',
-						undefined !== shadowTransparent[0].opacity ? shadowTransparent[0].opacity : 1
-					)
-			);
+			css.add_property('box-shadow', shadowCss(shadowTransparent[0], 14));
 		}
 		css.add_property('color', css.render_color(colorTransparent));
 		css.add_property('background', btnbgTransparent);
@@ -1300,22 +1184,7 @@ export default function BackendStyles(props) {
 		}
 		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
 		if (hasVisibleShadow(shadowSticky?.[0])) {
-			css.add_property(
-				'box-shadow',
-				(undefined !== shadowSticky[0].inset && shadowSticky[0].inset ? 'inset ' : '') +
-					shadowAxisPx(shadowSticky[0].hOffset, 0) +
-					'px ' +
-					shadowAxisPx(shadowSticky[0].vOffset, 0) +
-					'px ' +
-					shadowAxisPx(shadowSticky[0].blur, 14) +
-					'px ' +
-					shadowAxisPx(shadowSticky[0].spread, 0) +
-					'px ' +
-					KadenceColorOutput(
-						undefined !== shadowSticky[0].color ? shadowSticky[0].color : '#000000',
-						undefined !== shadowSticky[0].opacity ? shadowSticky[0].opacity : 1
-					)
-			);
+			css.add_property('box-shadow', shadowCss(shadowSticky[0], 14));
 		}
 		css.add_property('color', css.render_color(colorSticky));
 		css.add_property('background', btnbgSticky);

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -9,7 +9,7 @@ import {
 } from '@kadence/helpers';
 import { activePresetFor, blockPresetValues } from '../../../../extension/preset-picker';
 import { tokenPx } from '../../../../extension/design-tokens/token-px';
-import { resolveTokenAlias } from '../../../../extension/design-tokens/alias';
+import { pathOfAlias, resolveTokenAlias } from '../../../../extension/design-tokens/alias';
 import { isBackedToken } from '../../../../extension/design-tokens/backed-tokens';
 import { boundShadowToken } from '../../../../extension/design-tokens/shadow-token';
 
@@ -171,7 +171,7 @@ export function shadowCss(shadowItem, blurFallback) {
 
 	const bound = boundShadowToken(shadowItem);
 
-	if (bound && isBackedToken(bound.slice(1, -1))) {
+	if (bound && isBackedToken(pathOfAlias(bound))) {
 		return resolveTokenAlias(bound);
 	}
 

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -9,6 +9,9 @@ import {
 } from '@kadence/helpers';
 import { activePresetFor, blockPresetValues } from '../../../../extension/preset-picker';
 import { tokenPx } from '../../../../extension/design-tokens/token-px';
+import { resolveTokenAlias } from '../../../../extension/design-tokens/alias';
+import { isBackedToken } from '../../../../extension/design-tokens/backed-tokens';
+import { boundShadowToken } from '../../../../extension/design-tokens/shadow-token';
 
 /**
  * Whether the button's active preset resolves a padding and/or a margin.
@@ -120,6 +123,13 @@ export function hasVisibleShadow(shadowItem) {
 		return false;
 	}
 
+	// A bound item's real value lives in the token, which this gate cannot read. Counting it as visible
+	// keeps the base rule's `box-shadow: none` reset from erasing a shadow the token does paint —
+	// the same reasoning the per-leg alias branch below uses. Mirrors the PHP gate.
+	if (boundShadowToken(shadowItem)) {
+		return true;
+	}
+
 	return ['hOffset', 'vOffset', 'blur', 'spread'].some((axis) => {
 		const raw = shadowItem[axis];
 
@@ -134,6 +144,52 @@ export function hasVisibleShadow(shadowItem) {
 		// `Number(undefined)` is `NaN`, which a bare `!== 0` would read as visible; the PHP gate does not.
 		return Number.isFinite(value) && value !== 0;
 	});
+}
+
+/**
+ * One shadow item as a `box-shadow` declaration value.
+ *
+ * A `shadowToken` binding backed by the active library wins outright and the stored legs are never
+ * read — that is what keeps the value tracking the token. A binding the library no longer backs (a
+ * token deleted after the post was saved) falls back to those legs, which still hold the value the
+ * token resolved to when it was picked. That differs on purpose from an unbacked PER-LEG alias, which
+ * `shadowAxisPx()` cannot fall back for because the alias replaced the number outright.
+ *
+ * @param {?Object} shadowItem   One `shadow[0]`-shaped item.
+ * @param {number}  blurFallback What `blur` defaults to when unset — 14 on every current caller,
+ *                               taken as an argument rather than hard-coded so the historic per-state
+ *                               default stays with the call site that owns it.
+ *
+ * @since TBD
+ *
+ * @return {string} The `box-shadow` value, or '' when there is no item to render.
+ */
+export function shadowCss(shadowItem, blurFallback) {
+	if (!shadowItem) {
+		return '';
+	}
+
+	const bound = boundShadowToken(shadowItem);
+
+	if (bound && isBackedToken(bound.slice(1, -1))) {
+		return resolveTokenAlias(bound);
+	}
+
+	return (
+		(shadowItem.inset ? 'inset ' : '') +
+		shadowAxisPx(shadowItem.hOffset, 0) +
+		'px ' +
+		shadowAxisPx(shadowItem.vOffset, 0) +
+		'px ' +
+		shadowAxisPx(shadowItem.blur, blurFallback) +
+		'px ' +
+		shadowAxisPx(shadowItem.spread, 0) +
+		'px ' +
+		KadenceColorOutput(
+			undefined !== shadowItem.color ? shadowItem.color : '#000000',
+			undefined !== shadowItem.opacity ? shadowItem.opacity : 1
+		)
+	);
 }
 
 export default function BackendStyles(props) {

--- a/src/extension/design-tokens/__tests__/alias.test.js
+++ b/src/extension/design-tokens/__tests__/alias.test.js
@@ -16,7 +16,7 @@
  * languages assert against one source of truth. The primitives live in this plugin (not
  * `@kadence/helpers`) so the shared library carries no design-token knowledge.
  */
-import { isTokenAlias, resolveTokenAlias, TOKEN_VAR_PREFIX } from '../alias';
+import { isTokenAlias, pathOfAlias, resolveTokenAlias, TOKEN_VAR_PREFIX } from '../alias';
 import conformance from './fixtures/token-alias-conformance.json';
 
 describe('isTokenAlias', () => {
@@ -54,5 +54,22 @@ describe('resolveTokenAlias', () => {
 
 	it.each([null, undefined, 5, ['{a.b}']])('passes the non-string %p through unchanged', (value) => {
 		expect(resolveTokenAlias(value)).toBe(value);
+	});
+});
+
+describe('pathOfAlias', () => {
+	it.each(conformance.aliases.map(({ alias }) => [alias, alias.slice(1, -1)]))(
+		'returns %s the dotted path %s',
+		(alias, path) => {
+			expect(pathOfAlias(alias)).toBe(path);
+		}
+	);
+
+	it.each(conformance.nonAliases)('returns an empty string for the non-alias %p', (value) => {
+		expect(pathOfAlias(value)).toBe('');
+	});
+
+	it.each([null, undefined, 5, ['{a.b}']])('returns an empty string for the non-string %p', (value) => {
+		expect(pathOfAlias(value)).toBe('');
 	});
 });

--- a/src/extension/design-tokens/alias.js
+++ b/src/extension/design-tokens/alias.js
@@ -39,6 +39,25 @@ export function isTokenAlias(value) {
 }
 
 /**
+ * The dot-path referenced by an alias string, with the surrounding braces stripped. Mirrors PHP
+ * `Alias::path_of()` exactly, including its contract for a value that is not a well-formed alias.
+ *
+ * @param {*} value A value that may be an alias string, e.g. `{primitive.color.brand.primary}`.
+ *
+ * @since TBD
+ *
+ * @return {string} The inner dot-path, e.g. `primitive.color.brand.primary`. Empty string when the
+ *                   value is not a well-formed alias.
+ */
+export function pathOfAlias(value) {
+	if (!isTokenAlias(value)) {
+		return '';
+	}
+
+	return value.slice(1, -1);
+}
+
+/**
  * Resolve a design-token alias string to its CSS custom-property reference.
  *
  * Mirrors the PHP Resolver primitive (`'var(' . Css_Var::from_id( Alias::path_of( $value ) ) . ')'`)
@@ -54,7 +73,7 @@ export function resolveTokenAlias(value) {
 		return value;
 	}
 
-	const id = value.slice(1, -1).replace(/\./g, '--');
+	const id = pathOfAlias(value).replace(/\./g, '--');
 
 	return 'var(' + TOKEN_VAR_PREFIX + id + ')';
 }

--- a/src/extension/design-tokens/register-filters.js
+++ b/src/extension/design-tokens/register-filters.js
@@ -8,7 +8,7 @@
  * knowledge lives only in this plugin, and the change is strictly additive.
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
-import { isTokenAlias, resolveTokenAlias } from './alias';
+import { isTokenAlias, pathOfAlias, resolveTokenAlias } from './alias';
 import { isBackedToken } from './backed-tokens';
 
 const NAMESPACE = 'kadence-blocks/token-alias';
@@ -31,8 +31,7 @@ function resolveAlias(value) {
 		return value;
 	}
 
-	// Strip the { } braces to the dotted token id (the same slice resolveTokenAlias() does).
-	if (!isBackedToken(value.slice(1, -1))) {
+	if (!isBackedToken(pathOfAlias(value))) {
 		return value;
 	}
 

--- a/src/extension/design-tokens/token-dimension.js
+++ b/src/extension/design-tokens/token-dimension.js
@@ -18,7 +18,7 @@
 /**
  * Internal dependencies
  */
-import { isTokenAlias, resolveTokenAlias } from './alias';
+import { isTokenAlias, pathOfAlias, resolveTokenAlias } from './alias';
 import { isBackedToken } from './backed-tokens';
 
 /**
@@ -40,8 +40,7 @@ export function tokenDimension(value, unit) {
 		return `${value}${unit}`;
 	}
 
-	// Strip the braces to the dotted id, the same slice `resolveTokenAlias()` does.
-	if (!isBackedToken(value.slice(1, -1))) {
+	if (!isBackedToken(pathOfAlias(value))) {
 		return value;
 	}
 

--- a/src/extension/design-tokens/token-literals.js
+++ b/src/extension/design-tokens/token-literals.js
@@ -7,7 +7,7 @@
  * the literal a resolved-values map stores, without going through the server.
  */
 import { get } from 'lodash';
-import { isTokenAlias } from './alias';
+import { isTokenAlias, pathOfAlias } from './alias';
 
 /**
  * The resolved literal map for a token library, or an empty map when the pool is absent.
@@ -41,7 +41,7 @@ export function tokenLiteral(value, library) {
 		return value;
 	}
 
-	const literal = get(libraryLiterals(library), [value.slice(1, -1)], '');
+	const literal = get(libraryLiterals(library), [pathOfAlias(value)], '');
 
 	return literal === '' ? value : literal;
 }


### PR DESCRIPTION
Second slice of the shadow-token binding stack. The slice below it records a picked shadow token on a `shadowToken` key and names it on the control; this one teaches the **editor canvas** to resolve that binding, so the button on the canvas tracks the token instead of a frozen literal.

Based on `SOFT-4266/slice-1-shadow-token-binding-model`.

## What changed

**One `shadowCss()` helper replaces nine hand-rolled shorthand builders.** `backend-styles/index.js` built its `box-shadow` value inline at nine sites — the base, transparent and sticky states, plus an inset/non-inset pair for each of their hover variants. Each was a nine-line string concatenation. They are now one call.

`shadowCss( shadowItem, blurFallback )` returns, in order:

1. `var(--kb-token--<id>)` when the item carries a `shadowToken` binding **backed by the active library** — the stored legs are not read at all, which is what makes the value track the token;
2. `''` when the binding is no longer backed, i.e. the token was deleted after the item was saved. The block then falls back to its own default CSS, matching what every other deleted-token reference already does. The stored legs are deliberately not used: they hold the value the token resolved to at pick time, not the current one. They still earn their place elsewhere — they keep the item a valid literal shadow for readers that do not know the binding key, and they seed the control's Custom tab;
3. otherwise the literal shorthand built from those legs, for an item that carries no binding at all.

**`hasVisibleShadow()` agrees with that rule.** A **backed** binding counts as visible — the gate cannot read a token's value, so reading it as invisible would let the caller's `box-shadow: none` reset erase a shadow the token does paint. An **unbacked** binding counts as invisible, so a stale binding takes exactly the path an item with no shadow already takes. Without that second half a stale binding would still enter the shadow branch and skip the reset, leaving the fallback in the wrong place.

**A pre-existing bug fixed along the way.** The six hover builders did not use `shadowAxisPx()`, so a `{dot.alias}` on a per-leg value emitted invalid CSS like `{semantic.shadow.card}px`. Routing them through `shadowCss()` closes that; it was never reachable from the three base-state builders, which already used the helper.

The binding reader is imported from `extension/design-tokens/shadow-token`, not from `EditorShadowControl` — that module is deliberately dependency-free so this style builder does not pull React, SCSS and the `token-controls` barrel into a module that only builds strings.

## Behavior preserved

`shadowCss()` is byte-identical to each builder it replaces for any item with no binding. Two things it deliberately does **not** do, because their callers own them:

- it never returns `none`. The literal `box-shadow: none` a "None" pick renders comes from the callers' existing `hasExplicitShadow ? … : 'none'` ternary, which is untouched. `shadowCss()` only ever builds a shorthand or a `var()`;
- it does not decide whether to emit at all. The surrounding `if` conditions, including the one that lets a preset's `var(--kb-btn-shadow)` survive, are unchanged.

## Test plan

- `npm test -- src/blocks/singlebtn`
- `shadowCss()` is covered for: a backed binding emitting the token var, an unbacked binding returning nothing, an unbound item building the literal shorthand with its `inset` prefix, the historic per-leg defaults filling missing axes, and a missing item producing no declaration.
- `hasVisibleShadow()` is covered for a backed binding with all-zero legs reading as visible, and an unbacked one reading as invisible.
- Also adds `pathOfAlias()` to `extension/design-tokens/alias.js`, the JS peer of PHP's `Alias::path_of()`, replacing five hand-rolled `slice(1, -1)` copies. It is pinned against the shared `token-alias-conformance.json` fixture so the two peers cannot drift. `color-literal.js` is deliberately left alone — it is guarded only by a truthy check, and `entry.alias` there can be a non-brace value, so the swap would not be equivalent.
- The pre-existing canvas tests are unchanged and still pass, which is what pins the replacement as behavior-preserving — a changed expected string would mean `shadowCss()` is not byte-identical to the builder it replaced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved button shadow rendering for token-based and custom shadows, including inset shadows, transparency, hover states, and sticky styles.
  - Removed deleted or unavailable shadow bindings from rendered output while preserving valid design-token shadows.
  - Added reliable handling for incomplete shadow settings, including missing axes and shadow items.
  - Improved design-token alias recognition and resolution across dimensions, literals, and style settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->