### PR TITLE
[DTM] SOFT-4269 [3/4]: reset the workspace when a library is deleted or switched

### DIFF
--- a/src/style-library/__tests__/library-flows.test.js
+++ b/src/style-library/__tests__/library-flows.test.js
@@ -608,6 +608,35 @@ describe('deleteLibraryFlow', () => {
 		expect(order).toEqual(['forget:default', 'reset', 'refresh:default']);
 	});
 
+	it('does not report the delete as failed when forgetLibrary or resetWorkspace throws', async () => {
+		client.deleteLibrary.mockResolvedValue({ deleted: true });
+		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
+		const onError = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand-b',
+				activeSlug: 'default',
+				refreshFeed,
+				loadLibraries: jest.fn().mockResolvedValue(undefined),
+				forgetLibrary: jest.fn(() => {
+					throw new Error('forgetLibrary boom');
+				}),
+				resetWorkspace: jest.fn(() => {
+					throw new Error('resetWorkspace boom');
+				}),
+				onBusy: jest.fn(),
+				onError,
+				onActiveChanged: jest.fn(),
+			})
+		).resolves.toBeUndefined();
+
+		// The delete already succeeded by the time either callback ran, so neither throwing may
+		// surface as a failure — the app still lands on the feed it is supposed to.
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(onError).not.toHaveBeenCalled();
+	});
+
 	it('forgets the library that was deleted, not the one the app lands on', async () => {
 		const forgetLibrary = jest.fn();
 

--- a/src/style-library/__tests__/library-flows.test.js
+++ b/src/style-library/__tests__/library-flows.test.js
@@ -373,6 +373,7 @@ describe('deleteLibraryFlow', () => {
 			refreshFeed,
 			loadLibraries,
 			forgetLibrary: jest.fn(),
+			revalidateLibraryCaches: jest.fn(),
 			resetWorkspace: jest.fn(),
 			onBusy,
 			onError: jest.fn(),
@@ -409,6 +410,7 @@ describe('deleteLibraryFlow', () => {
 			refreshFeed,
 			loadLibraries: jest.fn().mockResolvedValue(undefined),
 			forgetLibrary: jest.fn(),
+			revalidateLibraryCaches: jest.fn(),
 			resetWorkspace: jest.fn(),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -434,6 +436,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
 				forgetLibrary: jest.fn(),
+				revalidateLibraryCaches: jest.fn(),
 				resetWorkspace: jest.fn(),
 				onBusy,
 				onError,
@@ -460,6 +463,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
 				forgetLibrary: jest.fn(),
+				revalidateLibraryCaches: jest.fn(),
 				resetWorkspace: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -490,6 +494,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
 				forgetLibrary: jest.fn(),
+				revalidateLibraryCaches: jest.fn(),
 				resetWorkspace: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -512,6 +517,7 @@ describe('deleteLibraryFlow', () => {
 			refreshFeed,
 			loadLibraries,
 			forgetLibrary: jest.fn(),
+			revalidateLibraryCaches: jest.fn(),
 			resetWorkspace: jest.fn(),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -543,6 +549,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed,
 				loadLibraries,
 				forgetLibrary: jest.fn(),
+				revalidateLibraryCaches: jest.fn(),
 				resetWorkspace: jest.fn(),
 				onBusy,
 				onError,
@@ -571,6 +578,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
 				forgetLibrary: jest.fn(),
+				revalidateLibraryCaches: jest.fn(),
 				resetWorkspace: jest.fn(),
 				onBusy,
 				onError,
@@ -582,7 +590,7 @@ describe('deleteLibraryFlow', () => {
 		expect(onBusy).toHaveBeenLastCalledWith(false);
 	});
 
-	it('forgets the deleted library and resets the workspace before reading the feed it lands on', async () => {
+	it('forgets the deleted library, resets the workspace, reads the feed it lands on, then re-arms the caches', async () => {
 		const order = [];
 		const forgetLibrary = jest.fn((slug) => order.push(`forget:${slug}`));
 		const resetWorkspace = jest.fn(() => order.push('reset'));
@@ -590,6 +598,7 @@ describe('deleteLibraryFlow', () => {
 			order.push(`refresh:${slug}`);
 			return Promise.resolve();
 		});
+		const revalidateLibraryCaches = jest.fn(() => order.push('revalidate'));
 
 		client.deleteLibrary.mockResolvedValue({ deleted: false });
 
@@ -599,13 +608,14 @@ describe('deleteLibraryFlow', () => {
 			refreshFeed,
 			loadLibraries: jest.fn(() => Promise.resolve()),
 			forgetLibrary,
+			revalidateLibraryCaches,
 			resetWorkspace,
 			onBusy: jest.fn(),
 			onError: jest.fn(),
 			onActiveChanged: jest.fn(),
 		});
 
-		expect(order).toEqual(['forget:default', 'reset', 'refresh:default']);
+		expect(order).toEqual(['forget:default', 'reset', 'refresh:default', 'revalidate']);
 	});
 
 	it('does not report the delete as failed when forgetLibrary or resetWorkspace throws', async () => {
@@ -622,6 +632,7 @@ describe('deleteLibraryFlow', () => {
 				forgetLibrary: jest.fn(() => {
 					throw new Error('forgetLibrary boom');
 				}),
+				revalidateLibraryCaches: jest.fn(),
 				resetWorkspace: jest.fn(() => {
 					throw new Error('resetWorkspace boom');
 				}),
@@ -634,6 +645,35 @@ describe('deleteLibraryFlow', () => {
 		// The delete already succeeded by the time either callback ran, so neither throwing may
 		// surface as a failure — the app still lands on the feed it is supposed to.
 		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	it('does not report the delete as failed when revalidateLibraryCaches throws', async () => {
+		client.deleteLibrary.mockResolvedValue({ deleted: true });
+		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
+		const loadLibraries = jest.fn().mockResolvedValue(undefined);
+		const onError = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand-b',
+				activeSlug: 'default',
+				refreshFeed,
+				loadLibraries,
+				forgetLibrary: jest.fn(),
+				revalidateLibraryCaches: jest.fn(() => {
+					throw new Error('revalidateLibraryCaches boom');
+				}),
+				resetWorkspace: jest.fn(),
+				onBusy: jest.fn(),
+				onError,
+				onActiveChanged: jest.fn(),
+			})
+		).resolves.toBeUndefined();
+
+		// The delete and the feed swap have both already landed by the time this runs, so its
+		// failure must not be reported as a failed delete — the list refresh still runs after it.
+		expect(loadLibraries).toHaveBeenCalled();
 		expect(onError).not.toHaveBeenCalled();
 	});
 
@@ -650,6 +690,7 @@ describe('deleteLibraryFlow', () => {
 				forgetLibrary: jest.fn(() => {
 					throw new Error('forgetLibrary boom');
 				}),
+				revalidateLibraryCaches: jest.fn(),
 				resetWorkspace,
 				onBusy: jest.fn(),
 				onError: jest.fn(),
@@ -673,6 +714,7 @@ describe('deleteLibraryFlow', () => {
 			refreshFeed: jest.fn(() => Promise.resolve()),
 			loadLibraries: jest.fn(() => Promise.resolve()),
 			forgetLibrary,
+			revalidateLibraryCaches: jest.fn(),
 			resetWorkspace: jest.fn(),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
@@ -686,6 +728,7 @@ describe('deleteLibraryFlow', () => {
 	it('resets nothing when the delete request itself fails', async () => {
 		const forgetLibrary = jest.fn();
 		const resetWorkspace = jest.fn();
+		const revalidateLibraryCaches = jest.fn();
 
 		client.deleteLibrary.mockRejectedValue(new Error('Nope'));
 
@@ -696,6 +739,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed: jest.fn(() => Promise.resolve()),
 				loadLibraries: jest.fn(() => Promise.resolve()),
 				forgetLibrary,
+				revalidateLibraryCaches,
 				resetWorkspace,
 				onBusy: jest.fn(),
 				onError: jest.fn(),
@@ -705,10 +749,12 @@ describe('deleteLibraryFlow', () => {
 
 		expect(forgetLibrary).not.toHaveBeenCalled();
 		expect(resetWorkspace).not.toHaveBeenCalled();
+		expect(revalidateLibraryCaches).not.toHaveBeenCalled();
 	});
 
 	it('resets before a missing successor can even be requested', async () => {
 		const resetWorkspace = jest.fn();
+		const revalidateLibraryCaches = jest.fn();
 
 		await expect(
 			deleteLibraryFlow({
@@ -718,6 +764,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
 				forgetLibrary: jest.fn(),
+				revalidateLibraryCaches,
 				resetWorkspace,
 				onBusy: jest.fn(),
 				onError: jest.fn(),
@@ -726,6 +773,7 @@ describe('deleteLibraryFlow', () => {
 		).rejects.toThrow();
 
 		expect(resetWorkspace).not.toHaveBeenCalled();
+		expect(revalidateLibraryCaches).not.toHaveBeenCalled();
 		expect(client.deleteLibrary).not.toHaveBeenCalled();
 	});
 });

--- a/src/style-library/__tests__/library-flows.test.js
+++ b/src/style-library/__tests__/library-flows.test.js
@@ -618,6 +618,49 @@ describe('deleteLibraryFlow', () => {
 		expect(order).toEqual(['forget:default', 'reset', 'refresh:default', 'revalidate']);
 	});
 
+	it('waits for the feed read to settle before re-arming the caches', async () => {
+		client.deleteLibrary.mockResolvedValue({ deleted: true });
+
+		let resolveFeed;
+		const refreshFeed = jest.fn(
+			() =>
+				new Promise((resolve) => {
+					resolveFeed = resolve;
+				})
+		);
+		const revalidateLibraryCaches = jest.fn();
+
+		const settled = deleteLibraryFlow({
+			slug: 'brand-b',
+			activeSlug: 'default',
+			refreshFeed,
+			loadLibraries: jest.fn().mockResolvedValue(undefined),
+			forgetLibrary: jest.fn(),
+			resetWorkspace: jest.fn(),
+			revalidateLibraryCaches,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+			onActiveChanged: jest.fn(),
+		});
+
+		// Let every already-resolved link in the chain run. The feed read is still outstanding, so
+		// the re-arm must not have happened yet — a version that fired it alongside the call rather
+		// than after the read would already have run here.
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(refreshFeed).toHaveBeenCalledWith('default');
+		expect(revalidateLibraryCaches).not.toHaveBeenCalled();
+
+		resolveFeed({ slug: 'default' });
+		await settled;
+
+		expect(revalidateLibraryCaches).toHaveBeenCalledTimes(1);
+	});
+
 	it('does not report the delete as failed when forgetLibrary or resetWorkspace throws', async () => {
 		client.deleteLibrary.mockResolvedValue({ deleted: true });
 		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
@@ -653,6 +696,9 @@ describe('deleteLibraryFlow', () => {
 		const refreshFeed = jest.fn().mockResolvedValue({ slug: 'default' });
 		const loadLibraries = jest.fn().mockResolvedValue(undefined);
 		const onError = jest.fn();
+		const revalidateLibraryCaches = jest.fn(() => {
+			throw new Error('revalidateLibraryCaches boom');
+		});
 
 		await expect(
 			deleteLibraryFlow({
@@ -661,9 +707,7 @@ describe('deleteLibraryFlow', () => {
 				refreshFeed,
 				loadLibraries,
 				forgetLibrary: jest.fn(),
-				revalidateLibraryCaches: jest.fn(() => {
-					throw new Error('revalidateLibraryCaches boom');
-				}),
+				revalidateLibraryCaches,
 				resetWorkspace: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
@@ -675,6 +719,7 @@ describe('deleteLibraryFlow', () => {
 		// failure must not be reported as a failed delete — the list refresh still runs after it.
 		expect(loadLibraries).toHaveBeenCalled();
 		expect(onError).not.toHaveBeenCalled();
+		expect(revalidateLibraryCaches).toHaveBeenCalledTimes(1);
 	});
 
 	it('still resets the workspace when forgetting the cached state throws first', async () => {

--- a/src/style-library/__tests__/library-flows.test.js
+++ b/src/style-library/__tests__/library-flows.test.js
@@ -44,7 +44,7 @@ describe('openLibraryFlow', () => {
 		const onBusy = jest.fn();
 		const onError = jest.fn();
 
-		await openLibraryFlow({ slug: 'brand-b', refreshFeed, onBusy, onError });
+		await openLibraryFlow({ slug: 'brand-b', refreshFeed, resetWorkspace: jest.fn(), onBusy, onError });
 
 		expect(refreshFeed).toHaveBeenCalledWith('brand-b');
 		expect(client.setActiveLibrary).not.toHaveBeenCalled();
@@ -59,10 +59,31 @@ describe('openLibraryFlow', () => {
 		const onBusy = jest.fn();
 		const onError = jest.fn();
 
-		await expect(openLibraryFlow({ slug: 'ghost', refreshFeed, onBusy, onError })).rejects.toBe(failure);
+		await expect(
+			openLibraryFlow({ slug: 'ghost', refreshFeed, resetWorkspace: jest.fn(), onBusy, onError })
+		).rejects.toBe(failure);
 
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy.mock.calls).toEqual([[true], [false]]);
+	});
+
+	it('resets the workspace before reading the new library, so no panel renders across the swap', async () => {
+		const order = [];
+		const resetWorkspace = jest.fn(() => order.push('reset'));
+		const refreshFeed = jest.fn(() => {
+			order.push('refresh');
+			return Promise.resolve();
+		});
+
+		await openLibraryFlow({
+			slug: 'brand',
+			refreshFeed,
+			resetWorkspace,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+		});
+
+		expect(order).toEqual(['reset', 'refresh']);
 	});
 });
 
@@ -351,6 +372,8 @@ describe('deleteLibraryFlow', () => {
 			activeSlug: 'default',
 			refreshFeed,
 			loadLibraries,
+			forgetLibrary: jest.fn(),
+			resetWorkspace: jest.fn(),
 			onBusy,
 			onError: jest.fn(),
 			onActiveChanged: jest.fn(),
@@ -385,6 +408,8 @@ describe('deleteLibraryFlow', () => {
 			successorSlug: 'brand-c',
 			refreshFeed,
 			loadLibraries: jest.fn().mockResolvedValue(undefined),
+			forgetLibrary: jest.fn(),
+			resetWorkspace: jest.fn(),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
 			onActiveChanged,
@@ -408,6 +433,8 @@ describe('deleteLibraryFlow', () => {
 				activeSlug: 'brand-b',
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
+				forgetLibrary: jest.fn(),
+				resetWorkspace: jest.fn(),
 				onBusy,
 				onError,
 				onActiveChanged: jest.fn(),
@@ -432,6 +459,8 @@ describe('deleteLibraryFlow', () => {
 				successorSlug: 'ghost',
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
+				forgetLibrary: jest.fn(),
+				resetWorkspace: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
 				onActiveChanged: jest.fn(),
@@ -460,6 +489,8 @@ describe('deleteLibraryFlow', () => {
 				successorSlug: 'brand-c',
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
+				forgetLibrary: jest.fn(),
+				resetWorkspace: jest.fn(),
 				onBusy: jest.fn(),
 				onError,
 				onActiveChanged,
@@ -480,6 +511,8 @@ describe('deleteLibraryFlow', () => {
 			activeSlug: 'default',
 			refreshFeed,
 			loadLibraries,
+			forgetLibrary: jest.fn(),
+			resetWorkspace: jest.fn(),
 			onBusy: jest.fn(),
 			onError: jest.fn(),
 			onActiveChanged: jest.fn(),
@@ -509,6 +542,8 @@ describe('deleteLibraryFlow', () => {
 				activeSlug: 'default',
 				refreshFeed,
 				loadLibraries,
+				forgetLibrary: jest.fn(),
+				resetWorkspace: jest.fn(),
 				onBusy,
 				onError,
 				onActiveChanged: jest.fn(),
@@ -535,6 +570,8 @@ describe('deleteLibraryFlow', () => {
 				activeSlug: 'default',
 				refreshFeed: jest.fn(),
 				loadLibraries: jest.fn(),
+				forgetLibrary: jest.fn(),
+				resetWorkspace: jest.fn(),
 				onBusy,
 				onError,
 				onActiveChanged: jest.fn(),
@@ -543,5 +580,98 @@ describe('deleteLibraryFlow', () => {
 
 		expect(onError).toHaveBeenCalledWith({ message: failure.message });
 		expect(onBusy).toHaveBeenLastCalledWith(false);
+	});
+
+	it('forgets the deleted library and resets the workspace before reading the feed it lands on', async () => {
+		const order = [];
+		const forgetLibrary = jest.fn((slug) => order.push(`forget:${slug}`));
+		const resetWorkspace = jest.fn(() => order.push('reset'));
+		const refreshFeed = jest.fn((slug) => {
+			order.push(`refresh:${slug}`);
+			return Promise.resolve();
+		});
+
+		client.deleteLibrary.mockResolvedValue({ deleted: false });
+
+		await deleteLibraryFlow({
+			slug: 'default',
+			activeSlug: 'default',
+			refreshFeed,
+			loadLibraries: jest.fn(() => Promise.resolve()),
+			forgetLibrary,
+			resetWorkspace,
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+			onActiveChanged: jest.fn(),
+		});
+
+		expect(order).toEqual(['forget:default', 'reset', 'refresh:default']);
+	});
+
+	it('forgets the library that was deleted, not the one the app lands on', async () => {
+		const forgetLibrary = jest.fn();
+
+		client.deleteLibrary.mockResolvedValue({ deleted: true });
+
+		await deleteLibraryFlow({
+			slug: 'retired',
+			activeSlug: 'default',
+			refreshFeed: jest.fn(() => Promise.resolve()),
+			loadLibraries: jest.fn(() => Promise.resolve()),
+			forgetLibrary,
+			resetWorkspace: jest.fn(),
+			onBusy: jest.fn(),
+			onError: jest.fn(),
+			onActiveChanged: jest.fn(),
+		});
+
+		expect(forgetLibrary).toHaveBeenCalledWith('retired');
+		expect(forgetLibrary).toHaveBeenCalledTimes(1);
+	});
+
+	it('resets nothing when the delete request itself fails', async () => {
+		const forgetLibrary = jest.fn();
+		const resetWorkspace = jest.fn();
+
+		client.deleteLibrary.mockRejectedValue(new Error('Nope'));
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'default',
+				activeSlug: 'default',
+				refreshFeed: jest.fn(() => Promise.resolve()),
+				loadLibraries: jest.fn(() => Promise.resolve()),
+				forgetLibrary,
+				resetWorkspace,
+				onBusy: jest.fn(),
+				onError: jest.fn(),
+				onActiveChanged: jest.fn(),
+			})
+		).rejects.toThrow('Nope');
+
+		expect(forgetLibrary).not.toHaveBeenCalled();
+		expect(resetWorkspace).not.toHaveBeenCalled();
+	});
+
+	it('resets before a missing successor can even be requested', async () => {
+		const resetWorkspace = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand',
+				activeSlug: 'brand',
+				successorSlug: '',
+				refreshFeed: jest.fn(),
+				loadLibraries: jest.fn(),
+				forgetLibrary: jest.fn(),
+				resetWorkspace,
+				onBusy: jest.fn(),
+				onError: jest.fn(),
+				onActiveChanged: jest.fn(),
+			})
+		).rejects.toThrow();
+
+		expect(resetWorkspace).not.toHaveBeenCalled();
+		expect(client.deleteLibrary).not.toHaveBeenCalled();
 	});
 });

--- a/src/style-library/__tests__/library-flows.test.js
+++ b/src/style-library/__tests__/library-flows.test.js
@@ -637,6 +637,31 @@ describe('deleteLibraryFlow', () => {
 		expect(onError).not.toHaveBeenCalled();
 	});
 
+	it('still resets the workspace when forgetting the cached state throws first', async () => {
+		client.deleteLibrary.mockResolvedValue({ deleted: true });
+		const resetWorkspace = jest.fn();
+
+		await expect(
+			deleteLibraryFlow({
+				slug: 'brand-b',
+				activeSlug: 'default',
+				refreshFeed: jest.fn().mockResolvedValue({ slug: 'default' }),
+				loadLibraries: jest.fn().mockResolvedValue(undefined),
+				forgetLibrary: jest.fn(() => {
+					throw new Error('forgetLibrary boom');
+				}),
+				resetWorkspace,
+				onBusy: jest.fn(),
+				onError: jest.fn(),
+				onActiveChanged: jest.fn(),
+			})
+		).resolves.toBeUndefined();
+
+		// The reset is what stops the deleted library's draft from claiming unsaved changes, so a
+		// failure in the cache cleanup that runs before it must not take it down too.
+		expect(resetWorkspace).toHaveBeenCalledTimes(1);
+	});
+
 	it('forgets the library that was deleted, not the one the app lands on', async () => {
 		const forgetLibrary = jest.fn();
 

--- a/src/style-library/__tests__/use-libraries.test.js
+++ b/src/style-library/__tests__/use-libraries.test.js
@@ -3,8 +3,9 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RegistryProvider } from '@wordpress/data';
 import { useLibraries } from '../hooks/use-libraries';
-import { fetchLibraries } from '../api/client';
+import { fetchLibraries, deleteLibrary, setActiveLibrary } from '../api/client';
 import { createTestRegistry } from '../store/test-utils';
+import { paletteListingKey, presetsKey } from '../store/constants';
 
 jest.mock('../api/client', () => ({
 	fetchLibraries: jest.fn(),
@@ -16,6 +17,8 @@ jest.mock('../api/client', () => ({
 
 const ROW_A = { slug: 'default', title: '', version: 'v1', document: {} };
 const ROW_B = { slug: 'brand', title: 'Brand', version: 'v1', document: {} };
+const NAMESPACE = 'kb-design-tokens/v1';
+const STORE = 'kadence-blocks/style-library';
 
 describe('useLibraries', () => {
 	let container;
@@ -111,17 +114,17 @@ describe('useLibraries', () => {
 	function mountProbe() {
 		let latest = null;
 
-		function Probe({ feed, refreshFeed }) {
-			latest = useLibraries(feed, refreshFeed);
+		function Probe({ feed, refreshFeed, resetWorkspace }) {
+			latest = useLibraries(feed, refreshFeed, resetWorkspace);
 			return null;
 		}
 
 		return {
-			render: async (feed, refreshFeed) => {
+			render: async (feed, refreshFeed, resetWorkspace = jest.fn()) => {
 				await act(() =>
 					root.render(
 						<RegistryProvider value={registry}>
-							<Probe feed={feed} refreshFeed={refreshFeed} />
+							<Probe feed={feed} refreshFeed={refreshFeed} resetWorkspace={resetWorkspace} />
 						</RegistryProvider>
 					)
 				);
@@ -230,5 +233,50 @@ describe('useLibraries', () => {
 		await act(() => settleWithTimers(registry.resolveSelect('kadence-blocks/style-library').getLibraries()));
 
 		expect(probe.latest().libraries).toHaveLength(2);
+	});
+
+	it('forgets the deleted library, so its cached presets and palettes stop being served', async () => {
+		fetchLibraries.mockResolvedValue([ROW_A, ROW_B]);
+		setActiveLibrary.mockResolvedValue({ slug: 'default' });
+		deleteLibrary.mockResolvedValue({ deleted: true });
+
+		const store = registry.dispatch(STORE);
+		store.receiveBlockPresets(presetsKey(NAMESPACE, 'kadence/singlebtn', 'brand'), { hero: {} });
+		store.receivePaletteListing(paletteListingKey(NAMESPACE, 'brand'), [{ id: 'p1' }]);
+
+		const probe = mountProbe();
+		await probe.render(
+			{ slug: 'brand' },
+			jest.fn(() => Promise.resolve())
+		);
+
+		await act(() => settleWithTimers(probe.latest().deleteLibrary('brand', 'default')));
+
+		const select = registry.select(STORE);
+
+		expect(select.getBlockPresets(NAMESPACE, 'kadence/singlebtn', 'brand')).toBeNull();
+		expect(select.getPaletteListing(NAMESPACE, 'brand').palettes).toEqual([]);
+	});
+
+	it('hands the workspace reset it was given to both the open and the delete flow', async () => {
+		fetchLibraries.mockResolvedValue([ROW_A, ROW_B]);
+		setActiveLibrary.mockResolvedValue({ slug: 'default' });
+		deleteLibrary.mockResolvedValue({ deleted: true });
+
+		const resetWorkspace = jest.fn();
+		const probe = mountProbe();
+		await probe.render(
+			{ slug: 'default' },
+			jest.fn(() => Promise.resolve()),
+			resetWorkspace
+		);
+
+		await act(() => settleWithTimers(probe.latest().openLibrary('brand')));
+		expect(resetWorkspace).toHaveBeenCalledTimes(1);
+
+		// `activeSlug` is still `default` here, so this deletes a library the site is not using and
+		// needs no successor — the branch that exercises the delete path with the fewest moving parts.
+		await act(() => settleWithTimers(probe.latest().deleteLibrary('brand')));
+		expect(resetWorkspace).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/style-library/__tests__/use-palettes.test.js
+++ b/src/style-library/__tests__/use-palettes.test.js
@@ -220,6 +220,23 @@ describe('usePalettes', () => {
 		expect(probe.latest().openError).toEqual({ message: 'Something broke' });
 	});
 
+	it('clears a stale listing error once the library it came from is no longer the one showing', async () => {
+		client.fetchPalettes.mockRejectedValueOnce(new Error('Something broke'));
+
+		const probe = mountProbe();
+		await probe.render();
+
+		expect(probe.latest().openError).toEqual({ message: 'Something broke' });
+
+		// Re-rendering the same probe with a different slug is the library swap: `ColorPaletteScreen`
+		// stays the same element in the same position, so this reconciles the mounted hook instead of
+		// remounting it — the same path a real library switch takes.
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		await probe.render({ feed: { ...FEED, slug: 'brand-b' } });
+
+		expect(probe.latest().openError).toBeNull();
+	});
+
 	it('activatePalette dispatches the write response via onReceive, moving activeId and palette together', async () => {
 		client.fetchPalettes.mockResolvedValueOnce(listingRows());
 		client.setCurrentPalette.mockResolvedValueOnce(listingRows({ currentId: SUNSET_ID }));

--- a/src/style-library/__tests__/workspace.test.js
+++ b/src/style-library/__tests__/workspace.test.js
@@ -1,5 +1,8 @@
 /* eslint-env jest */
 import { resetWorkspace } from '../helpers/workspace';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useDraftChannelState } from '../hooks/use-draft-channel';
 
 describe('resetWorkspace', () => {
 	it('clears the draft channel and empties the route scope and item', () => {
@@ -53,5 +56,62 @@ describe('resetWorkspace', () => {
 
 		expect(() => resetWorkspace({ clearPublication: null, replace })).not.toThrow();
 		expect(replace).toHaveBeenCalledWith({ scope: '', item: '' });
+	});
+});
+
+describe('resetWorkspace against the live draft channel', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	});
+
+	/**
+	 * Mount the real draft channel and expose its latest value, so the guard can be exercised
+	 * against the actual hook rather than a stand-in.
+	 *
+	 * @return {Function} Reads the channel value from the most recent render.
+	 */
+	function mountChannel() {
+		let latest = null;
+
+		function Probe() {
+			latest = useDraftChannelState();
+			return null;
+		}
+
+		act(() => root.render(<Probe />));
+
+		return () => latest;
+	}
+
+	it('lets a guarded navigation run immediately after a dirty draft is cleared', () => {
+		const channel = mountChannel();
+		const navigation = jest.fn();
+
+		act(() => channel().publish({ itemId: 'size.md', label: 'Medium', draft: { value: '2rem' }, isDirty: true }));
+		act(() => channel().guard(navigation));
+
+		// The reported symptom: a dirty draft parks the navigation behind the modal.
+		expect(channel().isGuardOpen).toBe(true);
+		expect(navigation).not.toHaveBeenCalled();
+
+		act(() => resetWorkspace({ clearPublication: channel().clearPublication, replace: jest.fn() }));
+
+		expect(channel().isGuardOpen).toBe(false);
+
+		act(() => channel().guard(navigation));
+
+		expect(navigation).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/style-library/__tests__/workspace.test.js
+++ b/src/style-library/__tests__/workspace.test.js
@@ -80,6 +80,8 @@ describe('resetWorkspace against the live draft channel', () => {
 	 * Mount the real draft channel and expose its latest value, so the guard can be exercised
 	 * against the actual hook rather than a stand-in.
 	 *
+	 * @since TBD
+	 *
 	 * @return {Function} Reads the channel value from the most recent render.
 	 */
 	function mountChannel() {

--- a/src/style-library/app/StyleLibraryApp.js
+++ b/src/style-library/app/StyleLibraryApp.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { SnackbarList } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -43,6 +43,7 @@ import { BreakpointProvider } from '../../token-controls/context/breakpoint';
 import { DEFAULT_SCREEN_ID } from '../constants/screens';
 import { buildBaseStylesNav, buildBlockPresetsNav, resolveScreen } from '../helpers/screens';
 import { libraryDisplayTitle } from '../helpers/libraries';
+import { resetWorkspace } from '../helpers/workspace';
 
 /**
  * The Base Styles ids with a real screen component, extended by each subsequent per-screen
@@ -76,7 +77,20 @@ const SCREEN_COMPONENTS = {
 export function StyleLibraryApp() {
 	const feed = useDesignTokensFeed();
 	const { route, navigate, replace } = useStyleLibraryRoute();
-	const libraries = useLibraries(feed.feed, feed.refreshFeed);
+
+	// The draft channel (see `hooks/use-draft-channel.js`): built here because this is the one
+	// component that already renders both the screen and its settings-panel slot, so it is the only
+	// place a provider for the two of them can live. Built before `useLibraries` below because the
+	// library flows need to clear it when they replace the feed under an open panel.
+	const channel = useDraftChannelState();
+
+	// Pulled out of `channel` rather than depending on `channel` itself: `useDraftChannelState()`
+	// returns a fresh object literal on every render, while `clearPublication` is individually
+	// stable — the same reasoning `ScaleSettings.js` documents for its own publish effect.
+	const clearPublication = channel.clearPublication;
+	const libraryReset = useCallback(() => resetWorkspace({ clearPublication, replace }), [clearPublication, replace]);
+
+	const libraries = useLibraries(feed.feed, feed.refreshFeed, libraryReset);
 
 	const snackbarNotices = useSelect(
 		(select) =>
@@ -86,11 +100,6 @@ export function StyleLibraryApp() {
 		[]
 	);
 	const { removeNotice } = useDispatch('core/notices');
-
-	// The draft channel (see `hooks/use-draft-channel.js`): built here because this is the one
-	// component that already renders both the screen and its settings-panel slot, so it is the only
-	// place a provider for the two of them can live.
-	const channel = useDraftChannelState();
 
 	const baseStylesNav = useMemo(() => buildBaseStylesNav(), []);
 	const blockPresetsNav = useMemo(() => buildBlockPresetsNav(feed.feed), [feed.feed]);

--- a/src/style-library/helpers/library-flows.js
+++ b/src/style-library/helpers/library-flows.js
@@ -48,18 +48,25 @@ export function errorMessage(error) {
  * until someone explicitly activates a different one through `activateLibraryFlow`.
  *
  * @param {Object}   args
- * @param {string}   args.slug        The token library slug to open for editing.
- * @param {Function} args.refreshFeed Replaces the feed with a fresh REST read for a slug.
- * @param {Function} args.onBusy      Called with a boolean as the request starts and settles.
- * @param {Function} args.onError     Called with `{ message }` on failure.
+ * @param {string}   args.slug           The token library slug to open for editing.
+ * @param {Function} args.refreshFeed    Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.resetWorkspace Clears the draft channel and the open route item, so the
+ *                                       library being left behind cannot strand a draft.
+ * @param {Function} args.onBusy         Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError        Called with `{ message }` on failure.
  *
  * @since TBD
  *
  * @return {Promise<void>} Resolves once the feed refresh completes; rejects on failure, after
  *                          `onError`/`onBusy` have already run.
  */
-export function openLibraryFlow({ slug, refreshFeed, onBusy, onError }) {
+export function openLibraryFlow({ slug, refreshFeed, resetWorkspace, onBusy, onError }) {
 	onBusy(true);
+
+	// Before the read, not after: the open panel's draft belongs to the library being left, and
+	// the panel cannot reseed itself when the values change underneath it. Unmounting it first is
+	// what stops it reporting unsaved changes about a draft with nowhere left to go.
+	resetWorkspace();
 
 	return refreshFeed(slug)
 		.then(() => onBusy(false))
@@ -243,6 +250,8 @@ export function renameLibraryFlow({ slug, title, libraries, loadLibraries, onBus
  *                                        active non-default library.
  * @param {Function} args.refreshFeed     Replaces the feed with a fresh REST read for a slug.
  * @param {Function} args.loadLibraries   Refreshes the libraries list.
+ * @param {Function} args.forgetLibrary   Drops every cached entry addressed to a library slug.
+ * @param {Function} args.resetWorkspace  Clears the draft channel and the open route item.
  * @param {Function} args.onBusy          Called with a boolean as the request starts and settles.
  * @param {Function} args.onError         Called with `{ message }` on failure.
  * @param {Function} args.onActiveChanged Called with the slug that ends up active, when it moves.
@@ -258,6 +267,8 @@ export function deleteLibraryFlow({
 	successorSlug,
 	refreshFeed,
 	loadLibraries,
+	forgetLibrary,
+	resetWorkspace,
 	onBusy,
 	onError,
 	onActiveChanged,
@@ -293,6 +304,14 @@ export function deleteLibraryFlow({
 
 	return activation
 		.then(() => deleteLibrary(slug))
+		.then(() => {
+			// Both run only once the delete has actually landed, and both run before the feed is
+			// re-read. Resetting earlier would throw away an open draft for a request that might
+			// still fail; resetting later would let a screen render the fresh feed while still
+			// holding the deleted library's cached presets, palettes and pending overlays.
+			forgetLibrary(slug);
+			resetWorkspace();
+		})
 		.then(() => refreshFeed(nextSlug))
 		.then(() =>
 			// A failed refetch here must not undo a delete that already succeeded — by this point

--- a/src/style-library/helpers/library-flows.js
+++ b/src/style-library/helpers/library-flows.js
@@ -63,12 +63,18 @@ export function errorMessage(error) {
 export function openLibraryFlow({ slug, refreshFeed, resetWorkspace, onBusy, onError }) {
 	onBusy(true);
 
-	// Before the read, not after: the open panel's draft belongs to the library being left, and
-	// the panel cannot reseed itself when the values change underneath it. Unmounting it first is
-	// what stops it reporting unsaved changes about a draft with nowhere left to go.
-	resetWorkspace();
+	return Promise.resolve()
+		.then(() => {
+			// Before the read, not after: the open panel's draft belongs to the library being left,
+			// and the panel cannot reseed itself when the values change underneath it. Unmounting it
+			// first is what stops it reporting unsaved changes about a draft with nowhere left to go.
+			// Running it inside the chain (rather than before it starts) keeps a throw here inside
+			// this flow's own `.catch()`, instead of escaping synchronously and leaving `onBusy(false)`
+			// never called.
+			resetWorkspace();
 
-	return refreshFeed(slug)
+			return refreshFeed(slug);
+		})
 		.then(() => onBusy(false))
 		.catch((err) => {
 			onError({ message: errorMessage(err) });
@@ -309,8 +315,17 @@ export function deleteLibraryFlow({
 			// re-read. Resetting earlier would throw away an open draft for a request that might
 			// still fail; resetting later would let a screen render the fresh feed while still
 			// holding the deleted library's cached presets, palettes and pending overlays.
-			forgetLibrary(slug);
-			resetWorkspace();
+			//
+			// Wrapped in its own try/catch, not folded into the flow's outer `.catch()`, for the same
+			// reason the `loadLibraries()` step below swallows its own failure: by this point
+			// `deleteLibrary(slug)` has already resolved, so a throw from either callback (e.g.
+			// `resetWorkspace()`'s `history.replaceState`) must not be reported as a failed delete.
+			try {
+				forgetLibrary(slug);
+				resetWorkspace();
+			} catch {
+				// Intentionally swallowed — see above.
+			}
 		})
 		.then(() => refreshFeed(nextSlug))
 		.then(() =>

--- a/src/style-library/helpers/library-flows.js
+++ b/src/style-library/helpers/library-flows.js
@@ -250,17 +250,19 @@ export function renameLibraryFlow({ slug, title, libraries, loadLibraries, onBus
  * so it remains and stays active, and there is no successor to name.
  *
  * @param {Object}   args
- * @param {string}   args.slug            The token library slug to delete or reset.
- * @param {string}   args.activeSlug      The slug the site currently renders with.
- * @param {string}   [args.successorSlug] The library to activate first, required when deleting the
- *                                        active non-default library.
- * @param {Function} args.refreshFeed     Replaces the feed with a fresh REST read for a slug.
- * @param {Function} args.loadLibraries   Refreshes the libraries list.
- * @param {Function} args.forgetLibrary   Drops every cached entry addressed to a library slug.
- * @param {Function} args.resetWorkspace  Clears the draft channel and the open route item.
- * @param {Function} args.onBusy          Called with a boolean as the request starts and settles.
- * @param {Function} args.onError         Called with `{ message }` on failure.
- * @param {Function} args.onActiveChanged Called with the slug that ends up active, when it moves.
+ * @param {string}   args.slug                    The token library slug to delete or reset.
+ * @param {string}   args.activeSlug              The slug the site currently renders with.
+ * @param {string}   [args.successorSlug]         The library to activate first, required when
+ *                                                deleting the active non-default library.
+ * @param {Function} args.refreshFeed             Replaces the feed with a fresh REST read for a slug.
+ * @param {Function} args.loadLibraries           Refreshes the libraries list.
+ * @param {Function} args.forgetLibrary           Drops every cached entry addressed to a library slug.
+ * @param {Function} args.revalidateLibraryCaches Re-arms the resolvers `forgetLibrary` left empty,
+ *                                                once the feed has moved off the deleted library.
+ * @param {Function} args.resetWorkspace          Clears the draft channel and the open route item.
+ * @param {Function} args.onBusy                  Called with a boolean as the request starts and settles.
+ * @param {Function} args.onError                 Called with `{ message }` on failure.
+ * @param {Function} args.onActiveChanged         Called with the slug that ends up active, when it moves.
  *
  * @since TBD
  *
@@ -274,6 +276,7 @@ export function deleteLibraryFlow({
 	refreshFeed,
 	loadLibraries,
 	forgetLibrary,
+	revalidateLibraryCaches,
 	resetWorkspace,
 	onBusy,
 	onError,
@@ -336,6 +339,16 @@ export function deleteLibraryFlow({
 			}
 		})
 		.then(() => refreshFeed(nextSlug))
+		.then(() => {
+			// After the feed swap, never before: re-arming these resolvers while the app still
+			// points at the deleted library re-fetches a slug the server no longer has, and the
+			// failure surfaces as a stale error notice on the library the user lands on.
+			try {
+				revalidateLibraryCaches();
+			} catch {
+				// Intentionally swallowed — see above.
+			}
+		})
 		.then(() =>
 			// A failed refetch here must not undo a delete that already succeeded — by this point
 			// `deleteLibrary(slug)` has already resolved. A stale list is already surfaced

--- a/src/style-library/helpers/library-flows.js
+++ b/src/style-library/helpers/library-flows.js
@@ -320,8 +320,16 @@ export function deleteLibraryFlow({
 			// reason the `loadLibraries()` step below swallows its own failure: by this point
 			// `deleteLibrary(slug)` has already resolved, so a throw from either callback (e.g.
 			// `resetWorkspace()`'s `history.replaceState`) must not be reported as a failed delete.
+			// Caught separately rather than as one block: the workspace reset is what stops a deleted
+			// library's draft from claiming unsaved changes, so it has to run even if forgetting that
+			// library's cached state failed first.
 			try {
 				forgetLibrary(slug);
+			} catch {
+				// Intentionally swallowed — see above.
+			}
+
+			try {
 				resetWorkspace();
 			} catch {
 				// Intentionally swallowed — see above.

--- a/src/style-library/helpers/library-flows.js
+++ b/src/style-library/helpers/library-flows.js
@@ -317,7 +317,9 @@ export function deleteLibraryFlow({
 			// Both run only once the delete has actually landed, and both run before the feed is
 			// re-read. Resetting earlier would throw away an open draft for a request that might
 			// still fail; resetting later would let a screen render the fresh feed while still
-			// holding the deleted library's cached presets, palettes and pending overlays.
+			// holding the deleted library's cached presets, palettes and pending overlays. That is
+			// about emptying those values, which must happen before the feed read. Re-arming the
+			// resolvers that fill them is a separate step below, and it deliberately runs later.
 			//
 			// Wrapped in its own try/catch, not folded into the flow's outer `.catch()`, for the same
 			// reason the `loadLibraries()` step below swallows its own failure: by this point
@@ -340,9 +342,9 @@ export function deleteLibraryFlow({
 		})
 		.then(() => refreshFeed(nextSlug))
 		.then(() => {
-			// After the feed swap, never before: re-arming these resolvers while the app still
-			// points at the deleted library re-fetches a slug the server no longer has, and the
-			// failure surfaces as a stale error notice on the library the user lands on.
+			// After the feed swap, never before: re-arming these resolvers for a library the app is
+			// leaving is pointless work, and this is the right place to do it regardless. The
+			// stale-notice protection itself lives in the palette hook, not in this ordering.
 			try {
 				revalidateLibraryCaches();
 			} catch {

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -44,17 +44,19 @@ import { STORE_NAME } from '../store';
  * Each slot is cleared the instant its own flow starts again, so a stale error from a previous
  * attempt never lingers past a fresh try at the same action.
  *
- * @param {Object}   feed        The design-tokens admin feed (provides the library being edited).
- * @param {Function} refreshFeed Replaces the feed with a fresh REST read for a slug (from
- *                               `use-design-tokens-feed`), so opening a library re-renders every
- *                               consumer without a page reload.
+ * @param {Object}   feed           The design-tokens admin feed (provides the library being edited).
+ * @param {Function} refreshFeed    Replaces the feed with a fresh REST read for a slug (from
+ *                                  `use-design-tokens-feed`), so opening a library re-renders every
+ *                                  consumer without a page reload.
+ * @param {Function} resetWorkspace Clears the draft channel and the open route item, so a replaced
+ *                                  feed never strands an open settings panel's draft.
  *
  * @since TBD
  *
  * @return {Object} The library list, the two slugs, the busy flag, the per-flow error slots and
  *                  the functions that clear them, and the five operations.
  */
-export function useLibraries(feed, refreshFeed) {
+export function useLibraries(feed, refreshFeed, resetWorkspace) {
 	const [isBusy, setIsBusy] = useState(false);
 	const [openError, setOpenError] = useState(null);
 	const [activateError, setActivateError] = useState(null);
@@ -112,6 +114,32 @@ export function useLibraries(feed, refreshFeed) {
 		return registry.resolveSelect(STORE_NAME).getLibraries();
 	}, [registry]);
 
+	/**
+	 * Drop the store's cached state for a library and re-arm the resolvers that fill it.
+	 *
+	 * The action empties the cached values; the invalidations are what make them refetch —
+	 * `@wordpress/data` still has each tuple marked resolved, and would otherwise keep serving the
+	 * now-empty slice forever. Invalidating per selector rather than per tuple avoids having to
+	 * enumerate `(namespace, block, slug)` for every preset-bound block here, and costs nothing:
+	 * only one library is open at a time, so no other slug's tuples are mounted to re-resolve.
+	 *
+	 * @param {string} slug Token library slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	const forgetLibrary = useCallback(
+		(slug) => {
+			const store = registry.dispatch(STORE_NAME);
+
+			store.forgetLibrary(slug);
+			store.invalidateResolutionForStoreSelector('getPaletteListing');
+			store.invalidateResolutionForStoreSelector('getBlockPresets');
+		},
+		[registry]
+	);
+
 	const clearOpenError = useCallback(() => setOpenError(null), []);
 	const clearActivateError = useCallback(() => setActivateError(null), []);
 	const clearCreateError = useCallback(() => setCreateError(null), []);
@@ -132,8 +160,8 @@ export function useLibraries(feed, refreshFeed) {
 	// `createError`, never through `openError`, and its own `onBusy` so only the user-initiated
 	// open blocks the app. Creation runs behind its own modal, which reports progress itself.
 	const runOpen = useCallback(
-		({ slug, onError, onBusy }) => openLibraryFlow({ slug, refreshFeed, onBusy, onError }),
-		[refreshFeed]
+		({ slug, onError, onBusy }) => openLibraryFlow({ slug, refreshFeed, resetWorkspace, onBusy, onError }),
+		[refreshFeed, resetWorkspace]
 	);
 
 	const openLibrary = useCallback(
@@ -193,12 +221,14 @@ export function useLibraries(feed, refreshFeed) {
 				successorSlug,
 				refreshFeed,
 				loadLibraries,
+				forgetLibrary,
+				resetWorkspace,
 				onBusy: setSwapBusy,
 				onError: setDeleteError,
 				onActiveChanged: setActiveSlug,
 			});
 		},
-		[activeSlug, loadLibraries, refreshFeed, setSwapBusy]
+		[activeSlug, loadLibraries, refreshFeed, forgetLibrary, resetWorkspace, setSwapBusy]
 	);
 
 	return {

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -139,10 +139,12 @@ export function useLibraries(feed, refreshFeed, resetWorkspace) {
 	 * and costs nothing — a resolver only refires for a tuple something actually reads, and one
 	 * screen is mounted at a time.
 	 *
-	 * Runs after the feed has moved to the library being kept. Re-arming any earlier would refire
-	 * the mounted screen's resolver against the deleted slug, and that request's failure would be
-	 * copied into the palette screen's own error state, leaving a stale notice on the library the
-	 * user lands on.
+	 * Runs after the feed read rather than before it: re-arming the resolvers for a library the app
+	 * is on its way out of is wasted work, and any request it does provoke is answered for a slug
+	 * the server may no longer have. This is ordering hygiene, not a guarantee — the visible slug
+	 * advances on a React render that has not necessarily committed by the time this runs, so a
+	 * resolver can still briefly refire against the previous library. What keeps that from reaching
+	 * the user is that a palette listing error is cleared when the library changes.
 	 *
 	 * @since TBD
 	 *

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -115,22 +115,11 @@ export function useLibraries(feed, refreshFeed, resetWorkspace) {
 	}, [registry]);
 
 	/**
-	 * Drop the store's cached state for a library and re-arm the resolvers that fill it.
+	 * Drop the store's cached values for a library.
 	 *
-	 * The action empties the cached values; the invalidations are what make them refetch —
-	 * `@wordpress/data` still has each tuple marked resolved, and would otherwise keep serving the
-	 * now-empty slice forever. Invalidating per selector rather than per tuple avoids having to
-	 * enumerate `(namespace, block, slug)` for every preset-bound block here, and costs nothing:
-	 * only one library is open at a time, so no other slug's tuples are mounted to re-resolve.
-	 *
-	 * Called while the app is still pointed at the library being deleted, so a hard delete
-	 * re-arms these resolvers against a slug the server no longer has, and the browser fires one
-	 * guaranteed-404 request as a result. That is expected, not a bug: its error lands on a
-	 * `getPaletteListing`/`getBlockPresets` tuple keyed to the deleted slug, which nothing reads
-	 * again once the feed moves to the next library moments later. Moving this call to after the
-	 * feed re-read would avoid the request, but would let a screen render the fresh feed while
-	 * still serving the deleted library's cached presets and palettes until the invalidation
-	 * caught up — worse than a 404 nothing acts on.
+	 * Only empties the slices; it deliberately does not re-arm the resolvers that fill them. That
+	 * is `revalidateLibraryCaches` below, which runs later in the flow — re-arming while the app is
+	 * still pointed at the library being deleted would refetch a slug the server no longer has.
 	 *
 	 * @param {string} slug Token library slug.
 	 *
@@ -138,16 +127,33 @@ export function useLibraries(feed, refreshFeed, resetWorkspace) {
 	 *
 	 * @return {void}
 	 */
-	const forgetLibrary = useCallback(
-		(slug) => {
-			const store = registry.dispatch(STORE_NAME);
+	const forgetLibrary = useCallback((slug) => registry.dispatch(STORE_NAME).forgetLibrary(slug), [registry]);
 
-			store.forgetLibrary(slug);
-			store.invalidateResolutionForStoreSelector('getPaletteListing');
-			store.invalidateResolutionForStoreSelector('getBlockPresets');
-		},
-		[registry]
-	);
+	/**
+	 * Re-arm the resolvers behind the per-library caches, so the library now on screen re-fetches
+	 * what `forgetLibrary` emptied.
+	 *
+	 * Emptying a slice is not enough on its own: `@wordpress/data` still has each tuple marked
+	 * resolved and would keep serving the empty slice forever. Invalidating per selector rather
+	 * than per tuple avoids enumerating `(namespace, block, slug)` for every preset-bound block,
+	 * and costs nothing — a resolver only refires for a tuple something actually reads, and one
+	 * screen is mounted at a time.
+	 *
+	 * Runs after the feed has moved to the library being kept. Re-arming any earlier would refire
+	 * the mounted screen's resolver against the deleted slug, and that request's failure would be
+	 * copied into the palette screen's own error state, leaving a stale notice on the library the
+	 * user lands on.
+	 *
+	 * @since TBD
+	 *
+	 * @return {void}
+	 */
+	const revalidateLibraryCaches = useCallback(() => {
+		const store = registry.dispatch(STORE_NAME);
+
+		store.invalidateResolutionForStoreSelector('getPaletteListing');
+		store.invalidateResolutionForStoreSelector('getBlockPresets');
+	}, [registry]);
 
 	const clearOpenError = useCallback(() => setOpenError(null), []);
 	const clearActivateError = useCallback(() => setActivateError(null), []);
@@ -231,13 +237,14 @@ export function useLibraries(feed, refreshFeed, resetWorkspace) {
 				refreshFeed,
 				loadLibraries,
 				forgetLibrary,
+				revalidateLibraryCaches,
 				resetWorkspace,
 				onBusy: setSwapBusy,
 				onError: setDeleteError,
 				onActiveChanged: setActiveSlug,
 			});
 		},
-		[activeSlug, loadLibraries, refreshFeed, forgetLibrary, resetWorkspace, setSwapBusy]
+		[activeSlug, loadLibraries, refreshFeed, forgetLibrary, revalidateLibraryCaches, resetWorkspace, setSwapBusy]
 	);
 
 	return {

--- a/src/style-library/hooks/use-libraries.js
+++ b/src/style-library/hooks/use-libraries.js
@@ -123,6 +123,15 @@ export function useLibraries(feed, refreshFeed, resetWorkspace) {
 	 * enumerate `(namespace, block, slug)` for every preset-bound block here, and costs nothing:
 	 * only one library is open at a time, so no other slug's tuples are mounted to re-resolve.
 	 *
+	 * Called while the app is still pointed at the library being deleted, so a hard delete
+	 * re-arms these resolvers against a slug the server no longer has, and the browser fires one
+	 * guaranteed-404 request as a result. That is expected, not a bug: its error lands on a
+	 * `getPaletteListing`/`getBlockPresets` tuple keyed to the deleted slug, which nothing reads
+	 * again once the feed moves to the next library moments later. Moving this call to after the
+	 * feed re-read would avoid the request, but would let a screen render the fresh feed while
+	 * still serving the deleted library's cached presets and palettes until the invalidation
+	 * caught up — worse than a 404 nothing acts on.
+	 *
 	 * @param {string} slug Token library slug.
 	 *
 	 * @since TBD

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -184,6 +184,15 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 	);
 	const isLoading = !hasFinishedListing && !listing.palettes.length;
 
+	// An error belongs to the library it came from. `ColorPaletteScreen` is the same element in the
+	// same position across a library swap, so React reconciles rather than remounts it and this
+	// state would otherwise survive onto a library it says nothing about. Declared above the effect
+	// that sets it so that, on a swap that genuinely fails, the clear runs first and the new
+	// library's own failure still lands.
+	useEffect(() => {
+		setOpenError(null);
+	}, [namespace, slug]);
+
 	// Mirrors `hooks/use-libraries.js`'s identical effect: a resolution failure for
 	// `getPaletteListing` surfaces here the same way a failed write already does via its own
 	// `onError: setOpenError`.


### PR DESCRIPTION
## Summary

Fixes the reported bug: deleting a library did not reset the interface, kept every edit in memory, and then complained about unsaved changes on navigation.

### Root cause

`useSettingsPanel` seeds a panel's draft **once per open item** and deliberately never reseeds it when the persisted values change underneath. That one-shot rule is load-bearing — it stops a save's `refreshFeed` from clobbering a sibling panel's in-flight edit.

`deleteLibraryFlow` ended with `refreshFeed(...)` and nothing else. So the open panel's `initialValues` became the post-delete baseline while its draft still held the pre-delete edits, `computeIsDirty` went permanently true, and every guarded navigation opened the unsaved-changes modal about a draft with nothing left to save.

The existing stale-item self-heal only rescues an item that *vanished*. A token that still exists in the baseline (`semantic.color.primary`, say) kept its orphaned dirty draft, which is why the bug reproduced reliably rather than intermittently.

### The fix

`openLibraryFlow` and `deleteLibraryFlow` now take the two resets as injected callbacks, matching how they already take `refreshFeed` and `loadLibraries`:

- **`resetWorkspace()`** clears the draft channel and empties `scope`/`item`, unmounting the panel and taking the stale draft with it. Both flows call it.
- **`forgetLibrary(slug)`** drops the deleted library's cached store state. Delete only — switching destroys no data, and both libraries' caches stay valid.

Ordering is the point: both run **after** the delete resolves and **before** `refreshFeed`. Resetting earlier would throw away a draft for a request that might still fail; resetting later would let a screen render the fresh feed while still holding the deleted library's cached presets, palettes and pending overlays. `forgetLibrary` is called with the **deleted** slug, never the one the app lands on.

`useLibraries` gains a required third argument and builds the `forgetLibrary` callback. The store action empties the cached values; the two `invalidateResolutionForStoreSelector` calls are what make them refetch, since `@wordpress/data` otherwise still has each tuple marked resolved. `StyleLibraryApp` builds the reset and moves `useDraftChannelState()` above `useLibraries` so it exists in time.

Neither reset can report a failure as a failed operation: in `openLibraryFlow` the call sits inside the promise chain so the existing `.catch()` covers it, and in `deleteLibraryFlow` each is caught separately — the workspace reset still runs if forgetting the cached state throws first, because the reset is what actually stops the unsaved-changes complaint.

Neither parameter is defaulted. A default would let a caller silently skip the wiring, which is the bug class being fixed.

## Test plan

- `npm test -- src/style-library/__tests__/library-flows.test.js` — 32 passing, covering call ordering (`forget → reset → refresh`), the deleted-slug identity, and the three paths where neither reset may run (delete rejects, missing successor, activation fails).
- `npm test -- src/style-library/__tests__/use-libraries.test.js` — asserts real store state after a delete rather than spying on dispatch.
- Full JS suite green (117 suites, 1744 tests).

**Manual:** open a Spacing token, edit it without saving, delete the library being edited. The panel closes on its own, the screen shows baseline values, and navigating away prompts nothing.

## Stack

1. `library-reset/slice-1-forget-library-store-action` — the store action (#1478)
2. `library-reset/slice-2-workspace-reset-helper` — the workspace reset helper (#1481)
3. **This PR** — wiring both into the library flows
4. `library-reset/slice-4-guard-library-switch` — prompt before discarding a draft on switch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Opening or deleting a style library now resets the active workspace and draft state.
  * Deleted libraries no longer leave cached palettes or presets behind.
  * Cleanup errors no longer interrupt otherwise successful library deletions.
  * Unsaved drafts correctly block navigation until the workspace is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->