### PR TITLE
[DTM] SOFT-4266 [3/6]: resolve a whole-shadow token binding on the front end

### DIFF
--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Attribute;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Renders_Preset_Classes;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 
 /**
  * Abstract class to register blocks, build CSS, and enqueue scripts.
@@ -734,13 +735,15 @@ class Kadence_Blocks_Abstract_Block {
 	 * @return bool Whether the item paints a visible shadow.
 	 */
 	protected function has_visible_shadow( array $shadow_item ): bool {
-		// A backed bound item's real value lives in the token, unknown here. Counting it as visible keeps
-		// the caller's `box-shadow: none` reset from erasing a shadow the token does paint — the same
-		// reasoning the aliased-leg branch below uses. An unbacked binding renders nothing (see
-		// Kadence_Blocks_CSS::render_shadow()), so it must not count as visible either, or the reset it
-		// should fall through to would be skipped for no shadow at all.
-		if ( Kadence_Blocks_CSS::get_instance()->is_token_reference_backed( $shadow_item[ Kadence_Blocks_CSS::get_shadow_token_key() ] ?? null ) ) {
-			return true;
+		// A bound item's visibility is decided by its binding alone; the stored legs are never consulted
+		// for one. Backed, its real value lives in the token and is unknown here, so it counts as visible
+		// or the caller's `box-shadow: none` reset would erase a shadow the token does paint. Unbacked, it
+		// renders nothing (see Kadence_Blocks_CSS::render_shadow()), so it must count as INVISIBLE and let
+		// the caller fall through to that reset — reading its legs instead would keep a stale binding in
+		// the shadow branch, where the empty render is dropped and the reset never runs.
+		$shadow_token = $shadow_item[ Kadence_Blocks_CSS::get_shadow_token_key() ] ?? null;
+		if ( Alias::is_alias( $shadow_token ) ) {
+			return Kadence_Blocks_CSS::get_instance()->is_token_reference_backed( $shadow_token );
 		}
 
 		foreach ( [ 'hOffset', 'vOffset', 'blur', 'spread' ] as $axis ) {

--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -12,7 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Attribute;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Renders_Preset_Classes;
-use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 
 /**
  * Abstract class to register blocks, build CSS, and enqueue scripts.
@@ -718,8 +717,11 @@ class Kadence_Blocks_Abstract_Block {
 	 *
 	 * A non-numeric, non-empty leg is a {dot.alias} token reference, which resolves to a var() whose
 	 * value is unknown here — it counts as visible, since treating it as a zero would let the
-	 * caller's `box-shadow: none` reset erase a shadow the token does paint. A `shadowToken` binding
-	 * on the item follows the same reasoning for the whole shadow.
+	 * caller's `box-shadow: none` reset erase a shadow the token does paint. A `shadowToken` binding on
+	 * the item follows the same reasoning for the whole shadow, but only while the binding is backed by
+	 * the active library: an unbacked one (a token deleted after the item was saved) no longer paints
+	 * anything the renderer will emit, so it must not block the `box-shadow: none` reset either — it is
+	 * treated as invisible, the same as an item with no binding and no geometry.
 	 *
 	 * Lives here rather than on any one block because it answers a question about the shared shadow
 	 * value shape, which every shadow-carrying block stores identically. It is what a block gates its
@@ -732,10 +734,12 @@ class Kadence_Blocks_Abstract_Block {
 	 * @return bool Whether the item paints a visible shadow.
 	 */
 	protected function has_visible_shadow( array $shadow_item ): bool {
-		// A bound item's real value lives in the token, unknown here. Counting it as visible keeps the
-		// caller's `box-shadow: none` reset from erasing a shadow the token does paint — the same
-		// reasoning the aliased-leg branch below uses.
-		if ( Alias::is_alias( $shadow_item[ Kadence_Blocks_CSS::get_shadow_token_key() ] ?? null ) ) {
+		// A backed bound item's real value lives in the token, unknown here. Counting it as visible keeps
+		// the caller's `box-shadow: none` reset from erasing a shadow the token does paint — the same
+		// reasoning the aliased-leg branch below uses. An unbacked binding renders nothing (see
+		// Kadence_Blocks_CSS::render_shadow()), so it must not count as visible either, or the reset it
+		// should fall through to would be skipped for no shadow at all.
+		if ( Kadence_Blocks_CSS::get_instance()->is_token_reference_backed( $shadow_item[ Kadence_Blocks_CSS::get_shadow_token_key() ] ?? null ) ) {
 			return true;
 		}
 

--- a/includes/blocks/class-kadence-blocks-abstract-block.php
+++ b/includes/blocks/class-kadence-blocks-abstract-block.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette\Renders_Palette_Attribute;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Renders_Preset_Classes;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Alias;
 
 /**
  * Abstract class to register blocks, build CSS, and enqueue scripts.
@@ -717,7 +718,8 @@ class Kadence_Blocks_Abstract_Block {
 	 *
 	 * A non-numeric, non-empty leg is a {dot.alias} token reference, which resolves to a var() whose
 	 * value is unknown here — it counts as visible, since treating it as a zero would let the
-	 * caller's `box-shadow: none` reset erase a shadow the token does paint.
+	 * caller's `box-shadow: none` reset erase a shadow the token does paint. A `shadowToken` binding
+	 * on the item follows the same reasoning for the whole shadow.
 	 *
 	 * Lives here rather than on any one block because it answers a question about the shared shadow
 	 * value shape, which every shadow-carrying block stores identically. It is what a block gates its
@@ -730,6 +732,13 @@ class Kadence_Blocks_Abstract_Block {
 	 * @return bool Whether the item paints a visible shadow.
 	 */
 	protected function has_visible_shadow( array $shadow_item ): bool {
+		// A bound item's real value lives in the token, unknown here. Counting it as visible keeps the
+		// caller's `box-shadow: none` reset from erasing a shadow the token does paint — the same
+		// reasoning the aliased-leg branch below uses.
+		if ( Alias::is_alias( $shadow_item[ Kadence_Blocks_CSS::get_shadow_token_key() ] ?? null ) ) {
+			return true;
+		}
+
 		foreach ( [ 'hOffset', 'vOffset', 'blur', 'spread' ] as $axis ) {
 			$value = $shadow_item[ $axis ] ?? 0;
 

--- a/includes/blocks/class-kadence-blocks-singlebtn-block.php
+++ b/includes/blocks/class-kadence-blocks-singlebtn-block.php
@@ -666,8 +666,9 @@ class Kadence_Blocks_Singlebtn_Block extends Kadence_Blocks_Abstract_Block {
 	 * Route a stored button box-shadow object through the alias-aware render_shadow().
 	 *
 	 * Applies this block's historic per-leg defaults so a literal shadow renders byte-identically
-	 * to the former inline builder, while a {dot.alias} on any numeric leg resolves to its token
-	 * var() instead of freezing to a literal.
+	 * to the former inline builder. A `{dot.alias}` on any numeric leg resolves to its token var()
+	 * instead of freezing to a literal, and a `shadowToken` binding on the item resolves the whole
+	 * shorthand to its token var().
 	 *
 	 * @since TBD
 	 *

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -25,6 +25,18 @@ use KadenceWP\KadenceBlocks\Psr\Log\LoggerInterface;
 class Kadence_Blocks_CSS {
 
 	/**
+	 * The shadow item's optional binding key: the {dot.alias} of the shadow token the value follows.
+	 * Kept alongside the numeric legs rather than replacing them, so an item stays a valid literal
+	 * shadow for readers that do not know this key and has something to fall back to when the bound
+	 * token is no longer in the active library.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const SHADOW_TOKEN_KEY = 'shadowToken';
+
+	/**
 	 * CSS to enqueue
 	 *
 	 * @var array
@@ -253,6 +265,17 @@ class Kadence_Blocks_CSS {
 		'md' => 'var(--global-kb-gap-md, 2rem)',
 		'lg' => 'var(--global-kb-gap-lg, 4rem)',
 	);
+
+	/**
+	 * The shadow item key that carries a whole-shadow token binding.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The binding key.
+	 */
+	public static function get_shadow_token_key(): string {
+		return self::SHADOW_TOKEN_KEY;
+	}
 
 	/**
 	 * Instance Control
@@ -1646,6 +1669,10 @@ class Kadence_Blocks_CSS {
 	/**
 	 * Generates the shadow output.
 	 *
+	 * A `shadowToken` key holding a {dot.alias} binds the WHOLE shadow to a token: when that token is
+	 * backed by the active library the method returns its bare var() and reads no other key. Everything
+	 * else — including an unbacked binding — renders from the numeric legs as before.
+	 *
 	 * @param array                     $shadow   an array of shadow settings.
 	 * @param array<string, string|float> $defaults optional per-caller fallback literals used to fill
 	 *                                            any empty/missing leg before rendering. When omitted
@@ -1662,6 +1689,14 @@ class Kadence_Blocks_CSS {
 		}
 		if ( ! is_array( $shadow ) ) {
 			return false;
+		}
+		// A backed whole-shadow binding replaces the entire shorthand, so the legs below are never read.
+		// An unbacked one (a token deleted after the post was saved) falls through to them instead: unlike
+		// a per-leg alias, which displaced its number and leaves nothing to fall back to, the legs here
+		// still hold the value the token resolved to when it was picked.
+		$shadow_token_reference = $this->get_backed_token_reference( $shadow[ self::SHADOW_TOKEN_KEY ] ?? null );
+		if ( null !== $shadow_token_reference ) {
+			return $shadow_token_reference;
 		}
 		if ( ! isset( $shadow['color'] ) ) {
 			return false;

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1681,7 +1681,7 @@ class Kadence_Blocks_CSS {
 	 * @return string|false
 	 */
 	public function render_shadow( $shadow, array $defaults = [] ) {
-		if ( ! is_array( $shadow ) || empty( $shadow ) ) {
+		if ( ! is_array( $shadow ) ) {
 			return false;
 		}
 
@@ -1696,6 +1696,10 @@ class Kadence_Blocks_CSS {
 
 		if ( ! empty( $defaults ) ) {
 			$shadow = $this->normalize_shadow_defaults( $shadow, $defaults );
+		}
+
+		if ( empty( $shadow ) ) {
+			return false;
 		}
 
 		if ( ! isset( $shadow['color'] ) ) {

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1105,6 +1105,22 @@ class Kadence_Blocks_CSS {
 	}
 
 	/**
+	 * Whether a value is a `{dot.alias}` reference backed by the active library — the same backing check
+	 * {@see self::get_backed_token_reference()} uses to decide whether a renderer emits a var() or falls
+	 * back to a default. Exposed for callers outside this class (e.g. the shadow-visibility gate on
+	 * {@see Kadence_Blocks_Abstract_Block}) that need to reuse the check rather than duplicate it.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The raw attribute value.
+	 *
+	 * @return bool True when the value is an alias reference backed by the active library.
+	 */
+	public function is_token_reference_backed( $value ): bool {
+		return null !== $this->get_backed_token_reference( $value );
+	}
+
+	/**
 	 * Whether a design-token id is backed by the active library — i.e. the Css_Var projector emits a
 	 * `--kb-token--<id>` custom property for it. A binding may reference a stale alias (a token removed
 	 * after it was stored); minting a var() for it would leave a dead custom property with no definition,
@@ -1670,8 +1686,11 @@ class Kadence_Blocks_CSS {
 	 * Generates the shadow output.
 	 *
 	 * A `shadowToken` key holding a {dot.alias} binds the WHOLE shadow to a token: when that token is
-	 * backed by the active library the method returns its bare var() and reads no other key. Everything
-	 * else — including an unbacked binding — renders from the numeric legs as before.
+	 * backed by the active library the method returns its bare var() and reads no other key. When the
+	 * binding is unbacked (the token was deleted after the item was saved), the method returns false
+	 * instead of falling back to the item's stored legs, so the caller's own default CSS takes over —
+	 * matching every other token binding in this class. An item that carries no `shadowToken` at all is
+	 * unaffected and renders from its legs as before.
 	 *
 	 * @param array                     $shadow   an array of shadow settings.
 	 * @param array<string, string|float> $defaults optional per-caller fallback literals used to fill
@@ -1686,12 +1705,19 @@ class Kadence_Blocks_CSS {
 		}
 
 		// A backed whole-shadow binding replaces the entire shorthand, so the legs below are never read.
-		// An unbacked one (a token deleted after the post was saved) falls through to them instead: unlike
-		// a per-leg alias, which displaced its number and leaves nothing to fall back to, the legs here
-		// still hold the value the token resolved to when it was picked.
-		$shadow_token_reference = $this->get_backed_token_reference( $shadow[ self::SHADOW_TOKEN_KEY ] ?? null );
+		$shadow_token           = $shadow[ self::SHADOW_TOKEN_KEY ] ?? null;
+		$shadow_token_reference = $this->get_backed_token_reference( $shadow_token );
 		if ( null !== $shadow_token_reference ) {
 			return $shadow_token_reference;
+		}
+
+		// An unbacked binding (a token deleted after the item was saved) emits nothing rather than
+		// falling back to the legs: they still hold the value the token resolved to when it was picked,
+		// not the current one, so reading them here would render a stale shadow instead of letting the
+		// caller's own default CSS take over. An item with no `shadowToken` at all is not a binding and
+		// falls through to the legs below as always.
+		if ( Alias::is_alias( $shadow_token ) ) {
+			return false;
 		}
 
 		if ( ! empty( $defaults ) ) {

--- a/includes/class-kadence-blocks-css.php
+++ b/includes/class-kadence-blocks-css.php
@@ -1681,15 +1681,10 @@ class Kadence_Blocks_CSS {
 	 * @return string|false
 	 */
 	public function render_shadow( $shadow, array $defaults = [] ) {
-		if ( ! empty( $defaults ) && is_array( $shadow ) ) {
-			$shadow = $this->normalize_shadow_defaults( $shadow, $defaults );
-		}
-		if ( empty( $shadow ) ) {
+		if ( ! is_array( $shadow ) || empty( $shadow ) ) {
 			return false;
 		}
-		if ( ! is_array( $shadow ) ) {
-			return false;
-		}
+
 		// A backed whole-shadow binding replaces the entire shorthand, so the legs below are never read.
 		// An unbacked one (a token deleted after the post was saved) falls through to them instead: unlike
 		// a per-leg alias, which displaced its number and leaves nothing to fall back to, the legs here
@@ -1698,6 +1693,11 @@ class Kadence_Blocks_CSS {
 		if ( null !== $shadow_token_reference ) {
 			return $shadow_token_reference;
 		}
+
+		if ( ! empty( $defaults ) ) {
+			$shadow = $this->normalize_shadow_defaults( $shadow, $defaults );
+		}
+
 		if ( ! isset( $shadow['color'] ) ) {
 			return false;
 		}

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -336,6 +336,20 @@ class SinglebtnTest extends KadenceBlocksUnit {
 			],
 			'expected_visible' => true,
 		];
+
+		yield 'unbacked bound token with zero legs' => [
+			'shadow_item'      => [
+				'shadowToken' => '{semantic.shadow.does-not-exist}',
+				'color'       => 'transparent',
+				'opacity'     => 1,
+				'hOffset'     => 0,
+				'vOffset'     => 0,
+				'blur'        => 0,
+				'spread'      => 0,
+				'inset'       => false,
+			],
+			'expected_visible' => false,
+		];
 	}
 
 	/**
@@ -369,6 +383,42 @@ class SinglebtnTest extends KadenceBlocksUnit {
 		$css_helper = new CSSTestHelper( $output );
 		$selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
 
+		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => 'none' ] );
+	}
+
+	/**
+	 * A whole-shadow binding whose token the active library no longer backs emits no `box-shadow` from
+	 * the binding and reaches the `box-shadow: none` reset, the same as a button with no shadow at all.
+	 * A stale binding must not skip the reset the way a backed one legitimately does.
+	 *
+	 * @return void
+	 */
+	public function testStaleShadowBindingReachesTheNoneFallback(): void {
+		$this->seedPreset( 'bare', 'Bare', [ 'button-bg' => '#ff0000' ] );
+
+		$output = $this->render_button(
+			[
+				'kbPreset'      => 'bare',
+				'displayShadow' => true,
+				'shadow'        => [
+					[
+						'shadowToken' => '{semantic.shadow.does-not-exist}',
+						'color'       => '#0f0',
+						'opacity'     => 1,
+						'hOffset'     => 0,
+						'vOffset'     => 2,
+						'blur'        => 8,
+						'spread'      => 0,
+						'inset'       => false,
+					],
+				],
+			]
+		);
+
+		$css_helper = new CSSTestHelper( $output );
+		$selector   = '.wp-block-kadence-advancedbtn .kb-btn123.kb-button';
+
+		$this->assertStringNotContainsString( 'var(--kb-token--semantic--shadow--does-not-exist)', $output );
 		$css_helper->assertCSSPropertiesEqual( $selector, [ 'box-shadow' => 'none' ] );
 	}
 

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -350,6 +350,24 @@ class SinglebtnTest extends KadenceBlocksUnit {
 			],
 			'expected_visible' => false,
 		];
+
+		// The legs a binding leaves behind are the value it resolved to at pick time, so a stale binding
+		// almost always has non-zero ones. Reading them here would report it visible and keep it in the
+		// shadow branch, where its empty render is dropped and the `none` reset never runs — the all-zero
+		// case above cannot tell that apart, because zero legs report invisible either way.
+		yield 'unbacked bound token with non-zero legs' => [
+			'shadow_item'      => [
+				'shadowToken' => '{semantic.shadow.does-not-exist}',
+				'color'       => '#0f0',
+				'opacity'     => 1,
+				'hOffset'     => 0,
+				'vOffset'     => 2,
+				'blur'        => 8,
+				'spread'      => 0,
+				'inset'       => false,
+			],
+			'expected_visible' => false,
+		];
 	}
 
 	/**

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -225,7 +225,8 @@ class SinglebtnTest extends KadenceBlocksUnit {
 	public function testBoundShadowEmitsTokenVar(): void {
 		$output = $this->render_button(
 			[
-				'shadow' => [
+				'displayShadow' => true,
+				'shadow'        => [
 					[
 						'shadowToken' => '{semantic.shadow.card}',
 						'color'       => '#0f0',

--- a/tests/wpunit/Blocks/SinglebtnTest.php
+++ b/tests/wpunit/Blocks/SinglebtnTest.php
@@ -217,6 +217,33 @@ class SinglebtnTest extends KadenceBlocksUnit {
 	}
 
 	/**
+	 * A button whose shadow is bound to a token emits that token's custom property as its box-shadow,
+	 * so editing the token in the Style Library moves every button that follows it.
+	 *
+	 * @return void
+	 */
+	public function testBoundShadowEmitsTokenVar(): void {
+		$output = $this->render_button(
+			[
+				'shadow' => [
+					[
+						'shadowToken' => '{semantic.shadow.card}',
+						'color'       => '#0f0',
+						'opacity'     => 1,
+						'hOffset'     => 0,
+						'vOffset'     => 2,
+						'blur'        => 8,
+						'spread'      => 0,
+						'inset'       => false,
+					],
+				],
+			]
+		);
+
+		$this->assertStringContainsString( 'box-shadow:var(--kb-token--semantic--shadow--card)', $output );
+	}
+
+	/**
 	 * A shadow item's own axes decide whether `box-shadow` is emitted, with no separate toggle or
 	 * sibling boolean attribute gating it.
 	 *
@@ -291,6 +318,20 @@ class SinglebtnTest extends KadenceBlocksUnit {
 				'blur'    => 0,
 				'spread'  => 0,
 				'color'   => '#000000',
+			],
+			'expected_visible' => true,
+		];
+
+		yield 'bound token with zero legs' => [
+			'shadow_item'      => [
+				'shadowToken' => '{semantic.shadow.card}',
+				'color'       => 'transparent',
+				'opacity'     => 1,
+				'hOffset'     => 0,
+				'vOffset'     => 0,
+				'blur'        => 0,
+				'spread'      => 0,
+				'inset'       => false,
 			],
 			'expected_visible' => true,
 		];

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -169,6 +169,52 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	}
 
 	/**
+	 * A whole-shadow binding renders as the token's bare var(), replacing the entire shorthand rather
+	 * than one leg of it.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowEmitsBareVarForWholeShadowBinding(): void {
+		$this->assertSame(
+			'var(--kb-token--semantic--shadow--card)',
+			$this->css->render_shadow( [
+				'shadowToken' => '{semantic.shadow.card}',
+				'color'       => '#0f0',
+				'opacity'     => 1,
+				'hOffset'     => 0,
+				'vOffset'     => 2,
+				'blur'        => 8,
+				'spread'      => 0,
+				'inset'       => false,
+			] ),
+			'render_shadow must emit the bare var() for a whole-shadow binding'
+		);
+	}
+
+	/**
+	 * A whole-shadow binding the active library no longer backs falls back to the stored legs, which
+	 * still hold the value the token resolved to when it was picked.
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowFallsBackToLegsForUnbackedWholeShadowBinding(): void {
+		$this->assertSame(
+			'0px 2px 8px 0px #0f0',
+			$this->css->render_shadow( [
+				'shadowToken' => '{semantic.shadow.does-not-exist}',
+				'color'       => '#0f0',
+				'opacity'     => 1,
+				'hOffset'     => 0,
+				'vOffset'     => 2,
+				'blur'        => 8,
+				'spread'      => 0,
+				'inset'       => false,
+			] ),
+			'render_shadow must fall back to the stored legs when the bound token is not backed'
+		);
+	}
+
+	/**
 	 * render_typography emits the bare var() reference for an aliased desktop line-height and
 	 * letter-spacing.
 	 *

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -192,14 +192,13 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	}
 
 	/**
-	 * A whole-shadow binding the active library no longer backs falls back to the stored legs, which
-	 * still hold the value the token resolved to when it was picked.
+	 * A whole-shadow binding the active library no longer backs renders nothing, letting the caller's
+	 * own default CSS take over instead of the legs frozen at pick time.
 	 *
 	 * @return void
 	 */
-	public function testRenderShadowFallsBackToLegsForUnbackedWholeShadowBinding(): void {
-		$this->assertSame(
-			'0px 2px 8px 0px #0f0',
+	public function testRenderShadowReturnsFalseForUnbackedWholeShadowBinding(): void {
+		$this->assertFalse(
 			$this->css->render_shadow( [
 				'shadowToken' => '{semantic.shadow.does-not-exist}',
 				'color'       => '#0f0',
@@ -210,7 +209,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 				'spread'      => 0,
 				'inset'       => false,
 			] ),
-			'render_shadow must fall back to the stored legs when the bound token is not backed'
+			'render_shadow must return false when the bound token is not backed'
 		);
 	}
 
@@ -252,16 +251,15 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	}
 
 	/**
-	 * A whole-shadow binding the active library no longer backs still falls back to the normalized
-	 * legs when a non-empty $defaults array is passed.
+	 * A whole-shadow binding the active library no longer backs renders nothing even when a non-empty
+	 * $defaults array is passed.
 	 *
 	 * @since TBD
 	 *
 	 * @return void
 	 */
-	public function testRenderShadowFallsBackToLegsForUnbackedWholeShadowBindingWithDefaults(): void {
-		$this->assertSame(
-			'0px 2px 8px 0px #0f0',
+	public function testRenderShadowReturnsFalseForUnbackedWholeShadowBindingWithDefaults(): void {
+		$this->assertFalse(
 			$this->css->render_shadow(
 				[
 					'shadowToken' => '{semantic.shadow.does-not-exist}',
@@ -282,7 +280,7 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 					'opacity' => 0.2,
 				]
 			),
-			'render_shadow must fall back to the normalized legs when the bound token is not backed, even with $defaults'
+			'render_shadow must return false when the bound token is not backed, even with $defaults'
 		);
 	}
 

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -287,6 +287,34 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	}
 
 	/**
+	 * An empty shadow item with a non-empty $defaults array still renders those defaults as a
+	 * complete shorthand instead of returning false. normalize_shadow_defaults() must run before
+	 * the emptiness check, not after: the two guards must stay separate rather than being
+	 * collapsed into one leading `! is_array( $shadow ) || empty( $shadow )` check.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowRendersDefaultsForEmptyShadowWithDefaults(): void {
+		$this->assertSame(
+			'0px 0px 14px 0px rgba(0, 0, 0, 0.2)',
+			$this->css->render_shadow(
+				[],
+				[
+					'hOffset' => '0',
+					'vOffset' => '0',
+					'blur'    => '14',
+					'spread'  => '0',
+					'color'   => '#000000',
+					'opacity' => 0.2,
+				]
+			),
+			'render_shadow must render the caller defaults as a full shorthand when the shadow item is empty'
+		);
+	}
+
+	/**
 	 * render_typography emits the bare var() reference for an aliased desktop line-height and
 	 * letter-spacing.
 	 *

--- a/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
+++ b/tests/wpunit/KadenceBlocksCssTokenEmissionTest.php
@@ -215,6 +215,78 @@ final class KadenceBlocksCssTokenEmissionTest extends TestCase {
 	}
 
 	/**
+	 * A whole-shadow binding renders as the token's bare var() even when a non-empty $defaults array
+	 * is passed, matching what render_button_shadow() always passes on the singlebtn front end. This
+	 * is the regression case: reading the binding after normalize_shadow_defaults() strips the
+	 * `shadowToken` key made the lookup always miss on that path.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowEmitsBareVarForWholeShadowBindingWithDefaults(): void {
+		$this->assertSame(
+			'var(--kb-token--semantic--shadow--card)',
+			$this->css->render_shadow(
+				[
+					'shadowToken' => '{semantic.shadow.card}',
+					'color'       => '#0f0',
+					'opacity'     => 1,
+					'hOffset'     => 0,
+					'vOffset'     => 2,
+					'blur'        => 8,
+					'spread'      => 0,
+					'inset'       => false,
+				],
+				[
+					'hOffset' => '0',
+					'vOffset' => '0',
+					'blur'    => '14',
+					'spread'  => '0',
+					'color'   => '#000000',
+					'opacity' => 0.2,
+				]
+			),
+			'render_shadow must emit the bare var() for a whole-shadow binding even when $defaults is non-empty'
+		);
+	}
+
+	/**
+	 * A whole-shadow binding the active library no longer backs still falls back to the normalized
+	 * legs when a non-empty $defaults array is passed.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function testRenderShadowFallsBackToLegsForUnbackedWholeShadowBindingWithDefaults(): void {
+		$this->assertSame(
+			'0px 2px 8px 0px #0f0',
+			$this->css->render_shadow(
+				[
+					'shadowToken' => '{semantic.shadow.does-not-exist}',
+					'color'       => '#0f0',
+					'opacity'     => 1,
+					'hOffset'     => 0,
+					'vOffset'     => 2,
+					'blur'        => 8,
+					'spread'      => 0,
+					'inset'       => false,
+				],
+				[
+					'hOffset' => '0',
+					'vOffset' => '0',
+					'blur'    => '14',
+					'spread'  => '0',
+					'color'   => '#000000',
+					'opacity' => 0.2,
+				]
+			),
+			'render_shadow must fall back to the normalized legs when the bound token is not backed, even with $defaults'
+		);
+	}
+
+	/**
 	 * render_typography emits the bare var() reference for an aliased desktop line-height and
 	 * letter-spacing.
 	 *


### PR DESCRIPTION
Third slice of the shadow-token binding stack. The slices below record a picked shadow token on a `shadowToken` key and resolve it in the editor canvas; this one makes the **front end** agree, so the rendered page tracks the token rather than a literal frozen at pick time.

Based on `SOFT-4266/slice-2-editor-canvas-shadow-css`.

## What changed

**`Kadence_Blocks_CSS::render_shadow()` resolves a whole-shadow binding.** A shadow item may carry a `shadowToken` key holding a `{dot.alias}`. When that token is backed by the active library the method returns its bare `var(--kb-token--<id>)` and reads no other key.

When the binding is **unbacked** — the token was deleted after the item was saved — it returns `false`, so the block falls back to its own default CSS. That matches what this method already does for an unbacked per-leg alias, and what every other deleted-token reference does. The stored legs are deliberately not used as a fallback: they hold the value the token resolved to at pick time, not the current one. No call site needs changing, because `add_rule()` guards with `if ( $value && ! empty( $value ) )` and drops the declaration rather than emitting `box-shadow:;`.

The key is exposed through `Kadence_Blocks_CSS::get_shadow_token_key()` over a `private const`, since it is read from another class.

**`has_visible_shadow()` agrees with that rule.** It now lives on `Kadence_Blocks_Abstract_Block`, so the guard lands there and every shadow-carrying block gets it. A **backed** binding counts as visible — the gate cannot read a token's value, and reading it as invisible would let a caller's `box-shadow: none` reset erase a shadow the token does paint. An **unbacked** binding counts as invisible. That second half is load-bearing: left visible, a stale binding would still enter the shadow branch and skip its `elseif ( ! $has_preset_shadow )` reset, putting the fallback in the wrong place.

Backing is established through a new public `Kadence_Blocks_CSS::is_token_reference_backed()`, which wraps the existing private `get_backed_token_reference()` rather than duplicating the check.

## Two ordering details that are load-bearing

**The binding is read before `normalize_shadow_defaults()` runs.** That helper does not filter — it returns a fresh seven-key array (`hOffset`, `vOffset`, `blur`, `spread`, `color`, `opacity`, `inset`), so it silently drops `shadowToken`. Since `render_button_shadow()` always passes a non-empty `$defaults`, reading the binding after normalizing would have made the whole feature dead on every button on the front end while still working in the editor. The lookup therefore sits above the normalize call, on the original array.

**The `empty( $shadow )` guard stays below the normalize call.** Splitting it out to the top looks like a tidy but is not behavior-neutral: `render_shadow( [], $non_empty_defaults )` has always normalized the empty array into a complete default item and rendered it, and the image block reaches that path whenever `boxShadow` is `[[]]`. The guard order is preserved, and a test pins it so the two are not merged back together later.

## Purely additive for the other blocks

`render_shadow()` is shared by nine blocks. The new branch fires only on a `shadowToken` key that no other block writes, and `normalize_shadow_defaults()` / `render_legacy_shadow()` are untouched, so every other caller's output is byte-identical.

## Test plan

- `slic run wpunit KadenceBlocksCssTokenEmissionTest`
- `slic run wpunit Blocks/SinglebtnTest`
- `slic run wpunit KadenceBlocksCssBcSnapshotTest` — the guard that the shared `render_shadow()` still renders every other block's shadows unchanged.
- Covered: a backed binding emitting the bare `var()` both with and without a `$defaults` array (the with-defaults case is the one that exercises the real button path); an unbacked binding returning `false` in both shapes; an empty item with caller defaults still rendering those defaults; a backed binding with all-zero legs counting as visible and an unbacked one not; the end-to-end button render emitting `box-shadow:var(--kb-token--…)`; and a stale binding reaching the `box-shadow: none` fallback.
- The existing "None" test still asserts `box-shadow: none`, unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shadow token handling so active, supported tokens render correctly.
  * Added support for whole-shadow token references.
  * Prevented stale or unresolved token references from producing invalid shadow styles.
  * Preserved visibility for valid zero-offset shadows and applied appropriate fallbacks when bindings are unavailable.

* **Tests**
  * Added coverage for supported, unresolved, and stale shadow token bindings.
  * Verified fallback rendering for empty shadow settings and shadows with defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->