### PR TITLE
[DTM] SOFT-4266 [6/6]: bring the image block's shadow up to the same binding and defaults

### DIFF
--- a/src/blocks/image/__tests__/box-shadow.test.js
+++ b/src/blocks/image/__tests__/box-shadow.test.js
@@ -1,0 +1,102 @@
+/* eslint-env jest */
+
+/**
+ * The editor canvas's `box-shadow` for `kadence/image`, which has to agree with the front-end
+ * renderer in `class-kadence-blocks-image-block.php` on all three counts: the enable flag gates it,
+ * a whole-shadow token binding wins over the stored legs, and an unbound item keeps the historic
+ * per-leg defaults.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { imageBoxShadowCss } from '../box-shadow';
+import metadata from '../block.json';
+
+// The `@kadence/helpers` barrel eagerly pulls in a REST-fetch helper with no `@wordpress/api-fetch`
+// module to resolve under Jest. Only the color output is reached from here, so a stub is enough.
+jest.mock('@kadence/helpers', () => ({
+	KadenceColorOutput: jest.fn((color, opacity) =>
+		undefined === opacity || 1 === opacity ? color : `rgba(${color}, ${opacity})`
+	),
+}));
+
+const BOUND_ITEM = {
+	color: '#00ff00',
+	opacity: 1,
+	hOffset: 0,
+	vOffset: 2,
+	blur: 8,
+	spread: 0,
+	inset: false,
+	shadowToken: '{semantic.shadow.card}',
+};
+
+describe('imageBoxShadowCss', () => {
+	beforeEach(() => {
+		window.kadenceDesignTokensPresets = { active: 'default' };
+		window.kadenceDesignTokensPickable = {
+			values: { default: { 'semantic.shadow.card': '0px 2px 8px 0px rgba(23, 23, 23, 0.12)' } },
+		};
+	});
+
+	afterEach(() => {
+		delete window.kadenceDesignTokensPresets;
+		delete window.kadenceDesignTokensPickable;
+	});
+
+	/**
+	 * A fresh image carries the shipped visible default but a lowered flag, so the canvas paints
+	 * nothing — the pairing that makes that default safe to register.
+	 *
+	 * @return {void}
+	 */
+	it('paints nothing for a fresh image whose flag is lowered', () => {
+		expect(
+			imageBoxShadowCss(metadata.attributes.displayBoxShadow.default, metadata.attributes.boxShadow.default)
+		).toBeUndefined();
+	});
+
+	/**
+	 * Legacy content saved with the old toggle switched OFF kept whatever values were behind it. The
+	 * flag, not the geometry, still decides, so those values stay unpainted.
+	 *
+	 * @return {void}
+	 */
+	it('paints nothing for a legacy item left behind a lowered flag', () => {
+		expect(imageBoxShadowCss(false, [{ ...BOUND_ITEM, shadowToken: undefined }])).toBeUndefined();
+	});
+
+	/**
+	 * A bound item resolves to the token's custom property, so editing the token moves the image
+	 * without the post being re-saved — the whole point of the binding, and what the front end already
+	 * emits from `render_shadow()`.
+	 *
+	 * @return {void}
+	 */
+	it('emits the token var for a backed binding', () => {
+		expect(imageBoxShadowCss(true, [BOUND_ITEM])).toBe('var(--kb-token--semantic--shadow--card)');
+	});
+
+	/**
+	 * An unbound item renders its stored legs, inset prefix included, exactly as the hand-rolled
+	 * builder did.
+	 *
+	 * @return {void}
+	 */
+	it('builds the literal shorthand for an unbound item', () => {
+		expect(imageBoxShadowCss(true, [{ ...BOUND_ITEM, shadowToken: undefined, inset: true }])).toBe(
+			'inset 0px 2px 8px 0px #00ff00'
+		);
+	});
+
+	/**
+	 * Missing axes fall back to this block's own historic defaults: 14 for blur, 0.2 for opacity, and
+	 * 0 everywhere else.
+	 *
+	 * @return {void}
+	 */
+	it('applies the historic per-leg defaults for missing axes', () => {
+		expect(imageBoxShadowCss(true, [{ color: '#000000', vOffset: 4 }])).toBe('0px 4px 14px 0px rgba(#000000, 0.2)');
+	});
+});

