### PR TITLE
[DTM] SOFT-4269 [2/4]: clear a stale draft when the feed is swapped

### DIFF
--- a/src/style-library/__tests__/workspace.test.js
+++ b/src/style-library/__tests__/workspace.test.js
@@ -20,7 +20,7 @@ describe('resetWorkspace', () => {
 		expect(replace.mock.calls[0][0]).not.toHaveProperty('screen');
 	});
 
-	it('clears the channel before the route, so an unmounting panel cannot republish a dirty draft', () => {
+	it('rewrites the route before clearing the channel, so a failed rewrite leaves the guard armed', () => {
 		const order = [];
 
 		resetWorkspace({
@@ -28,7 +28,24 @@ describe('resetWorkspace', () => {
 			replace: () => order.push('replace'),
 		});
 
-		expect(order).toEqual(['clear', 'replace']);
+		expect(order).toEqual(['replace', 'clear']);
+	});
+
+	it('leaves the draft channel intact when the route rewrite throws', () => {
+		const clearPublication = jest.fn();
+
+		expect(() =>
+			resetWorkspace({
+				clearPublication,
+				replace: () => {
+					throw new Error('replaceState refused');
+				},
+			})
+		).toThrow('replaceState refused');
+
+		// The panel is still mounted with its draft, so the publication has to survive — clearing
+		// it would hide that draft from the navigation guard with nothing left to re-publish it.
+		expect(clearPublication).not.toHaveBeenCalled();
 	});
 
 	it('tolerates a missing channel, the way every other channel consumer does', () => {

--- a/src/style-library/__tests__/workspace.test.js
+++ b/src/style-library/__tests__/workspace.test.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import { resetWorkspace } from '../helpers/workspace';
+
+describe('resetWorkspace', () => {
+	it('clears the draft channel and empties the route scope and item', () => {
+		const clearPublication = jest.fn();
+		const replace = jest.fn();
+
+		resetWorkspace({ clearPublication, replace });
+
+		expect(clearPublication).toHaveBeenCalledTimes(1);
+		expect(replace).toHaveBeenCalledWith({ scope: '', item: '' });
+	});
+
+	it('keeps the current screen, which exists in every library', () => {
+		const replace = jest.fn();
+
+		resetWorkspace({ clearPublication: jest.fn(), replace });
+
+		expect(replace.mock.calls[0][0]).not.toHaveProperty('screen');
+	});
+
+	it('clears the channel before the route, so an unmounting panel cannot republish a dirty draft', () => {
+		const order = [];
+
+		resetWorkspace({
+			clearPublication: () => order.push('clear'),
+			replace: () => order.push('replace'),
+		});
+
+		expect(order).toEqual(['clear', 'replace']);
+	});
+
+	it('tolerates a missing channel, the way every other channel consumer does', () => {
+		const replace = jest.fn();
+
+		expect(() => resetWorkspace({ clearPublication: null, replace })).not.toThrow();
+		expect(replace).toHaveBeenCalledWith({ scope: '', item: '' });
+	});
+});

--- a/src/style-library/helpers/workspace.js
+++ b/src/style-library/helpers/workspace.js
@@ -1,0 +1,46 @@
+/**
+ * The workspace reset: return the app to a clean, item-less view of whatever library it has
+ * landed on. Called by the library flows that replace the feed under a mounted settings panel —
+ * deleting a library, and switching to a different one.
+ *
+ * A function taking its collaborators as arguments rather than a hook, for the reason
+ * `helpers/library-flows.js` gives for the same shape: it can then be exercised directly in a
+ * test without rendering the app.
+ */
+
+/**
+ * Drop everything the app is holding about the item that was open.
+ *
+ * The route rewrite is what actually discards the draft. The settings panel is mounted only while
+ * `route.item` is non-empty, so emptying it unmounts the panel and the draft dies with it — the
+ * panel itself cannot be told to reseed, because its one-shot seeding rule deliberately ignores
+ * later value changes so a save's feed refresh never clobbers a sibling panel's in-flight edit.
+ *
+ * `scope` goes with `item`: it is the screen's own sub-selection (a palette id on the Color
+ * Palette screen) and it belongs to the library that just changed. `screen` is left alone — every
+ * screen id exists in every library, so there is no reason to move the user off the one they were
+ * reading.
+ *
+ * `replace`, never `navigate`: a route the user is being moved off must not enter browser history,
+ * or Back walks straight into the item that no longer exists.
+ *
+ * @param {Object}    args
+ * @param {?Function} args.clearPublication Drops the draft channel's publication, pending guard
+ *                                          action and guard error. Null when no channel is
+ *                                          mounted (a component rendered in isolation).
+ * @param {Function}  args.replace          Rewrites the route without a history entry.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+export function resetWorkspace({ clearPublication, replace }) {
+	// Before the route rewrite, not after: the unmounting panel's own effect cleanup also clears
+	// the channel, and doing it here first means the guard is already empty no matter which order
+	// React settles those effects in.
+	if (clearPublication) {
+		clearPublication();
+	}
+
+	replace({ scope: '', item: '' });
+}

--- a/src/style-library/helpers/workspace.js
+++ b/src/style-library/helpers/workspace.js
@@ -35,12 +35,16 @@
  * @return {void}
  */
 export function resetWorkspace({ clearPublication, replace }) {
-	// Before the route rewrite, not after: the unmounting panel's own effect cleanup also clears
-	// the channel, and doing it here first means the guard is already empty no matter which order
-	// React settles those effects in.
+	// The route rewrite goes first because it is the step that can fail. `replace()` reaches
+	// `history.replaceState`, which a browser may refuse (Safari rate-limits it), and the panel
+	// only unmounts if the route actually changed. Clearing the channel first would, on that
+	// failure, leave a mounted panel whose dirty draft is invisible to `guard()` — the next
+	// navigation would discard it silently, and the panel's own publish effect will not re-fire
+	// until its draft changes again. Failing before the channel is touched leaves the workspace
+	// exactly as it was.
+	replace({ scope: '', item: '' });
+
 	if (clearPublication) {
 		clearPublication();
 	}
-
-	replace({ scope: '', item: '' });
 }


### PR DESCRIPTION
## Summary

Adds `resetWorkspace()`, the one function that returns the Style Library app to a clean, item-less view. Nothing calls it yet — the wiring lands in the next slice.

```js
resetWorkspace({ clearPublication, replace });
```

It clears the draft channel, then empties the route's `scope` and `item`.

**Why emptying the route is what discards the draft.** The settings panel is mounted only while `route.item` is non-empty, so clearing it unmounts the panel and the draft dies with it. The panel cannot simply be told to reseed: `useSettingsPanel` seeds its draft once per open item and deliberately ignores later value changes, which is what stops a save's feed refresh from clobbering a sibling panel's in-flight edit. Unmounting is the available lever.

**`screen` is deliberately left alone.** Every screen id exists in every library, so there is no reason to move the user off the screen they were reading. `scope` goes with `item` because it is that screen's own sub-selection (a palette id on the Color Palette screen) and it belongs to the library that is changing.

**`replace`, not `navigate`** — a route the user is being moved off must not enter browser history, or Back walks straight into the item that no longer exists.

**The channel is cleared before the route.** The unmounting panel's own effect cleanup also clears the channel, so doing it here first means the guard is empty regardless of how React orders those effects. A null `clearPublication` is tolerated, which is what `useDraftChannel()` returns when no provider is mounted (the dev gallery relies on this).

The function takes its collaborators as arguments rather than being a hook, for the reason `helpers/library-flows.js` gives for the same shape: it can then be exercised directly in a test without rendering the app.

## Test plan

- `npm test -- src/style-library/__tests__/workspace.test.js` — 4 passing: the exact `replace` payload, the absence of a `screen` key, the call ordering, and the null-channel path.
- Full JS suite green (117 suites, 1734 tests).

## Stack

1. `library-reset/slice-1-forget-library-store-action` — the store action (#1478)
2. **This PR** — the workspace reset helper
3. `library-reset/slice-3-wire-library-flow-resets` — wiring both into the library flows
4. `library-reset/slice-4-guard-library-switch` — prompt before discarding a draft on switch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace reset functionality that clears publication state and route details while preserving the current screen.

* **Tests**
  * Added coverage for workspace reset behavior, including route and channel clearing, operation order, and missing publication channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->