### PR TITLE
[DTM] SOFT-4266 [4/6]: keep the shadow enable flags and canvas in step with a binding

### DIFF
--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -10,7 +10,8 @@
 /**
  * Internal dependencies
  */
-import { hasVisibleShadow, shadowAxisPx, shadowCss } from '../index';
+import { KadenceBlocksCSS } from '@kadence/helpers';
+import BackendStyles, { hasVisibleShadow, shadowAxisPx, shadowCss } from '../index';
 
 // `backend-styles/index.js` imports the `@kadence/helpers` barrel, which eagerly pulls in a
 // REST-fetch helper that has no `@wordpress/api-fetch` module to resolve under Jest (the same
@@ -217,6 +218,131 @@ describe('shadowCss', () => {
 	 */
 	it('returns an empty string for a missing item', () => {
 		expect(shadowCss(undefined, 14)).toBe('');
+	});
+});
+
+/**
+ * Builds a minimal fake `KadenceBlocksCSS` instance that records every selector/property pair the
+ * component adds, so a test can read back the final `box-shadow` value for a given selector without
+ * pulling in the real class or its rendering.
+ *
+ * @since TBD
+ *
+ * @return {{set_selector: Function, add_property: Function, add_raw_styles: Function, render_color:
+ *   Function, render_measure_output: Function, css_output: Function, rules: Array}} The fake CSS
+ *   builder, plus its recorded `rules` for assertions.
+ */
+function createFakeCss() {
+	const rules = [];
+	let current = null;
+
+	return {
+		set_selector: (selector) => {
+			current = { selector, props: {} };
+			rules.push(current);
+		},
+		add_property: (property, value) => {
+			if (!current) {
+				current = { selector: '', props: {} };
+				rules.push(current);
+			}
+			current.props[property] = value;
+		},
+		add_raw_styles: () => {},
+		render_color: (color) => color,
+		render_measure_output: () => {},
+		css_output: () => '',
+		rules,
+	};
+}
+
+/**
+ * Reads back the `box-shadow` value recorded for one selector out of a fake CSS builder's rules.
+ *
+ * @param {Array}  rules    The fake CSS builder's recorded rules.
+ * @param {string} selector The selector to look up.
+ *
+ * @since TBD
+ *
+ * @return {*} The recorded `box-shadow` value, or undefined when none was recorded.
+ */
+function boxShadowFor(rules, selector) {
+	return rules.find((entry) => entry.selector === selector && 'box-shadow' in entry.props)?.props['box-shadow'];
+}
+
+describe('BackendStyles shadow flag gating', () => {
+	const BASE_SELECTOR = '.kb-single-btn-abc123 .kt-button-abc123';
+	const HOVER_SELECTOR = '.kb-single-btn-abc123 .kt-button-abc123:hover';
+	const VISIBLE_SHADOW = { hOffset: 2, vOffset: 2, blur: 4, spread: 0, color: '#000000', opacity: 1, inset: false };
+
+	let fakeCss;
+
+	beforeEach(() => {
+		fakeCss = createFakeCss();
+		KadenceBlocksCSS.mockImplementation(() => fakeCss);
+	});
+
+	afterEach(() => {
+		KadenceBlocksCSS.mockReset();
+	});
+
+	/**
+	 * A lowered `displayShadow` suppresses the base state's box-shadow even though the stored shadow
+	 * itself is visible, matching the PHP renderer's own gate for this state.
+	 *
+	 * @return {void}
+	 */
+	it('emits no box-shadow for the base state when displayShadow is lowered but the shadow is visible', () => {
+		BackendStyles({
+			attributes: { uniqueID: 'abc123', displayShadow: false, shadow: [VISIBLE_SHADOW] },
+			previewDevice: 'Desktop',
+		});
+
+		expect(boxShadowFor(fakeCss.rules, BASE_SELECTOR)).toBe('none');
+	});
+
+	/**
+	 * A raised `displayShadow` still emits the base state's box-shadow for the same visible value.
+	 *
+	 * @return {void}
+	 */
+	it('emits box-shadow for the base state when displayShadow is raised and the shadow is visible', () => {
+		BackendStyles({
+			attributes: { uniqueID: 'abc123', displayShadow: true, shadow: [VISIBLE_SHADOW] },
+			previewDevice: 'Desktop',
+		});
+
+		expect(boxShadowFor(fakeCss.rules, BASE_SELECTOR)).toBe(shadowCss(VISIBLE_SHADOW, 14));
+	});
+
+	/**
+	 * A lowered `displayHoverShadow` suppresses the hover state's box-shadow even though the stored
+	 * shadow itself is visible, matching the PHP renderer's own gate for this state.
+	 *
+	 * @return {void}
+	 */
+	it('emits no box-shadow for the hover state when displayHoverShadow is lowered but the shadow is visible', () => {
+		BackendStyles({
+			attributes: { uniqueID: 'abc123', displayHoverShadow: false, shadowHover: [VISIBLE_SHADOW] },
+			previewDevice: 'Desktop',
+		});
+
+		expect(boxShadowFor(fakeCss.rules, HOVER_SELECTOR)).toBe('');
+	});
+
+	/**
+	 * A raised `displayHoverShadow` still emits the hover state's box-shadow for the same visible
+	 * value.
+	 *
+	 * @return {void}
+	 */
+	it('emits box-shadow for the hover state when displayHoverShadow is raised and the shadow is visible', () => {
+		BackendStyles({
+			attributes: { uniqueID: 'abc123', displayHoverShadow: true, shadowHover: [VISIBLE_SHADOW] },
+			previewDevice: 'Desktop',
+		});
+
+		expect(boxShadowFor(fakeCss.rules, HOVER_SELECTOR)).toBe(shadowCss(VISIBLE_SHADOW, 14));
 	});
 });
 

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -252,6 +252,8 @@ export default function BackendStyles(props) {
 		widthType,
 		shadow,
 		shadowHover,
+		displayShadow,
+		displayHoverShadow,
 		iconColor,
 		iconColorHover,
 		colorTransparent,
@@ -278,6 +280,8 @@ export default function BackendStyles(props) {
 		borderTransparentHoverRadiusUnit,
 		shadowTransparent,
 		shadowTransparentHover,
+		displayShadowTransparent,
+		displayHoverShadowTransparent,
 		colorSticky,
 		colorStickyHover,
 		backgroundSticky,
@@ -302,6 +306,8 @@ export default function BackendStyles(props) {
 		borderStickyHoverRadiusUnit,
 		shadowSticky,
 		shadowStickyHover,
+		displayShadowSticky,
+		displayHoverShadowSticky,
 	} = attributes;
 
 	const css = new KadenceBlocksCSS();
@@ -777,6 +783,7 @@ export default function BackendStyles(props) {
 	let btnBox2 = '';
 	const btnbgHover = 'gradient' === backgroundHoverType ? gradientHover : KadenceColorOutput(backgroundHover);
 	if (
+		displayHoverShadow &&
 		hasVisibleShadow(shadowHover?.[0]) &&
 		undefined !== shadowHover?.[0].inset &&
 		false === shadowHover?.[0].inset
@@ -785,7 +792,12 @@ export default function BackendStyles(props) {
 		btnBox2 = 'none';
 		btnRad = '0';
 	}
-	if (hasVisibleShadow(shadowHover?.[0]) && undefined !== shadowHover?.[0].inset && true === shadowHover?.[0].inset) {
+	if (
+		displayHoverShadow &&
+		hasVisibleShadow(shadowHover?.[0]) &&
+		undefined !== shadowHover?.[0].inset &&
+		true === shadowHover?.[0].inset
+	) {
 		btnBox2 = shadowCss(shadowHover[0], 14);
 		btnRad = undefined !== borderRadius ? borderRadius : '3';
 		btnBox = 'none';
@@ -800,6 +812,7 @@ export default function BackendStyles(props) {
 			? gradientTransparentHover
 			: KadenceColorOutput(backgroundTransparentHover);
 	if (
+		displayHoverShadowTransparent &&
 		hasVisibleShadow(shadowTransparentHover?.[0]) &&
 		undefined !== shadowTransparentHover?.[0].inset &&
 		false === shadowTransparentHover?.[0].inset
@@ -809,6 +822,7 @@ export default function BackendStyles(props) {
 		btnRadTransparent = '0';
 	}
 	if (
+		displayHoverShadowTransparent &&
 		hasVisibleShadow(shadowTransparentHover?.[0]) &&
 		undefined !== shadowTransparentHover?.[0].inset &&
 		true === shadowTransparentHover?.[0].inset
@@ -825,6 +839,7 @@ export default function BackendStyles(props) {
 	const btnbgStickyHover =
 		'gradient' === backgroundStickyHoverType ? gradientStickyHover : KadenceColorOutput(backgroundStickyHover);
 	if (
+		displayHoverShadowSticky &&
 		hasVisibleShadow(shadowStickyHover?.[0]) &&
 		undefined !== shadowStickyHover?.[0].inset &&
 		false === shadowStickyHover?.[0].inset
@@ -834,6 +849,7 @@ export default function BackendStyles(props) {
 		btnRadSticky = '0';
 	}
 	if (
+		displayHoverShadowSticky &&
 		hasVisibleShadow(shadowStickyHover?.[0]) &&
 		undefined !== shadowStickyHover?.[0].inset &&
 		true === shadowStickyHover?.[0].inset
@@ -978,8 +994,9 @@ export default function BackendStyles(props) {
 	}
 
 	// No `color` check: it falls back to '#000000' below, so requiring it would read a colorless but
-	// visible shadow as invisible, disagreeing with the PHP gate.
-	const hasExplicitShadow = hasVisibleShadow(shadow?.[0]);
+	// visible shadow as invisible, disagreeing with the PHP gate. `displayShadow` gates it too, matching
+	// the PHP renderer's `box-shadow` sites so a lowered flag falls through the same as an invisible shadow.
+	const hasExplicitShadow = displayShadow && hasVisibleShadow(shadow?.[0]);
 
 	if (hasExplicitShadow || !hasPresetShadow) {
 		css.add_property('box-shadow', hasExplicitShadow ? shadowCss(shadow[0], 14) : 'none');
@@ -1098,7 +1115,7 @@ export default function BackendStyles(props) {
 			);
 		}
 		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
-		if (hasVisibleShadow(shadowTransparent?.[0])) {
+		if (displayShadowTransparent && hasVisibleShadow(shadowTransparent?.[0])) {
 			css.add_property('box-shadow', shadowCss(shadowTransparent[0], 14));
 		}
 		css.add_property('color', css.render_color(colorTransparent));
@@ -1191,7 +1208,7 @@ export default function BackendStyles(props) {
 			);
 		}
 		// No `none` fallback: this selector outranks the base rule, which must carry through instead.
-		if (hasVisibleShadow(shadowSticky?.[0])) {
+		if (displayShadowSticky && hasVisibleShadow(shadowSticky?.[0])) {
 			css.add_property('box-shadow', shadowCss(shadowSticky[0], 14));
 		}
 		css.add_property('color', css.render_color(colorSticky));

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -344,6 +344,13 @@ export function hasVisibleShadow(item) {
 		return false;
 	}
 
+	// A bound item's real value lives in the token, unknown to this gate. Counting it as visible keeps
+	// the derived enable flag from being lowered under a shadow the token does paint — the same
+	// reasoning the other two copies of this predicate already apply.
+	if (boundShadowToken(item)) {
+		return true;
+	}
+
 	return ['hOffset', 'vOffset', 'blur', 'spread'].some((axis) => {
 		const value = item[axis] ?? 0;
 

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -48,7 +48,8 @@
  */
 import { BoxShadowControl, DEFAULT_COMPOSITE, findTokenEntry, parseResolvedShadow } from '../../../token-controls';
 import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
-import { isTokenAlias } from '../alias';
+import { isTokenAlias, pathOfAlias } from '../alias';
+import { isBackedToken } from '../backed-tokens';
 import { SHADOW_TOKEN_KEY, boundShadowToken } from '../shadow-token';
 
 /**
@@ -344,11 +345,15 @@ export function hasVisibleShadow(item) {
 		return false;
 	}
 
-	// A bound item's real value lives in the token, unknown to this gate. Counting it as visible keeps
-	// the derived enable flag from being lowered under a shadow the token does paint — the same
-	// reasoning the other two copies of this predicate already apply.
-	if (boundShadowToken(item)) {
-		return true;
+	// A bound item is decided by its binding alone, never by its stored legs — the same rule the
+	// renderers' two copies of this predicate apply. Backed, its real value lives in the token and is
+	// unknown here, so it counts as visible and the derived enable flag stays raised under a shadow the
+	// token does paint. Unbacked, the renderers paint nothing, so raising the flag would leave the
+	// inspector claiming a shadow the page does not show.
+	const bound = boundShadowToken(item);
+
+	if (bound) {
+		return isBackedToken(pathOfAlias(bound));
 	}
 
 	return ['hOffset', 'vOffset', 'blur', 'spread'].some((axis) => {

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -684,3 +684,57 @@ describe('hasVisibleShadow', () => {
 		expect(hasVisibleShadow(item)).toBe(expected);
 	});
 });
+
+describe('hasVisibleShadow with a token binding', () => {
+	// `isBackedToken()` reads the localized pool and fails OPEN when there is none, so without these
+	// stubs every alias would read as backed and the unbacked case below could not be expressed.
+	beforeEach(() => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = {
+			values: { default: { 'semantic.shadow.card': '0px 2px 8px 0px #1717171f' } },
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+		delete window.kadenceDesignTokensPickable;
+	});
+
+	/**
+	 * A backed binding is visible whatever its legs say — its real value lives in the token, which this
+	 * gate cannot read, so the derived enable flag must stay raised under a shadow the token paints.
+	 *
+	 * @return {void}
+	 */
+	it('reads a backed binding as visible even with all-zero legs', () => {
+		expect(
+			hasVisibleShadow({
+				hOffset: 0,
+				vOffset: 0,
+				blur: 0,
+				spread: 0,
+				[SHADOW_TOKEN_KEY]: '{semantic.shadow.card}',
+			})
+		).toBe(true);
+	});
+
+	/**
+	 * An unbacked binding is invisible whatever its legs say. The legs are the value the token resolved
+	 * to at pick time and both renderers now ignore them, so raising the flag would leave the inspector
+	 * claiming a shadow the page does not paint. Non-zero legs on purpose: a stale binding almost always
+	 * has them, and zero legs read invisible either way, so they cannot tell this rule apart.
+	 *
+	 * @return {void}
+	 */
+	it('reads an unbacked binding as invisible even with non-zero legs', () => {
+		expect(
+			hasVisibleShadow({
+				hOffset: 0,
+				vOffset: 2,
+				blur: 8,
+				spread: 0,
+				[SHADOW_TOKEN_KEY]: '{semantic.shadow.deleted}',
+			})
+		).toBe(false);
+	});
+});

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -675,6 +675,11 @@ describe('hasVisibleShadow', () => {
 		['a spread only', { hOffset: 0, vOffset: 0, blur: 0, spread: 3 }, true],
 		['a token alias leg', { hOffset: 0, vOffset: '{semantic.shadow.media}', blur: 0, spread: 0 }, true],
 		['an empty-string leg', { hOffset: '', vOffset: '', blur: '', spread: '' }, false],
+		[
+			'a bound item with all-zero legs',
+			{ hOffset: 0, vOffset: 0, blur: 0, spread: 0, [SHADOW_TOKEN_KEY]: '{semantic.shadow.media}' },
+			true,
+		],
 	])('reads %s correctly', (_label, item, expected) => {
 		expect(hasVisibleShadow(item)).toBe(expected);
 	});


### PR DESCRIPTION
Fourth slice of the shadow-token binding stack. Two changes that put the block's silent shadow enable flags and the editor canvas in step with the binding the slices below introduced.

Based on `SOFT-4266/slice-3-front-end-token-binding`.

## Why a bound token could fail to render

Each of the six shadow states has a silent `display*Shadow*` boolean, and the inspector derives it on every write as `hasVisibleShadow(value?.[0])`.

There are three copies of that "does this item paint anything?" predicate — one in the editor-canvas style builder, one on `Kadence_Blocks_Abstract_Block`, and one in `EditorShadowControl`, which is the copy the inspector uses. The slices below this one made the first two understand a `shadowToken` binding. The third still inspected only `hOffset`/`vOffset`/`blur`/`spread`.

So picking a shadow token whose resolved value happens to be all-zero lowered the flag, and the binding never rendered. That is not hypothetical — `semantic.shadow.media` and `semantic.shadow.button` both resolve to `0px 0px 0px 0px` with a transparent color in `baseline.json`.

`EditorShadowControl`'s `hasVisibleShadow()` now treats a bound item as visible before it looks at any leg, using the same `boundShadowToken()` reader and the same reasoning as the other two copies: the item's real value lives in the token and is unknown to the gate, so counting it as invisible would suppress a shadow the token does paint.

## The editor canvas now honors the flag

The front end gates each of its six `box-shadow` sites on that state's flag. The editor-canvas builder did not read the flags at all, so a button whose flag is lowered but whose stored shadow is visible rendered nothing on the site while still painting on the canvas.

Every canvas site now requires its own state's flag, paired against the PHP renderer state by state:

| state | flag |
|---|---|
| `shadow` | `displayShadow` |
| `shadowHover` | `displayHoverShadow` |
| `shadowTransparent` | `displayShadowTransparent` |
| `shadowTransparentHover` | `displayHoverShadowTransparent` |
| `shadowSticky` | `displayShadowSticky` |
| `shadowStickyHover` | `displayHoverShadowSticky` |

Nothing downstream of the gate changed. `shadowCss()`, the `hasExplicitShadow ? … : 'none'` ternary, the `if (hasExplicitShadow || !hasPresetShadow)` condition that lets a preset's `var(--kb-btn-shadow)` survive, and every `btnRad*` assignment are untouched — a lowered flag falls through to exactly where an invisible shadow already fell through.

`edit.js` needed no change: it already derives the flags through the helper this slice corrected.

## Test plan

- `npm test -- src/blocks/singlebtn src/extension/design-tokens`
- `hasVisibleShadow()` is covered for a bound item with all-zero legs reading as visible, with the unbound cases unchanged.
- The canvas is covered for a lowered flag emitting no shadow from a visible stored value, and a raised flag still emitting it, on the base state and a hover state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button shadow styling so hidden base, hover, transparent, and sticky shadows no longer appear unexpectedly.
  * Preserved shadow styling across states when a visible shadow is configured.
  * Shadow styles linked to design tokens now remain visible even when their numeric offsets are zero.
  * Deleted shadow tokens no longer produce unintended styling.

* **Tests**
  * Added coverage for independent shadow visibility, token-bound shadows, and shadow value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->