### PR TITLE
[DTM] SOFT-4269 [4/4]: ask before discarding a draft when switching libraries

### DIFF
--- a/src/style-library/__tests__/library-selector.test.js
+++ b/src/style-library/__tests__/library-selector.test.js
@@ -1,0 +1,205 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { LibrarySelector } from '../components/organisms/LibrarySelector';
+import { useDraftChannel } from '../hooks/use-draft-channel';
+
+// Same convention `scale-settings.test.js` uses for this hook: a bare `jest.fn()` stand-in whose
+// return value each test sets, rather than automocking the module.
+jest.mock('../hooks/use-draft-channel', () => ({
+	useDraftChannel: jest.fn(),
+}));
+
+// `SelectDropdown` and `CreateLibraryModal` both render `@wordpress/components` controls, which
+// ship their own nested `react` copy and trip React's "Invalid hook call" guard under this test's
+// top-level renderer (see `scale-settings.test.js`'s identical note). Stand-ins that expose only
+// what these tests need — a change trigger and the trailing action's click — keep the tests about
+// guard routing rather than dropdown or modal internals.
+jest.mock('../components/molecules/SelectDropdown', () => ({
+	SelectDropdown: ({ onChange, trailingAction }) => (
+		<div>
+			<button data-testid="choose-brand" onClick={() => onChange('brand')}>
+				choose brand
+			</button>
+			<button data-testid="trailing-action" onClick={() => trailingAction.onClick()}>
+				{trailingAction.label}
+			</button>
+		</div>
+	),
+}));
+
+jest.mock('../components/organisms/CreateLibraryModal', () => ({
+	CreateLibraryModal: () => <div data-testid="create-library-modal" />,
+}));
+
+const LIBRARIES = [{ slug: 'default', title: 'Default' }];
+
+let container;
+let root;
+
+/**
+ * Render `LibrarySelector` with a fresh set of prop spies, so each test can assert on calls
+ * without wiring its own boilerplate.
+ *
+ * @since TBD
+ *
+ * @return {{onOpen: Function}} The spies the component was rendered with.
+ */
+function renderSelector(onOpen = jest.fn(() => Promise.resolve())) {
+	act(() => {
+		root.render(
+			createElement(LibrarySelector, {
+				libraries: LIBRARIES,
+				activeSlug: 'default',
+				editingSlug: 'default',
+				editingTitle: 'Default',
+				isBusy: false,
+				isLoading: false,
+				isSwapping: false,
+				openError: null,
+				createError: null,
+				onOpen,
+				onCreate: jest.fn(() => Promise.resolve()),
+				onClearOpenError: jest.fn(),
+				onClearCreateError: jest.fn(),
+			})
+		);
+	});
+
+	return { onOpen };
+}
+
+/**
+ * Click a button rendered by the mocked `SelectDropdown`.
+ *
+ * @param {string} testId The button's `data-testid`.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function clickButton(testId) {
+	act(() => {
+		container.querySelector(`[data-testid="${testId}"]`).click();
+	});
+}
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+	useDraftChannel.mockReset();
+	useDraftChannel.mockReturnValue(null);
+});
+
+afterEach(() => {
+	act(() => {
+		root.unmount();
+	});
+	container.remove();
+});
+
+describe('LibrarySelector draft-channel guard', () => {
+	/**
+	 * With no channel mounted, choosing a library opens it directly.
+	 *
+	 * @return {void}
+	 */
+	it('opens a library directly when no channel is mounted', () => {
+		const { onOpen } = renderSelector();
+
+		clickButton('choose-brand');
+
+		expect(onOpen).toHaveBeenCalledWith('brand');
+	});
+
+	/**
+	 * With a channel mounted, choosing a library routes through `channel.guard` and does not open
+	 * the library until the guarded callback runs — only then does `onOpen` fire, with the chosen
+	 * slug.
+	 *
+	 * @return {void}
+	 */
+	it('guards opening a library when a channel is mounted', () => {
+		const guard = jest.fn();
+		useDraftChannel.mockReturnValue({ guard });
+		const { onOpen } = renderSelector();
+
+		clickButton('choose-brand');
+
+		expect(guard).toHaveBeenCalledTimes(1);
+		expect(onOpen).not.toHaveBeenCalled();
+
+		act(() => {
+			guard.mock.calls[0][0]();
+		});
+
+		expect(onOpen).toHaveBeenCalledWith('brand');
+	});
+
+	/**
+	 * A rejected open is still swallowed once it runs behind a mounted channel's guard — the
+	 * rejection must not surface as an unhandled rejection.
+	 *
+	 * @return {void}
+	 */
+	it('swallows a rejected open behind a mounted channel', async () => {
+		const guard = jest.fn();
+		useDraftChannel.mockReturnValue({ guard });
+		const onOpen = jest.fn(() => Promise.reject(new Error('boom')));
+		renderSelector(onOpen);
+
+		clickButton('choose-brand');
+
+		await act(async () => {
+			guard.mock.calls[0][0]();
+			await Promise.resolve();
+		});
+
+		expect(onOpen).toHaveBeenCalledWith('brand');
+	});
+
+	/**
+	 * With a channel mounted, clicking the trailing action routes through `channel.guard` and does
+	 * not open the create modal until the guarded callback runs.
+	 *
+	 * @return {void}
+	 */
+	it('guards opening the create modal when a channel is mounted', () => {
+		const guard = jest.fn();
+		useDraftChannel.mockReturnValue({ guard });
+		renderSelector();
+
+		clickButton('trailing-action');
+
+		expect(guard).toHaveBeenCalledTimes(1);
+		expect(container.querySelector('[data-testid="create-library-modal"]')).toBeNull();
+
+		act(() => {
+			guard.mock.calls[0][0]();
+		});
+
+		expect(container.querySelector('[data-testid="create-library-modal"]')).not.toBeNull();
+	});
+
+	/**
+	 * With no channel mounted, clicking the trailing action opens the create modal directly.
+	 *
+	 * @return {void}
+	 */
+	it('opens the create modal directly when no channel is mounted', () => {
+		renderSelector();
+
+		clickButton('trailing-action');
+
+		expect(container.querySelector('[data-testid="create-library-modal"]')).not.toBeNull();
+	});
+});