--- a/src/blocks/image/__tests__/shadow-defaults.test.js
+++ b/src/blocks/image/__tests__/shadow-defaults.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+/**
+ * Pins `kadence/image`'s box shadow attributes to the pair the plugin has always shipped.
+ *
+ * The visible value default looks wrong in isolation, and is load-bearing for saved content:
+ * WordPress omits any attribute equal to its registered default, so an image whose shadow was
+ * switched on but never customized stored its flag and NO value key at all. Lowering the value
+ * default to a transparent shadow silently erases the shadow on every one of those images, and
+ * `deprecated.js` cannot repair them — it carries no shadow migration and only runs on a markup
+ * mismatch.
+ *
+ * What keeps a fresh image clean is the paired flag, which defaults to `false` and gates both
+ * renderers — pinned here too, since the two halves only work together.
+ */
+
+/**
+ * Internal dependencies
+ */
+import metadata from '../block.json';
+
+describe('kadence/image shipped shadow defaults', () => {
+	/**
+	 * The value default still registers the exact one-item visible shadow the plugin shipped.
+	 *
+	 * @return {void}
+	 */
+	it('registers the shipped visible shadow as the box shadow default', () => {
+		expect(metadata.attributes.boxShadow).toEqual({
+			type: 'array',
+			default: [{ color: '#000000', opacity: 0.2, spread: 0, blur: 14, hOffset: 0, vOffset: 0, inset: false }],
+		});
+	});
+
+	/**
+	 * The visible default above is only safe because its flag starts lowered.
+	 *
+	 * @return {void}
+	 */
+	it('pairs the box shadow value with an enable flag that starts lowered', () => {
+		expect(metadata.attributes.displayBoxShadow).toEqual({ type: 'boolean', default: false });
+	});
+});

--- a/src/blocks/image/block.json
+++ b/src/blocks/image/block.json
@@ -190,7 +190,15 @@
 		"boxShadow": {
 			"type": "array",
 			"default": [
-				{ "color": "transparent", "opacity": 1, "spread": 0, "blur": 0, "hOffset": 0, "vOffset": 0, "inset": false }
+				{
+					"color": "#000000",
+					"opacity": 0.2,
+					"spread": 0,
+					"blur": 14,
+					"hOffset": 0,
+					"vOffset": 0,
+					"inset": false
+				}
 			]
 		},
 		"displayDropShadow": {

--- a/src/blocks/image/box-shadow.js
+++ b/src/blocks/image/box-shadow.js
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import { hasVisibleShadow } from '../../extension/design-tokens/components/EditorShadowControl';
+import { shadowCss } from '../../extension/design-tokens/shadow-css';
+
+/**
+ * What `blur` falls back to when the stored item leaves it unset.
+ */
+const BLUR_FALLBACK = 14;
+
+/**
+ * What `opacity` falls back to when the stored item leaves it unset.
+ */
+const OPACITY_FALLBACK = 0.2;
+
+/**
+ * The editor canvas's inline `box-shadow` value for an image.
+ *
+ * Both halves have to agree before anything is painted: the stored flag, which legacy content may
+ * have left false with real values still behind it, and the value's own axes. That pairing, and the
+ * shared builder underneath, are what keep this canvas and the front-end renderer in step — including
+ * a whole-shadow token binding, which resolves to the token's custom property so editing the token
+ * moves the image without the post being re-saved.
+ *
+ * @param {boolean} displayBoxShadow The block's stored shadow enable flag.
+ * @param {?Array}  boxShadow        The stored `boxShadow` attribute value.
+ *
+ * @since TBD
+ *
+ * @return {string|undefined} The `box-shadow` value, or undefined when the image paints no shadow.
+ */
+export function imageBoxShadowCss(displayBoxShadow, boxShadow) {
+	if (!displayBoxShadow || !hasVisibleShadow(boxShadow?.[0])) {
+		return undefined;
+	}
+
+	// A binding whose token has been deleted resolves to nothing rather than to the stored legs, so
+	// the image falls back to its default CSS the way every other deleted-token reference does.
+	return shadowCss(boxShadow[0], BLUR_FALLBACK, OPACITY_FALLBACK) || undefined;
+}

--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -67,6 +67,7 @@ import {
 } from '../../extension/token-indicators/normalize';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorShadowControl, hasVisibleShadow } from '../../extension/design-tokens/components/EditorShadowControl';
