### PR TITLE
Line the Style Library loading skeleton up with the shell it stands in for

### DIFF
--- a/src/style-library/__tests__/app-shell-skeleton.test.js
+++ b/src/style-library/__tests__/app-shell-skeleton.test.js
@@ -79,4 +79,25 @@ describe('AppShellSkeleton', () => {
 		expect(nav).not.toBeNull();
 		expect(nav.querySelectorAll('.kadence-blocks-style-library__skeleton').length).toBeGreaterThan(0);
 	});
+
+	/**
+	 * The nav and header shapes sit inside the real `AppShell` wrappers, which are what carry the
+	 * frame's opaque surface and column widths — without them the library-switch overlay's
+	 * translucent scrim would leave the outgoing library's own header and nav showing through.
+	 *
+	 * @return {void}
+	 */
+	it('wraps its regions in the real shell frame elements', () => {
+		act(() => {
+			root.render(createElement(AppShellSkeleton));
+		});
+
+		const header = container.querySelector('.kadence-blocks-style-library__header');
+		const sidebar = container.querySelector('.kadence-blocks-style-library__sidebar');
+
+		expect(header).not.toBeNull();
+		expect(header.querySelector('.kadence-blocks-style-library__header-bar')).not.toBeNull();
+		expect(sidebar).not.toBeNull();
+		expect(sidebar.querySelector('.kadence-blocks-style-library__nav')).not.toBeNull();
+	});
 });