--- a/src/style-library/components/organisms/LibrarySelector.js
+++ b/src/style-library/components/organisms/LibrarySelector.js
@@ -25,6 +25,7 @@ import { __ } from '@wordpress/i18n';
 import { SelectDropdown } from '../molecules/SelectDropdown';
 import { isDefaultLibrary, libraryDisplayTitle } from '../../helpers/libraries';
 import { CreateLibraryModal } from './CreateLibraryModal';
+import { useDraftChannel } from '../../hooks/use-draft-channel';
 
 /**
  * Render the library selector.
@@ -64,6 +65,7 @@ export function LibrarySelector({
 	onClearCreateError,
 }) {
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
+	const channel = useDraftChannel();
 
 	const options = libraries.map((library) => {
 		const badges = [];
@@ -91,8 +93,15 @@ export function LibrarySelector({
 	// `openError` state above already surfaces a failure, so the rejection `onOpen`'s promise
 	// carries (there for a caller that chains off it, e.g. the create flow) is swallowed here
 	// rather than left unhandled.
+	//
+	// Guarded because opening another library replaces the feed under any open settings panel, and
+	// that panel's draft cannot survive the swap. Unlike deleting a library — where the draft's
+	// target is destroyed and prompting would be nonsense — the token being edited still exists, so
+	// the edit is worth offering to save.
 	const handleOpen = (slug) => {
-		onOpen(slug).catch(() => {});
+		const open = () => onOpen(slug).catch(() => {});
+
+		channel ? channel.guard(open) : open();
 	};
 
 	return (
@@ -119,7 +128,14 @@ export function LibrarySelector({
 				onChange={handleOpen}
 				trailingAction={{
 					label: __('Create Library', 'kadence-blocks'),
-					onClick: () => setIsCreateOpen(true),
+					// Guarded at the point the modal opens rather than around `onCreate`: creating a
+					// library ends by opening it, so it swaps the feed like any other switch, and
+					// asking here keeps the prompt from appearing on top of the create modal.
+					onClick: () => {
+						const openModal = () => setIsCreateOpen(true);
+
+						channel ? channel.guard(openModal) : openModal();
+					},
 				}}
 			/>
 			{isCreateOpen && (


### PR DESCRIPTION
## Summary

Switching to another library — or creating one, which switches to it — discarded an open settings panel's unsaved draft without asking. Switching *screens* prompts. This makes the two consistent.

`LibrarySelector` now consumes the draft channel and routes both library-switching entry points through `channel.guard()`, using the idiom already established in `ScaleScreen.js`:

```js
const open = () => onOpen(slug).catch(() => {});

channel ? channel.guard(open) : open();
```

The `channel ?` fallback is not defensive padding — `useDraftChannel()` returns `null` when no provider is mounted, which the dev gallery relies on.

**Two entry points, because creating a library also switches to it.** The create flow ends by opening the new library, so it swaps the feed like any other switch. The guard sits on the trailing action that opens the create modal rather than around `onCreate`, so the unsaved-changes prompt never stacks on top of the create modal.

**Deleting stays deliberately unguarded.** Destroying a library makes its draft moot, so prompting there would be nonsense — the same reasoning `ScaleSettings.js` gives for its own unguarded delete. This PR does not touch that path.

**Why the prompt is the right call here.** Unlike a delete, the token being edited still exists in the library being left, so the edit is worth offering to save. This also closes the failure mode raised on the previous PR: with the guard in place, a `refreshFeed` that fails after the workspace reset cannot lose anything, because the user has already chosen save or discard before the flow runs.

## Test plan

- `npm test -- src/style-library/__tests__/library-selector.test.js` — 5 passing, covering: no channel mounted (opens directly); channel mounted (asserts `onOpen` is *not* called until the guarded callback runs, then that it fires with the right slug); a rejected open still swallowed; create guarded; create with no channel.
- Full JS suite green (118 suites, 1749 tests).

**Manual:** edit a Spacing token without saving, then pick another library from the header dropdown. You are asked to save or discard instead of losing the edit silently.

## Note for the reviewer

The local pre-push PHP suites were skipped for this push: the shared slic test database is currently wedged (deadlock, then missing tables) and fails 249 unrelated `Optimizer` tests on branches that pushed green earlier today with identical PHP. This PR changes no PHP at all. CI's `tests.yml` is the authoritative run.

## Stack

1. `library-reset/slice-1-forget-library-store-action` — the store action (#1478)
2. `library-reset/slice-2-workspace-reset-helper` — the workspace reset helper (#1481)
3. `library-reset/slice-3-wire-library-flow-resets` — wiring both into the library flows (#1483)
4. **This PR** — prompt before discarding a draft on switch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added protection against losing unsaved drafts when switching libraries or opening the create-library dialog.
  - Actions proceed immediately when no draft channel is active and are safely deferred when unsaved changes may be affected.
  - Preserved graceful handling when a guarded library switch is declined or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->