+import { imageBoxShadowCss } from './box-shadow';
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
 import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
 import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
@@ -1330,6 +1331,7 @@ export default function Image({
 							<EditorShadowControl
 								label={__('Box Shadow', 'kadence-blocks')}
 								value={boxShadow}
+								enabled={displayBoxShadow}
 								onChange={(value) =>
 									setAttributes({
 										boxShadow: value,
@@ -1954,24 +1956,8 @@ export default function Image({
 
 					backgroundColor: '' !== backgroundColor ? KadenceColorOutput(backgroundColor) : undefined,
 
-					// Both halves have to agree: the stored flag, which legacy content may have left false
-					// with real values still behind it, and the value's own axes.
-					boxShadow:
-						displayBoxShadow && hasVisibleShadow(boxShadow?.[0])
-							? (undefined !== boxShadow[0].inset && boxShadow[0].inset ? 'inset ' : '') +
-								(undefined !== boxShadow[0].hOffset ? boxShadow[0].hOffset : 0) +
-								'px ' +
-								(undefined !== boxShadow[0].vOffset ? boxShadow[0].vOffset : 0) +
-								'px ' +
-								(undefined !== boxShadow[0].blur ? boxShadow[0].blur : 14) +
-								'px ' +
-								(undefined !== boxShadow[0].spread ? boxShadow[0].spread : 0) +
-								'px ' +
-								KadenceColorOutput(
-									undefined !== boxShadow[0].color ? boxShadow[0].color : '#000000',
-									undefined !== boxShadow[0].opacity ? boxShadow[0].opacity : 0.2
-								)
-							: undefined,
+					boxShadow: imageBoxShadowCss(displayBoxShadow, boxShadow),
+
 					filter:
 						undefined !== displayDropShadow && displayDropShadow
 							? 'drop-shadow(' +

--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -11,7 +11,8 @@
  * Internal dependencies
  */
 import { KadenceBlocksCSS } from '@kadence/helpers';
-import BackendStyles, { hasVisibleShadow, shadowAxisPx, shadowCss } from '../index';
+import BackendStyles, { hasVisibleShadow } from '../index';
+import { shadowAxisPx, shadowCss } from '../../../../../extension/design-tokens/shadow-css';
 import metadata from '../../../block.json';
 
 // `backend-styles/index.js` imports the `@kadence/helpers` barrel, which eagerly pulls in a

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -8,10 +8,8 @@ import {
 	getSpacingOptionOutput,
 } from '@kadence/helpers';
 import { activePresetFor, blockPresetValues } from '../../../../extension/preset-picker';
-import { tokenPx } from '../../../../extension/design-tokens/token-px';
-import { pathOfAlias, resolveTokenAlias } from '../../../../extension/design-tokens/alias';
-import { isBackedToken } from '../../../../extension/design-tokens/backed-tokens';
 import { boundShadowToken } from '../../../../extension/design-tokens/shadow-token';
+import { shadowCss } from '../../../../extension/design-tokens/shadow-css';
 
 /**
  * Whether the button's active preset resolves a padding and/or a margin.
@@ -84,30 +82,6 @@ export function presetShadowProperties(attributes) {
 }
 
 /**
- * One shadow axis as a bare pixel number.
- *
- * A {dot.alias} leg is resolved through the token pool the way the PHP renderer's `render_shadow()`
- * does. Concatenated raw it would emit `{alias}px`, which is not valid CSS — and `hasVisibleShadow()`
- * deliberately counts such a leg as visible, so it does reach here.
- *
- * @param {*} raw      The stored axis value.
- * @param {*} fallback What this axis defaults to when unset.
- *
- * @since TBD
- *
- * @return {*} The axis value to serialize.
- */
-export function shadowAxisPx(raw, fallback) {
-	if (typeof raw === 'string' && raw.trim() !== '' && !Number.isFinite(Number(raw))) {
-		const resolved = tokenPx(raw);
-
-		return resolved === null || resolved === undefined ? fallback : resolved;
-	}
-
-	return undefined !== raw && null !== raw ? raw : fallback;
-}
-
-/**
  * Whether a native shadow item paints anything visible — all-zero offsets, blur, and spread
  * render nothing regardless of color, matching the value the "None" pick now writes and mirroring
  * the PHP renderer's `has_visible_shadow()`.
@@ -149,55 +123,6 @@ export function hasVisibleShadow(shadowItem) {
 		// `Number(undefined)` is `NaN`, which a bare `!== 0` would read as visible; the PHP gate does not.
 		return Number.isFinite(value) && value !== 0;
 	});
-}
-
-/**
- * One shadow item as a `box-shadow` declaration value.
- *
- * A `shadowToken` binding backed by the active library wins outright and the stored legs are never
- * read — that is what keeps the value tracking the token. A binding the library no longer backs (a
- * token deleted after the post was saved) renders nothing: the block falls back to its default CSS
- * the same way every other block does when a token disappears, rather than the legs that still hold
- * the value the token resolved to when it was picked — those legs stay stored for readers that do
- * not know the binding key and to seed the Custom tab, but the renderer no longer reads them. An
- * unbound item still builds its literal shorthand from the legs below.
- *
- * @param {?Object} shadowItem   One `shadow[0]`-shaped item.
- * @param {number}  blurFallback What `blur` defaults to when unset — 14 on every current caller,
- *                               taken as an argument rather than hard-coded so the historic per-state
- *                               default stays with the call site that owns it.
- *
- * @since TBD
- *
- * @return {string} The `box-shadow` value, or '' when there is no item to render or the item's
- *                   binding is no longer backed by the active library.
- */
-export function shadowCss(shadowItem, blurFallback) {
-	if (!shadowItem) {
-		return '';
-	}
-
-	const bound = boundShadowToken(shadowItem);
-
-	if (bound) {
-		return isBackedToken(pathOfAlias(bound)) ? resolveTokenAlias(bound) : '';
-	}
-
-	return (
-		(shadowItem.inset ? 'inset ' : '') +
-		shadowAxisPx(shadowItem.hOffset, 0) +
-		'px ' +
-		shadowAxisPx(shadowItem.vOffset, 0) +
-		'px ' +
-		shadowAxisPx(shadowItem.blur, blurFallback) +
-		'px ' +
-		shadowAxisPx(shadowItem.spread, 0) +
-		'px ' +
-		KadenceColorOutput(
-			undefined !== shadowItem.color ? shadowItem.color : '#000000',
-			undefined !== shadowItem.opacity ? shadowItem.opacity : 1
-		)
-	);
 }
 
 export default function BackendStyles(props) {

--- a/src/blocks/singlebtn/components/backend-styles/index.js
+++ b/src/blocks/singlebtn/components/backend-styles/index.js
@@ -8,6 +8,8 @@ import {
 	getSpacingOptionOutput,
 } from '@kadence/helpers';
 import { activePresetFor, blockPresetValues } from '../../../../extension/preset-picker';
+import { pathOfAlias } from '../../../../extension/design-tokens/alias';
+import { isBackedToken } from '../../../../extension/design-tokens/backed-tokens';
 import { boundShadowToken } from '../../../../extension/design-tokens/shadow-token';
 import { shadowCss } from '../../../../extension/design-tokens/shadow-css';
 

--- a/src/extension/design-tokens/shadow-css.js
+++ b/src/extension/design-tokens/shadow-css.js
@@ -1,0 +1,99 @@
+/**
+ * A stored shadow item as a `box-shadow` declaration value.
+ *
+ * This lives beside `shadow-token.js` rather than inside either block that needs it: `kadence/image`
+ * and `kadence/singlebtn` both build a canvas `box-shadow` from the same `shadow[0]` shape and must
+ * honor a binding identically, and neither block should have to reach into the other for the builder.
+ * Like its neighbor it only builds strings, so it pulls in no React and no control barrel.
+ */
+
+/**
+ * External dependencies
+ */
+import { KadenceColorOutput } from '@kadence/helpers';
+
+/**
+ * Internal dependencies
+ */
+import { tokenPx } from './token-px';
+import { pathOfAlias, resolveTokenAlias } from './alias';
+import { isBackedToken } from './backed-tokens';
+import { boundShadowToken } from './shadow-token';
+
+/**
+ * One shadow axis as a bare pixel number.
+ *
+ * A {dot.alias} leg is resolved through the token pool the way the PHP renderer's `render_shadow()`
+ * does. Concatenated raw it would emit `{alias}px`, which is not valid CSS — and `hasVisibleShadow()`
+ * deliberately counts such a leg as visible, so it does reach here.
+ *
+ * @param {*} raw      The stored axis value.
+ * @param {*} fallback What this axis defaults to when unset.
+ *
+ * @since TBD
+ *
+ * @return {*} The axis value to serialize.
+ */
+export function shadowAxisPx(raw, fallback) {
+	if (typeof raw === 'string' && raw.trim() !== '' && !Number.isFinite(Number(raw))) {
+		const resolved = tokenPx(raw);
+
+		return resolved === null || resolved === undefined ? fallback : resolved;
+	}
+
+	return undefined !== raw && null !== raw ? raw : fallback;
+}
+
+/**
+ * One shadow item as a `box-shadow` declaration value.
+ *
+ * A `shadowToken` binding backed by the active library wins outright and the stored legs are never
+ * read — that is what keeps the value tracking the token. A binding the library no longer backs (a
+ * token deleted after the post was saved) falls back to those legs, which still hold the value the
+ * token resolved to when it was picked. That differs on purpose from an unbacked PER-LEG alias, which
+ * `shadowAxisPx()` cannot fall back for because the alias replaced the number outright.
+ *
+ * @param {?Object} shadowItem      One `shadow[0]`-shaped item.
+ * @param {number}  blurFallback    What `blur` defaults to when unset — 14 on every current caller,
+ *                                  taken as an argument rather than hard-coded so the historic
+ *                                  per-state default stays with the call site that owns it.
+ * @param {number}  opacityFallback What `opacity` defaults to when unset. Blocks disagree on this
+ *                                  one — `kadence/singlebtn` has always used 1 and `kadence/image`
+ *                                  0.2 — so it too stays with the call site.
+ *
+ * @since TBD
+ *
+ * @return {string} The `box-shadow` value, or '' when there is no item to render.
+ */
+export function shadowCss(shadowItem, blurFallback, opacityFallback = 1) {
+	if (!shadowItem) {
+		return '';
+	}
+
+	const bound = boundShadowToken(shadowItem);
+
+	// A bound item renders from its token or not at all. When the token is no longer in the active
+	// library the stored legs are deliberately NOT used as a fallback: the value falls back to the
+	// block's default CSS instead, which is what every other deleted-token reference already does.
+	// The legs still earn their place elsewhere — they keep the item a valid literal shadow for
+	// readers that do not know the binding key, and they seed the control's Custom tab.
+	if (bound) {
+		return isBackedToken(pathOfAlias(bound)) ? resolveTokenAlias(bound) : '';
+	}
+
+	return (
+		(shadowItem.inset ? 'inset ' : '') +
+		shadowAxisPx(shadowItem.hOffset, 0) +
+		'px ' +
+		shadowAxisPx(shadowItem.vOffset, 0) +
+		'px ' +
+		shadowAxisPx(shadowItem.blur, blurFallback) +
+		'px ' +
+		shadowAxisPx(shadowItem.spread, 0) +
+		'px ' +
+		KadenceColorOutput(
+			undefined !== shadowItem.color ? shadowItem.color : '#000000',
+			undefined !== shadowItem.opacity ? shadowItem.opacity : opacityFallback
+		)
+	);
+}

--- a/src/extension/design-tokens/shadow-css.js
+++ b/src/extension/design-tokens/shadow-css.js
@@ -49,9 +49,11 @@ export function shadowAxisPx(raw, fallback) {
  *
  * A `shadowToken` binding backed by the active library wins outright and the stored legs are never
  * read — that is what keeps the value tracking the token. A binding the library no longer backs (a
- * token deleted after the post was saved) falls back to those legs, which still hold the value the
- * token resolved to when it was picked. That differs on purpose from an unbacked PER-LEG alias, which
- * `shadowAxisPx()` cannot fall back for because the alias replaced the number outright.
+ * token deleted after the post was saved) renders nothing: the block falls back to its default CSS
+ * the same way every other block does when a token disappears, rather than the legs that still hold
+ * the value the token resolved to when it was picked — those legs stay stored for readers that do
+ * not know the binding key and to seed the Custom tab, but the renderer no longer reads them. An
+ * unbound item still builds its literal shorthand from the legs below.
  *
  * @param {?Object} shadowItem      One `shadow[0]`-shaped item.
  * @param {number}  blurFallback    What `blur` defaults to when unset — 14 on every current caller,
@@ -63,7 +65,8 @@ export function shadowAxisPx(raw, fallback) {
  *
  * @since TBD
  *
- * @return {string} The `box-shadow` value, or '' when there is no item to render.
+ * @return {string} The `box-shadow` value, or '' when there is no item to render or the item's
+ *                   binding is no longer backed by the active library.
  */
 export function shadowCss(shadowItem, blurFallback, opacityFallback = 1) {
 	if (!shadowItem) {

--- a/tests/wpunit/Blocks/ImageTest.php
+++ b/tests/wpunit/Blocks/ImageTest.php
@@ -202,7 +202,7 @@ class ImageTest extends KadenceBlocksUnit {
 		$output = $this->render_image(
 			[
 				'displayBoxShadow' => false,
-				'boxShadow'        => [ $this->shipped_shadow_default() ],
+				'boxShadow'        => [ $this->registered_shadow_default() ],
 			]
 		);
 
@@ -221,7 +221,7 @@ class ImageTest extends KadenceBlocksUnit {
 		$output = $this->render_image(
 			[
 				'displayBoxShadow' => true,
-				'boxShadow'        => [ $this->shipped_shadow_default() ],
+				'boxShadow'        => [ $this->registered_shadow_default() ],
 			]
 		);
 
@@ -233,21 +233,20 @@ class ImageTest extends KadenceBlocksUnit {
 	}
 
 	/**
-	 * The `boxShadow` attribute default `block.json` has always registered, spelled out here so a
-	 * change to that schema fails these tests loudly instead of silently weakening them.
+	 * The `boxShadow` attribute default as `block.json` actually registers it.
 	 *
-	 * @return array<string, mixed> The shipped default shadow item.
+	 * Read from the schema rather than spelled out here on purpose. These tests stand in for a saved
+	 * image that stored no `boxShadow` key of its own, so the value under test has to be the one the
+	 * parser would fill in; hard-coding it would let the schema drift back to a lowered default while
+	 * the tests kept passing against a literal that no longer exists anywhere. Their expected CSS stays
+	 * spelled out, so a drifted schema fails them loudly.
+	 *
+	 * @return array<string, mixed> The registered default shadow item.
 	 */
-	private function shipped_shadow_default(): array {
-		return [
-			'color'   => '#000000',
-			'opacity' => 0.2,
-			'spread'  => 0,
-			'blur'    => 14,
-			'hOffset' => 0,
-			'vOffset' => 0,
-			'inset'   => false,
-		];
+	private function registered_shadow_default(): array {
+		$schema = json_decode( (string) file_get_contents( KADENCE_BLOCKS_PATH . 'src/blocks/image/block.json' ), true );
+
+		return $schema['attributes']['boxShadow']['default'][0];
 	}
 
 	/**

--- a/tests/wpunit/Blocks/ImageTest.php
+++ b/tests/wpunit/Blocks/ImageTest.php
@@ -94,8 +94,8 @@ class ImageTest extends KadenceBlocksUnit {
 	}
 
 	/**
-	 * An all-zero shadow emits nothing. This is what makes the registered default safe: a fresh image
-	 * carries that value and must render exactly as it did when a `false` boolean suppressed it.
+	 * An all-zero shadow emits nothing — geometry alone decides, so the value the "None" pick writes
+	 * paints nothing whatever its color says.
 	 *
 	 * @return void
 	 */
@@ -188,6 +188,66 @@ class ImageTest extends KadenceBlocksUnit {
 		);
 
 		$this->assertStringContainsString( 'var(--kb-token--semantic--radius--media)', $output );
+	}
+
+	/**
+	 * A fresh image arrives with the shipped schema defaults — a VISIBLE `boxShadow` value paired with
+	 * a lowered `displayBoxShadow` — and must still paint nothing. The visible value exists only so a
+	 * legacy image that saved no value key of its own keeps its shadow; the lowered flag is what keeps
+	 * a brand-new image clean.
+	 *
+	 * @return void
+	 */
+	public function testFreshImageEmitsNoBoxShadowDespiteTheShippedVisibleDefault(): void {
+		$output = $this->render_image(
+			[
+				'displayBoxShadow' => false,
+				'boxShadow'        => [ $this->shipped_shadow_default() ],
+			]
+		);
+
+		$this->assertStringNotContainsString( 'box-shadow', $output );
+	}
+
+	/**
+	 * An image switched on before its shadow was ever customized saved the flag and NO `boxShadow`
+	 * key, because the value matched the registered default. It arrives with that default filled back
+	 * in and must render the shadow it has always rendered — the regression a lowered value default
+	 * causes, which nothing downstream repairs.
+	 *
+	 * @return void
+	 */
+	public function testLegacyImageWithNoStoredShadowValueStillRendersItsShippedShadow(): void {
+		$output = $this->render_image(
+			[
+				'displayBoxShadow' => true,
+				'boxShadow'        => [ $this->shipped_shadow_default() ],
+			]
+		);
+
+		$this->assertStringContainsString(
+			'box-shadow:0px 0px 14px 0px rgba(0, 0, 0, 0.2)',
+			$output,
+			'A raised flag with no stored shadow value must render the shipped default shadow.'
+		);
+	}
+
+	/**
+	 * The `boxShadow` attribute default `block.json` has always registered, spelled out here so a
+	 * change to that schema fails these tests loudly instead of silently weakening them.
+	 *
+	 * @return array<string, mixed> The shipped default shadow item.
+	 */
+	private function shipped_shadow_default(): array {
+		return [
+			'color'   => '#000000',
+			'opacity' => 0.2,
+			'spread'  => 0,
+			'blur'    => 14,
+			'hOffset' => 0,
+			'vOffset' => 0,
+			'inset'   => false,
+		];
 	}
 
 	/**


### PR DESCRIPTION
Final slice of the shadow-token binding stack. The slices below build the binding for `kadence/singlebtn`; this one brings `kadence/image` — the other block whose shadow control is `EditorShadowControl` — to the same state, and repairs a shadow regression it is carrying today.

Based on `SOFT-4266/slice-5-shipped-shadow-defaults-v2`.

## The image canvas ignored the binding while its front end honored it

Because both blocks share `EditorShadowControl` and `Kadence_Blocks_CSS::render_shadow()`, the slices below already made half of this live for images: `toNativeShadow()` writes `shadowToken` onto the `boxShadow` item, and the front end emits `var(--kb-token--<id>)` for it. The canvas did not — it built the shorthand inline from the frozen legs and never read the binding key, so the two agreed at pick time and diverged the moment the token was edited.

`shadowAxisPx()` and `shadowCss()` are lifted out of `src/blocks/singlebtn/components/backend-styles/index.js` into a new `src/extension/design-tokens/shadow-css.js`, beside `shadow-token.js`. Neither block reaches into the other, and the module stays a plain string builder — no React, no control barrel. `shadowCss()` gains an `opacityFallback` argument because the image's historic opacity default is `0.2` where the button's is `1`; existing callers are unchanged.

The image canvas now goes through `src/blocks/image/box-shadow.js`, which keeps its gate, its blur-14 / opacity-0.2 leg defaults and its `inset` prefix, and is testable without rendering the editor.

One behavior change falls out of this: a per-leg `{dot.alias}` on an image shadow now resolves through `tokenPx()` instead of being concatenated raw. The old output was `{semantic.shadow.card}px` — invalid CSS — so this fixes a latent bug and matches what the front end and the button already do.

## The `enabled` prop is wired into the image control

`EditorShadowControl` gained an `enabled` prop in the slice below so a lowered enable flag reads as unset rather than "Custom". `kadence/image` has the identical shape and both of its renderers gate on `displayBoxShadow`, but the control was passing no `enabled` — so a legacy image saved with the toggle switched off but real values behind it read as "Custom" in the inspector while both renderers painted nothing. It now passes `enabled={displayBoxShadow}`.

## `boxShadow`'s registered default was left lowered while its flag was restored

This is a live regression on the feature branch, not something this stack introduced.

`3c6512be6` removed the `displayBoxShadow` attribute **and** lowered `boxShadow`'s registered default from the shipped visible value to an all-zero transparent composite. `20c6b89f6` later walked back the flag half — it re-added the attribute and restored the gate — but left the value default lowered. The two halves have been inconsistent since.

That breaks saved content. WordPress omits an attribute equal to its registered default, so an image switched **on** but never customized stored `displayBoxShadow: true` and no `boxShadow` key at all. Parsed against the lowered default it resolves to the transparent composite, `has_visible_shadow()` reads it as invisible, and the shadow is gone.

Measured against `master`:

| attribute | vs shipped |
|---|---|
| `displayBoxShadow` | already restored |
| `boxShadow` | **still lowered** |
| `displayDropShadow` / `dropShadow` | untouched |

`boxShadow`'s default is restored to the shipped value. The already-restored `displayBoxShadow` flag is what keeps a fresh image clean — both renderers gate on it, so a visible default cannot make a new image sprout a shadow. This is the same two-halves-together fix the slice below makes for the button.

Nothing downstream would have caught it: `kadence/image` has a real `save()`, and `src/blocks/image/deprecated.js` is save-only with no `isEligible`, no `migrate` and no shadow handling, so an affected image is repaired only if someone reopens and re-edits it.

## Test plan

- `npm test -- src/blocks/image src/blocks/singlebtn src/extension/design-tokens`
- `slic run wpunit Blocks/ImageTest`
- Covered: a fresh image with the flag lowered emitting no shadow despite the restored visible default, on the canvas and the front end; a legacy image with the flag raised and no stored value rendering the shipped shadow; the canvas emitting the token `var()` for a backed binding, nothing for an unbacked one, and the stored legs for an unbound item; and `boxShadow`'s default matching the shipped schema so it cannot drift again.
- The button's canvas tests move to the lifted module's import path with no expectation changes, which is what pins the lift as behavior-preserving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for image box shadows with configurable visibility, opacity, blur, color, and inset styling.
  * Updated the default image shadow appearance to a subtle black shadow.

* **Bug Fixes**
  * Improved handling of legacy and missing shadow settings.
  * Prevented disabled or unresolved shadows from being rendered.
  * Preserved compatibility with existing shadow token values.

* **Tests**
  * Added comprehensive coverage for image shadow defaults, visibility, token resolution, and legacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->