--- a/src/style-library/components/organisms/AppShellSkeleton.js
+++ b/src/style-library/components/organisms/AppShellSkeleton.js
@@ -15,10 +15,21 @@ const SKELETON_NAV_IDS = [0, 1, 2, 3, 4, 5, 6];
 
 /**
  * The whole-app loading placeholder: a header-bar-shaped skeleton, a sidebar-nav-shaped skeleton,
- * and a blank content area, in the real `AppShell` markup (`.kadence-blocks-style-library__header-bar`
- * / `__nav` / `__content`) — used both for the app's cold-start gate (`StyleLibraryApp.js`, before
- * `feed.isReady`) and, reused as-is, for `AppShell`'s library-switch overlay (`isBlocked`), so both
- * loading moments render the same shape instead of a spinner.
+ * and a blank content area, in the real `AppShell` markup (`.kadence-blocks-style-library__header`
+ * / `__sidebar` / `__content` and the region classes the first two wrap) — used both for the app's
+ * cold-start gate (`StyleLibraryApp.js`, before `feed.isReady`) and, reused as-is, for `AppShell`'s
+ * library-switch overlay (`isBlocked`), so both loading moments render the same shape instead of a
+ * spinner.
+ *
+ * The content area stays empty on purpose: the incoming screen's shape is not knowable from here —
+ * a screen supplies its own skeleton once it mounts (`PresetScreen`'s row list, `ColorPaletteScreen`'s
+ * swatch grid), and guessing one at this level would mean drawing a layout the screen may not have.
+ *
+ * The `__header` and `__sidebar` wrappers matter as much as the shapes inside them: they are what
+ * carry the frame's opaque surface, its dividing rules and the sidebar's column width, so without
+ * them the overlay's translucent scrim leaves the outgoing library's real header controls and nav
+ * labels showing through the placeholder, and the nav column sizes itself to its own content
+ * instead of the sidebar's width.
  *
  * @since TBD
  *
@@ -33,24 +44,28 @@ export function AppShellSkeleton() {
 			aria-busy="true"
 			aria-label={__('Loading…', 'kadence-blocks')}
 		>
-			<div className="kadence-blocks-style-library__header-bar">
-				<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '8rem' }} />
-				<div className="kadence-blocks-style-library__header-library">
-					<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '12rem' }} />
+			<header className="kadence-blocks-style-library__header">
+				<div className="kadence-blocks-style-library__header-bar">
+					<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '8rem' }} />
+					<div className="kadence-blocks-style-library__header-library">
+						<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '12rem' }} />
+					</div>
+					<div className="kadence-blocks-style-library__header-actions">
+						<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '6rem' }} />
+					</div>
 				</div>
-				<div className="kadence-blocks-style-library__header-actions">
-					<Skeleton className="kadence-blocks-style-library__skeleton--bar" style={{ width: '6rem' }} />
-				</div>
-			</div>
+			</header>
 			<div className="kadence-blocks-style-library__body">
-				<nav className="kadence-blocks-style-library__nav">
-					{SKELETON_NAV_IDS.map((id) => (
-						<Skeleton
-							key={id}
-							className="kadence-blocks-style-library__skeleton--bar"
-							style={{ width: '9rem' }}
-						/>
-					))}
+				<nav className="kadence-blocks-style-library__sidebar">
+					<div className="kadence-blocks-style-library__nav">
+						{SKELETON_NAV_IDS.map((id) => (
+							<Skeleton
+								key={id}
+								className="kadence-blocks-style-library__skeleton--bar"
+								style={{ width: '9rem' }}
+							/>
+						))}
+					</div>
 				</nav>
 				<main className="kadence-blocks-style-library__content" />
 			</div>

--- a/src/style-library/components/organisms/AppShellSkeleton.scss
+++ b/src/style-library/components/organisms/AppShellSkeleton.scss
@@ -1,10 +1,13 @@
-// Unlike the real `AppShell`, this placeholder is never wrapped in
+// This placeholder reproduces the real `AppShell`'s inner wrappers — `__header`, `__sidebar`,
+// `__content` — so it inherits their surfaces, dividing rules and column widths rather than
+// restating them here. What it deliberately does NOT reuse is the outermost
 // `.kadence-blocks-style-library__shell` (which supplies the flex-column layout and the viewport
-// height) — it renders standalone at cold start (`StyleLibraryApp.js`, before `feed.isReady`) and,
-// reused as-is, inside `AppShell.js`'s `isBlocked` overlay (`.kadence-blocks-style-library__blocker`,
-// a `display: flex; align-items: center; justify-content: center` box with no width of its own).
-// Without sizing of its own, the skeleton shrink-wraps to its content and renders as a small,
-// centered box instead of filling the frame the way the spinner it replaced did.
+// height): the skeleton renders standalone at cold start (`StyleLibraryApp.js`, before
+// `feed.isReady`) and, reused as-is, inside `AppShell.js`'s `isBlocked` overlay
+// (`.kadence-blocks-style-library__blocker`, a `display: flex; align-items: center;
+// justify-content: center` box with no width of its own). Without sizing of its own, the skeleton
+// shrink-wraps to its content and renders as a small, centered box instead of filling the frame the
+// way the spinner it replaced did.
 .kadence-blocks-style-library__shell-skeleton {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
🎫  N/A

`AppShellSkeleton` reproduced the header bar and nav list but not the frame elements that hold them. `AppShell` wraps those regions in `.kadence-blocks-style-library__header` and `__sidebar`, which carry the opaque surface, the header's bottom rule, the sidebar's right rule, and the sidebar's fixed column width.

Without them, the library-switch overlay's translucent scrim left the outgoing library's real title, Rename/Delete buttons and nav labels showing through the placeholder, and the nav column shrink-wrapped to its own bars instead of sitting at the sidebar's width.

The skeleton now renders those two wrappers around the shapes it already had. The content area stays empty: the incoming screen's shape is not knowable from here, and each screen draws its own skeleton once it mounts.

Before

<img width="1072" height="639" alt="image" src="https://github.com/user-attachments/assets/d3dbd80d-c410-4e6d-b220-90f3f5fd2cba" />

After

<img width="840" height="421" alt="image" src="https://github.com/user-attachments/assets/7564dd46-53ab-49f2-a749-4eb485100715" />

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
