### PR TITLE
Ship one Default preset for the Button, matching every other block

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -386,35 +386,19 @@
 				"$type": "color",
 				"$value": "{primitive.color.brand.primary}"
 			},
-			"button-primary-bg": {
+			"button-bg": {
 				"$type": "color",
 				"$value": "{primitive.color.brand.button}"
 			},
-			"button-primary-text": {
+			"button-text": {
 				"$type": "color",
 				"$value": "{primitive.color.neutral.0}"
 			},
-			"button-primary-bg-hover": {
+			"button-bg-hover": {
 				"$type": "color",
 				"$value": "{primitive.color.brand.button-hover}"
 			},
-			"button-primary-text-hover": {
-				"$type": "color",
-				"$value": "{primitive.color.neutral.0}"
-			},
-			"button-secondary-bg": {
-				"$type": "color",
-				"$value": "{primitive.color.neutral.900}"
-			},
-			"button-secondary-text": {
-				"$type": "color",
-				"$value": "{primitive.color.neutral.0}"
-			},
-			"button-secondary-bg-hover": {
-				"$type": "color",
-				"$value": "{primitive.color.neutral.700}"
-			},
-			"button-secondary-text-hover": {
+			"button-text-hover": {
 				"$type": "color",
 				"$value": "{primitive.color.neutral.0}"
 			},
@@ -769,39 +753,14 @@
 					}
 				},
 				"kadence/singlebtn": {
-					"$default": "primary",
-					"primary": {
-						"label": "Primary",
+					"$default": "default",
+					"default": {
+						"label": "Default",
 						"tokens": {
-							"button-bg": "{semantic.color.button-primary-bg}",
-							"button-text": "{semantic.color.button-primary-text}",
-							"button-bg-hover": "{semantic.color.button-primary-bg-hover}",
-							"button-text-hover": "{semantic.color.button-primary-text-hover}",
-							"button-radius": "{semantic.radius.control}",
-							"button-border-width": "{semantic.border-width.default}",
-							"button-border-style": "{semantic.border-style.default}",
-							"button-border-color": "{semantic.color.border}",
-							"button-padding": [
-								"0.4em",
-								"1em",
-								"0.4em",
-								"1em"
-							],
-							"button-margin": [
-								"0",
-								"0",
-								"0",
-								"0"
-							]
-						}
-					},
-					"secondary": {
-						"label": "Secondary",
-						"tokens": {
-							"button-bg": "{semantic.color.button-secondary-bg}",
-							"button-text": "{semantic.color.button-secondary-text}",
-							"button-bg-hover": "{semantic.color.button-secondary-bg-hover}",
-							"button-text-hover": "{semantic.color.button-secondary-text-hover}",
+							"button-bg": "{semantic.color.button-bg}",
+							"button-text": "{semantic.color.button-text}",
+							"button-bg-hover": "{semantic.color.button-bg-hover}",
+							"button-text-hover": "{semantic.color.button-text-hover}",
 							"button-radius": "{semantic.radius.control}",
 							"button-border-width": "{semantic.border-width.default}",
 							"button-border-style": "{semantic.border-style.default}",

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -219,20 +219,15 @@ foreach ( $palette_slots as $token_id => $slot_label ) {
 }
 
 /**
- * Per-preset button color semantics (primary/secondary, resting + hover). The Button preset maps
- * reference these by value and they carry no projections of their own — the Kadence button reads them
- * through the preset's retarget bindings below, so overriding a primary semantic recolors that preset
- * without touching the global palette.
+ * Button color semantics (resting + hover). The Button preset map references these by value and they
+ * carry no projections of their own — the Kadence button reads them through the preset's retarget
+ * bindings below, so overriding one recolors the preset without touching the global palette.
  */
 $button_color_labels = [
-	'button-primary-bg'           => __( 'Button Primary Background', 'kadence-blocks' ),
-	'button-primary-text'         => __( 'Button Primary Text', 'kadence-blocks' ),
-	'button-primary-bg-hover'     => __( 'Button Primary Background (Hover)', 'kadence-blocks' ),
-	'button-primary-text-hover'   => __( 'Button Primary Text (Hover)', 'kadence-blocks' ),
-	'button-secondary-bg'         => __( 'Button Secondary Background', 'kadence-blocks' ),
-	'button-secondary-text'       => __( 'Button Secondary Text', 'kadence-blocks' ),
-	'button-secondary-bg-hover'   => __( 'Button Secondary Background (Hover)', 'kadence-blocks' ),
-	'button-secondary-text-hover' => __( 'Button Secondary Text (Hover)', 'kadence-blocks' ),
+	'button-bg'         => __( 'Button Background', 'kadence-blocks' ),
+	'button-text'       => __( 'Button Text', 'kadence-blocks' ),
+	'button-bg-hover'   => __( 'Button Background (Hover)', 'kadence-blocks' ),
+	'button-text-hover' => __( 'Button Text (Hover)', 'kadence-blocks' ),
 ];
 
 $button_color_tokens = [];
@@ -538,8 +533,8 @@ return [
 			 * background + text, Outline reads --global-palette-btn-bg for border + text, and both read the
 			 * matching -hover slots on :hover/:focus, so one color preset skins every shape and state. Each
 			 * binding names only the slot it retargets; the per-preset VALUE comes from the preset's token
-			 * map (which references the per-preset button-color semantics), so primary and secondary are
-			 * symmetric and each is overridable on its own semantic. Picking a preset re-skins a button with
+			 * map (which references the button-color semantics), so every preset is shaped the same way and
+			 * each is overridable on its own semantic. Picking a preset re-skins a button with
 			 * zero changes to its render path; a fresh button follows the $default.
 			 */
 			'block'         => 'kadence/singlebtn',
@@ -550,23 +545,23 @@ return [
 				'label' => __( 'Button', 'kadence-blocks' ),
 			],
 			'bindings'      => [
-				'button-bg'           => [
+				'button-bg'                 => [
 					'kadence_slot' => 'palette-btn-bg',
 					'control_attr' => 'background',
 				],
-				'button-text'         => [
+				'button-text'               => [
 					'kadence_slot' => 'palette-btn',
 					'control_attr' => 'color',
 				],
-				'button-bg-hover'     => [
+				'button-bg-hover'           => [
 					'kadence_slot' => 'palette-btn-bg-hover',
 					'control_attr' => 'backgroundHover',
 				],
-				'button-text-hover'   => [
+				'button-text-hover'         => [
 					'kadence_slot' => 'palette-btn-hover',
 					'control_attr' => 'colorHover',
 				],
-				'button-radius'       => [
+				'button-radius'             => [
 					'css_var'          => 'kb-btn-radius', // drives --kb-btn-radius so a preset can vary the radius.
 					'control_attr'     => 'borderRadius',
 					// The block names its per-device radius attributes by a prefix convention, which is a naming
@@ -582,7 +577,7 @@ return [
 				// every existing button and take padding away from the Button Size control. The binding
 				// exists so a preset CAN set them; until one does, the property resolves to nothing and no
 				// declaration is emitted.
-				'button-padding'      => [
+				'button-padding'            => [
 					'css_var'          => 'kb-btn-padding',
 					'control_attr'     => 'padding',
 					'responsive_attrs' => [
@@ -590,7 +585,7 @@ return [
 						'mobile' => 'mobilePadding',
 					],
 				],
-				'button-margin'       => [
+				'button-margin'             => [
 					'css_var'          => 'kb-btn-margin',
 					'control_attr'     => 'margin',
 					'responsive_attrs' => [
@@ -614,19 +609,19 @@ return [
 				// apart — width reads as a plain dimension and both style and color read as a plain color, so
 				// the editor would compare the nested shape as a flat one and never match. token-indicators
 				// reads the declared axis and combines the three into one bound/overridden state entry.
-				'button-border-width' => [
+				'button-border-width'       => [
 					'token'        => 'semantic.border-width.default',
 					'css_var'      => 'kb-btn-border-width',
 					'control_attr' => 'borderStyle',
 					'axis'         => 'border-width',
 				],
-				'button-border-style' => [
+				'button-border-style'       => [
 					'token'        => 'semantic.border-style.default',
 					'css_var'      => 'kb-btn-border-style',
 					'control_attr' => 'borderStyle',
 					'axis'         => 'border-style',
 				],
-				'button-border-color' => [
+				'button-border-color'       => [
 					'token'        => 'semantic.color.border',
 					'css_var'      => 'kb-btn-border-color',
 					'control_attr' => 'borderStyle',
@@ -635,7 +630,7 @@ return [
 				// No baseline default: an unstyled button carries no shadow, so the preset's $default omits
 				// this property entirely and the projector emits no box-shadow rule until a preset (or the
 				// user) sets one.
-				'button-shadow'       => [
+				'button-shadow'             => [
 					'token'   => 'semantic.shadow.button',
 					'css_var' => 'kb-btn-shadow',
 				],
@@ -890,7 +885,7 @@ return [
 				'label' => __( 'Section', 'kadence-blocks' ),
 			],
 			'bindings'      => [
-				'background'   => [
+				'background'        => [
 					'token'               => 'semantic.color.column-bg',
 					'css_prop'            => 'background-color',
 					'css_selector'        => '> .kt-inside-inner-col',
@@ -904,7 +899,7 @@ return [
 				// `border-color` rule on both surfaces. See the row's declaration above for the full account.
 				//
 				// @todo SOFT-4234: give the column a preset-able border trio.
-				'borderRadius' => [
+				'borderRadius'      => [
 					'token'               => 'semantic.radius.column',
 					'css_prop'            => 'border-radius',
 					'css_selector'        => '> .kt-inside-inner-col',
@@ -927,14 +922,14 @@ return [
 				// without clearing the column's own per-instance hover (three classes:
 				// `.kadence-column<uid>:hover > .kt-inside-inner-col`). Three ties that second one, and the tie
 				// breaks on source order in the block's favor.
-				'backgroundHover'     => [
+				'backgroundHover'   => [
 					'token'            => 'semantic.color.column-bg-hover',
 					'css_prop'         => 'background-color',
 					'css_state'        => ':hover > .kt-inside-inner-col.kt-inside-inner-col',
 					'editor_css_state' => ':hover > .kadence-inner-column-inner.kadence-inner-column-inner',
 					'control_attr'     => 'backgroundHover',
 				],
-				'borderHoverRadius'   => [
+				'borderHoverRadius' => [
 					'token'            => 'semantic.radius.column-hover',
 					'css_prop'         => 'border-radius',
 					'css_state'        => ':hover > .kt-inside-inner-col.kt-inside-inner-col',

--- a/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
+++ b/includes/resources/Design_Tokens/Resolver/Preset_Value_Normalizer.php
@@ -15,7 +15,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
  *
  * The editor captures concrete values (a hex, a length) from a block and sends them as literals. For each
  * value this normalizer looks for a semantic token whose resolved value matches it in the target library;
- * when one is found the literal is replaced with that token's alias (`{semantic.color.button-primary-bg}`),
+ * when one is found the literal is replaced with that token's alias (`{semantic.color.button-bg}`),
  * so a later edit to the semantic (or the primitive it points at) still cascades into the preset. A value
  * that is already an alias is left untouched, and a value with no matching semantic stays a literal.
  *

--- a/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Presets_Controller.php
@@ -1203,8 +1203,8 @@ final class Presets_Controller extends Controller {
 	 * `/default` sub-route and "order" by its `/order` sub-route, so a preset named either can never be
 	 * addressed through the per-preset item route — it would be undeletable.
 	 *
-	 * Scoped to creation, because "default" is not a hypothetical: every block but the Button ships its
-	 * baseline look as a preset slugged exactly that, and a site owner editing it is the ordinary case. A
+	 * Scoped to creation, because "default" is not a hypothetical: every block ships its baseline look as a
+	 * preset slugged exactly that, and a site owner editing it is the ordinary case. A
 	 * slug already present in the block's effective presets is therefore writable — the collision it would
 	 * cause is one the shipped data already made, and the only route it forecloses is DELETE, which that
 	 * preset should refuse anyway: it is the block's built-in look, and the editor offers deletion only for

--- a/includes/resources/Design_Tokens/Schema/Vocabulary/Alias.php
+++ b/includes/resources/Design_Tokens/Schema/Vocabulary/Alias.php
@@ -100,9 +100,9 @@ final class Alias {
 	 *
 	 * @since TBD
 	 *
-	 * @param string $id A dot-path into the document, e.g. "semantic.color.button-primary-bg".
+	 * @param string $id A dot-path into the document, e.g. "semantic.color.button-bg".
 	 *
-	 * @return string The alias string, e.g. "{semantic.color.button-primary-bg}".
+	 * @return string The alias string, e.g. "{semantic.color.button-bg}".
 	 */
 	public static function wrap( string $id ): string {
 		return '{' . $id . '}';

--- a/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
+++ b/src/extension/design-tokens/__tests__/fixtures/token-alias-conformance.json
@@ -3,7 +3,7 @@
 	"aliases": [
 		{ "alias": "{semantic.radius.media}", "cssVar": "var(--kb-token--semantic--radius--media)" },
 		{ "alias": "{primitive.color.brand.primary}", "cssVar": "var(--kb-token--primitive--color--brand--primary)" },
-		{ "alias": "{semantic.color.button-primary-bg}", "cssVar": "var(--kb-token--semantic--color--button-primary-bg)" },
+		{ "alias": "{semantic.color.button-bg}", "cssVar": "var(--kb-token--semantic--color--button-bg)" },
 		{ "alias": "{primitive.spacing.md}", "cssVar": "var(--kb-token--primitive--spacing--md)" },
 		{ "alias": "{a}", "cssVar": "var(--kb-token--a)" },
 		{ "alias": "{semantic.icon-size.default}", "cssVar": "var(--kb-token--semantic--icon-size--default)" }

--- a/src/extension/token-picker/__tests__/index.test.js
+++ b/src/extension/token-picker/__tests__/index.test.js
@@ -27,9 +27,9 @@ const POOL = {
 			role: 'color',
 		},
 		{
-			id: 'semantic.color.button-primary-bg',
-			alias: '{semantic.color.button-primary-bg}',
-			label: 'Button Primary Background',
+			id: 'semantic.color.button-bg',
+			alias: '{semantic.color.button-bg}',
+			label: 'Button Background',
 			type: 'color',
 			layer: 'semantic',
 			role: 'color',
@@ -137,7 +137,7 @@ const POOL = {
 	values: {
 		default: {
 			'primitive.color.blue-500': '#3182ce',
-			'semantic.color.button-primary-bg': '#2b6cb0',
+			'semantic.color.button-bg': '#2b6cb0',
 			'primitive.dimension.radius.sm': '4px',
 			'semantic.radius.button': '0.5rem',
 			'primitive.dimension.spacing.md': '16px',
@@ -151,7 +151,7 @@ const POOL = {
 			'primitive.dimension.border-width.sm': '1px',
 			'semantic.border-width.default': '2px',
 		},
-		brand: { 'semantic.color.button-primary-bg': '#000000' },
+		brand: { 'semantic.color.button-bg': '#000000' },
 	},
 };
 
@@ -249,9 +249,9 @@ describe('pickableTokensFor', () => {
 
 		expect(result).toEqual([
 			{
-				id: 'semantic.color.button-primary-bg',
-				alias: '{semantic.color.button-primary-bg}',
-				label: 'Button Primary Background',
+				id: 'semantic.color.button-bg',
+				alias: '{semantic.color.button-bg}',
+				label: 'Button Background',
 				value: '#2b6cb0',
 				type: 'color',
 				role: 'color',
@@ -310,9 +310,9 @@ describe('pickableTokensFor', () => {
 
 		expect(result).toEqual([
 			{
-				id: 'semantic.color.button-primary-bg',
-				alias: '{semantic.color.button-primary-bg}',
-				label: 'Button Primary Background',
+				id: 'semantic.color.button-bg',
+				alias: '{semantic.color.button-bg}',
+				label: 'Button Background',
 				value: '#000000',
 				type: 'color',
 				role: 'color',
@@ -331,7 +331,7 @@ describe('pickableTokensFor', () => {
 	it('falls back to the active library values for an unknown library slug', () => {
 		const result = pickableTokensFor('color', 'nonexistent-set');
 
-		expect(result.find((token) => token.id === 'semantic.color.button-primary-bg').value).toBe('#2b6cb0');
+		expect(result.find((token) => token.id === 'semantic.color.button-bg').value).toBe('#2b6cb0');
 	});
 
 	it('fails soft when the pool is missing, returning empty results without throwing', () => {

--- a/src/style-library/__tests__/paths.test.js
+++ b/src/style-library/__tests__/paths.test.js
@@ -122,8 +122,8 @@ describe('feedPath', () => {
 
 describe('tokenLabelPath', () => {
 	it('builds the label path for a token id', () => {
-		expect(tokenLabelPath('default', 'semantic.color.button-primary-bg')).toBe(
-			'/kb-design-tokens/v1/documents/default/labels/semantic.color.button-primary-bg'
+		expect(tokenLabelPath('default', 'semantic.color.button-bg')).toBe(
+			'/kb-design-tokens/v1/documents/default/labels/semantic.color.button-bg'
 		);
 	});
 

--- a/src/token-controls/__tests__/ColorControl.test.js
+++ b/src/token-controls/__tests__/ColorControl.test.js
@@ -181,7 +181,7 @@ describe('ColorControl', () => {
 	 * @return {void}
 	 */
 	it('shows the muted "Default" fallback when the value is bound but not one of the pickable groups', () => {
-		render({ value: '{semantic.color.button-primary-text}' });
+		render({ value: '{semantic.color.button-text}' });
 
 		expect(container.querySelector('.kb-color-control__value').textContent).toBe('Default');
 	});
@@ -193,7 +193,7 @@ describe('ColorControl', () => {
 	 * @return {void}
 	 */
 	it('renders a transparent swatch, not the raw alias, for an out-of-group value', () => {
-		render({ value: '{semantic.color.button-primary-text}' });
+		render({ value: '{semantic.color.button-text}' });
 
 		expect(container.querySelector('.kb-color-swatch').style.background).toBe('transparent');
 	});

--- a/src/token-controls/__tests__/token-css-var.test.js
+++ b/src/token-controls/__tests__/token-css-var.test.js
@@ -14,7 +14,7 @@ describe('tokenCssVar', () => {
 	});
 
 	it('leaves a dash inside a segment untouched', () => {
-		expect(tokenCssVar('semantic.color.button-primary-bg')).toBe('--kb-token--semantic--color--button-primary-bg');
+		expect(tokenCssVar('semantic.color.button-bg')).toBe('--kb-token--semantic--color--button-bg');
 	});
 
 	it('matches the shared alias-conformance fixture for a dot-path id', () => {

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -106,7 +106,7 @@ final class Feed_AssemblerTest extends TestCase {
 		$this->assertSame( Token_Store::default_slug(), $feed['slug'] );
 		$this->assertIsString( $feed['version'] );
 		$this->assertArrayHasKey( 'groups', $feed['schema'] );
-		$this->assertSame( '#3633e1', $feed['values']['semantic.color.button-primary-bg'] );
+		$this->assertSame( '#3633e1', $feed['values']['semantic.color.button-bg'] );
 		$this->assertIsArray( $feed['presets'] );
 		$this->assertIsArray( $feed['presetNav'] );
 		$this->assertIsArray( $feed['responsive'] );
@@ -126,7 +126,7 @@ final class Feed_AssemblerTest extends TestCase {
 			[
 				'semantic' => [
 					'color' => [
-						'button-primary-bg' => [
+						'button-bg' => [
 							'$type'  => 'color',
 							'$value' => '#0f7a3d',
 						],
@@ -140,7 +140,7 @@ final class Feed_AssemblerTest extends TestCase {
 		$feed = $this->assembler->for_slug( 'brand-b' );
 
 		$this->assertSame( 'brand-b', $feed['slug'] );
-		$this->assertSame( '#0f7a3d', $feed['values']['semantic.color.button-primary-bg'] );
+		$this->assertSame( '#0f7a3d', $feed['values']['semantic.color.button-bg'] );
 	}
 
 	/**
@@ -211,7 +211,7 @@ final class Feed_AssemblerTest extends TestCase {
 				'$extensions' => [
 					'com.kadence.designTokens' => [
 						'tokenLabels' => [
-							'semantic.color.button-primary-bg' => 'Cozy Button',
+							'semantic.color.button-bg' => 'Cozy Button',
 						],
 					],
 				],
@@ -226,7 +226,7 @@ final class Feed_AssemblerTest extends TestCase {
 
 		foreach ( $feed['schema']['groups'] as $entries ) {
 			foreach ( $entries as $entry ) {
-				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-primary-bg' ) {
+				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-bg' ) {
 					$found = $entry;
 					break 2;
 				}

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -131,15 +131,15 @@ final class LocalizerTest extends TestCase {
 		$this->assertTrue( $feed['resolved'] );
 		$this->assertSame( Token_Store::default_slug(), $feed['slug'] );
 
-		// Structure: the shipped button-primary-bg token reaches the schema.
+		// Structure: the shipped button-bg token reaches the schema.
 		$ids = [];
 		foreach ( $feed['schema']['groups'] as $entries ) {
 			$ids = array_merge( $ids, array_column( $entries, 'id' ) );
 		}
-		$this->assertContains( 'semantic.color.button-primary-bg', $ids );
+		$this->assertContains( 'semantic.color.button-bg', $ids );
 
 		// Values: keyed identically to the schema, the resolved hex.
-		$this->assertSame( '#3633e1', $feed['values']['semantic.color.button-primary-bg'] );
+		$this->assertSame( '#3633e1', $feed['values']['semantic.color.button-bg'] );
 
 		// REST descriptor.
 		$this->assertSame( 'kb-design-tokens/v1', $feed['rest']['namespace'] );
@@ -411,7 +411,7 @@ final class LocalizerTest extends TestCase {
 				'$extensions' => [
 					'com.kadence.designTokens' => [
 						'tokenLabels' => [
-							'semantic.color.button-primary-bg' => 'Cozy Button',
+							'semantic.color.button-bg' => 'Cozy Button',
 						],
 					],
 				],
@@ -430,7 +430,7 @@ final class LocalizerTest extends TestCase {
 
 		foreach ( $feed['schema']['groups'] as $entries ) {
 			foreach ( $entries as $entry ) {
-				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-primary-bg' ) {
+				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-bg' ) {
 					$found = $entry;
 					break 2;
 				}

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetNavTest.php
@@ -255,5 +255,4 @@ final class PresetNavTest extends TestCase {
 
 		$this->assertSame( ( new Preset_Nav( $this->registry ) )->all(), $feed['presetNav'] );
 	}
-
 }

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/PresetsTest.php
@@ -36,8 +36,8 @@ final class PresetsTest extends TestCase {
 		$button = $presets[ self::BUTTON ];
 
 		$this->assertSame( 'Style', $button['label'] );
-		$this->assertSame( 'primary', $button['default'] );
-		$this->assertSame( [ 'primary', 'secondary' ], $button['names'] );
+		$this->assertSame( 'default', $button['default'] );
+		$this->assertSame( [ 'default' ], $button['names'] );
 		$this->assertContains( 'button-bg', $button['properties'] );
 
 		// Structure: bindings carry the token reference / inline targets.
@@ -45,8 +45,7 @@ final class PresetsTest extends TestCase {
 		$this->assertArrayHasKey( 'button-bg', $button['bindings'] );
 
 		// Resolved preview values per preset — aliases flattened to their primitive color.
-		$this->assertSame( '#3633e1', $button['values']['primary']['button-bg'] );
-		$this->assertSame( '#1A202C', $button['values']['secondary']['button-bg'] );
+		$this->assertSame( '#3633e1', $button['values']['default']['button-bg'] );
 	}
 
 	public function testABlockRegisteredButAbsentFromTheDocumentIsSkipped(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Preset_CatalogTest.php
@@ -57,19 +57,14 @@ final class Preset_CatalogTest extends TestCase {
 
 		$button = $catalog['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
 
-		$this->assertSame( 'primary', $button['default'] );
+		$this->assertSame( 'default', $button['default'] );
 		// The picker's control label, declared on the preset bindings in declarations.php.
 		$this->assertSame( 'Style', $button['label'] );
 		$this->assertSame(
 			[
 				[
-					'slug'        => 'primary',
-					'label'       => 'Primary',
-					'userCreated' => false,
-				],
-				[
-					'slug'        => 'secondary',
-					'label'       => 'Secondary',
+					'slug'        => 'default',
+					'label'       => 'Default',
 					'userCreated' => false,
 				],
 			],
@@ -105,10 +100,10 @@ final class Preset_CatalogTest extends TestCase {
 	public function testItSurfacesPerPresetCssReferencesAlongsideLiterals(): void {
 		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
 
-		$this->assertArrayHasKey( 'primary', $button['references'] );
+		$this->assertArrayHasKey( 'default', $button['references'] );
 
-		$reference = $button['references']['primary']['button-bg'];
-		$literal   = $button['values']['primary']['button-bg'];
+		$reference = $button['references']['default']['button-bg'];
+		$literal   = $button['values']['default']['button-bg'];
 
 		// The reference is a var() chain; the literal is the flattened value. Both describe the same
 		// property, and the difference between them is the whole point of carrying both.
@@ -152,7 +147,7 @@ final class Preset_CatalogTest extends TestCase {
 		$flags   = wp_list_pluck( $presets, 'userCreated', 'slug' );
 
 		$this->assertTrue( $flags['accent'] );
-		$this->assertFalse( $flags['primary'] );
+		$this->assertFalse( $flags['default'] );
 	}
 
 	/**
@@ -203,10 +198,9 @@ final class Preset_CatalogTest extends TestCase {
 		$this->assertSame( 'borderRadius', $by_key['button-radius']['control_attr'] );
 
 		// Per-preset resolved values, keyed by preset slug then property id.
-		$this->assertArrayHasKey( 'primary', $button['values'] );
-		$this->assertArrayHasKey( 'secondary', $button['values'] );
-		$this->assertArrayHasKey( 'button-bg', $button['values']['primary'] );
-		$this->assertNotSame( '', $button['values']['primary']['button-bg'] );
+		$this->assertArrayHasKey( 'default', $button['values'] );
+		$this->assertArrayHasKey( 'button-bg', $button['values']['default'] );
+		$this->assertNotSame( '', $button['values']['default']['button-bg'] );
 	}
 
 	/**
@@ -333,7 +327,7 @@ final class Preset_CatalogTest extends TestCase {
 	public function testAPresetWithoutBreakpointsCarriesAnEmptyResponsiveMap(): void {
 		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
 
-		$this->assertSame( [], $button['responsive']['primary'] );
+		$this->assertSame( [], $button['responsive']['default'] );
 	}
 
 	/**
@@ -346,10 +340,10 @@ final class Preset_CatalogTest extends TestCase {
 	public function testOverriddenCarriesOnlyAPresetsOwnStoredPropertiesNotEveryResolvedOne(): void {
 		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
 
-		// "secondary" is baseline-only (never partially overridden by this test), so it has NOTHING of
-		// its own — even though `values['secondary']` resolves every bound property via the baseline.
-		$this->assertSame( [], $button['overridden']['secondary'] );
-		$this->assertNotEmpty( $button['values']['secondary'] );
+		// "default" is baseline-only (never partially overridden by this test), so it has NOTHING of
+		// its own — even though `values['default']` resolves every bound property via the baseline.
+		$this->assertSame( [], $button['overridden']['default'] );
+		$this->assertNotEmpty( $button['values']['default'] );
 	}
 
 	/**
@@ -361,14 +355,14 @@ final class Preset_CatalogTest extends TestCase {
 	public function testOverriddenReflectsAPartialStoredOverrideOfABaselinePreset(): void {
 		$this->store->save_document(
 			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
-			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+			. '"default":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
 		$button = $this->catalog->all()['libraries'][ Token_Store::default_slug() ][ self::BUTTON ];
 
-		$this->assertSame( [ 'button-bg' => true ], $button['overridden']['secondary'] );
+		$this->assertSame( [ 'button-bg' => true ], $button['overridden']['default'] );
 		// The merged/resolved value still surfaces for the un-overridden properties.
-		$this->assertNotSame( '', $button['values']['secondary']['button-text'] );
+		$this->assertNotSame( '', $button['values']['default']['button-text'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Palette/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Palette/Css_BuilderTest.php
@@ -46,11 +46,11 @@ final class Css_BuilderTest extends TestCase {
 	public function testItEmitsThePresetDeclarationsUnderTheSharedPresenceSelector(): void {
 		$css = $this->builder()->css(
 			[ 'dark' => [ '--kb-token--primitive--color--brand--primary' => '#0b1020' ] ],
-			'--kb-token--preset--kadence-singlebtn--primary--button-bg:var(--kb-token--semantic--color--button-primary-bg);'
+			'--kb-token--preset--kadence-singlebtn--default--button-bg:var(--kb-token--semantic--color--button-bg);'
 		);
 
 		$this->assertStringContainsString(
-			'[data-kb-palette]{--kb-token--preset--kadence-singlebtn--primary--button-bg:var(--kb-token--semantic--color--button-primary-bg);}',
+			'[data-kb-palette]{--kb-token--preset--kadence-singlebtn--default--button-bg:var(--kb-token--semantic--color--button-bg);}',
 			$css
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Palette/ProjectorTest.php
@@ -95,7 +95,7 @@ final class ProjectorTest extends TestCase {
 		// The semantic that aliases the re-tinted button primitive is resolved to the custom palette's color (not
 		// just the primitive) — this is what makes a block reading the semantic re-skin, and what the button's
 		// preset var chains to.
-		$this->assertStringContainsString( Css_Var::from_id( 'semantic.color.button-primary-bg' ) . ':#DD6B20;', $block );
+		$this->assertStringContainsString( Css_Var::from_id( 'semantic.color.button-bg' ) . ':#DD6B20;', $block );
 	}
 
 	/**
@@ -112,11 +112,11 @@ final class ProjectorTest extends TestCase {
 		$this->assertNotFalse( $start );
 		$block = substr( $css, (int) $start, (int) strpos( $css, '}', (int) $start ) - (int) $start + 1 );
 
-		// The Single Button's primary button-bg preset var chains to the button semantic, which the per-palette
+		// The Single Button's default button-bg preset var chains to the button semantic, which the per-palette
 		// selector re-declares — so on a palette subtree the preset follows the palette.
-		$this->assertStringContainsString( 'kadence-singlebtn--primary--button-bg', $block );
+		$this->assertStringContainsString( 'kadence-singlebtn--default--button-bg', $block );
 		$this->assertStringContainsString(
-			'var(' . Css_Var::from_id( 'semantic.color.button-primary-bg' ) . ')',
+			'var(' . Css_Var::from_id( 'semantic.color.button-bg' ) . ')',
 			$block
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -60,10 +60,12 @@ final class Css_BuilderTest extends TestCase {
 	 * @return void
 	 */
 	public function testItDefinesThePresetVarsCanonically(): void {
+		$this->seedAccentPreset();
+
 		$css = $this->builder( $this->registry )->css( 'default' );
 
-		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--primary--button-bg:var(--kb-token--semantic--color--button-primary-bg);', $css );
-		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--secondary--button-bg:var(--kb-token--semantic--color--button-secondary-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--default--button-bg:var(--kb-token--semantic--color--button-bg);', $css );
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--accent--button-bg:var(--kb-token--semantic--color--button-bg-hover);', $css );
 	}
 
 	/**
@@ -86,26 +88,28 @@ final class Css_BuilderTest extends TestCase {
 	 * @return void
 	 */
 	public function testItRetargetsButtonSlotsForANamedPreset(): void {
+		$this->seedAccentPreset();
+
 		$css = $this->builder( $this->registry )->css( 'default' );
 
 		$this->assertStringContainsString(
-			'.wp-block-kadence-singlebtn.kb-preset--secondary{'
-				. '--global-palette-btn-bg:var(--kb-token--preset--kadence-singlebtn--secondary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--preset--kadence-singlebtn--secondary--button-text);'
-				. '--global-palette-btn-bg-hover:var(--kb-token--preset--kadence-singlebtn--secondary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--preset--kadence-singlebtn--secondary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--secondary--button-radius);'
-				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-width);'
-				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--secondary--button-border-color);'
-				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--secondary--button-padding);'
-				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--secondary--button-margin);}',
+			'.wp-block-kadence-singlebtn.kb-preset--accent{'
+				. '--global-palette-btn-bg:var(--kb-token--preset--kadence-singlebtn--accent--button-bg);'
+				. '--global-palette-btn:var(--kb-token--preset--kadence-singlebtn--accent--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--preset--kadence-singlebtn--accent--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--preset--kadence-singlebtn--accent--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--accent--button-radius);'
+				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--accent--button-border-width);'
+				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--accent--button-border-style);'
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--accent--button-border-color);'
+				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--accent--button-padding);'
+				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--accent--button-margin);}',
 			$css
 		);
 	}
 
 	/**
-	 * The $default (primary) is re-emitted on the class-less block selector, so a button with no preset
+	 * The $default preset is re-emitted on the class-less block selector, so a button with no preset
 	 * selected still shows its preset look.
 	 *
 	 * @return void
@@ -115,16 +119,16 @@ final class Css_BuilderTest extends TestCase {
 
 		$this->assertStringContainsString(
 			'.wp-block-kadence-singlebtn{'
-				. '--global-palette-btn-bg:var(--kb-token--preset--kadence-singlebtn--primary--button-bg);'
-				. '--global-palette-btn:var(--kb-token--preset--kadence-singlebtn--primary--button-text);'
-				. '--global-palette-btn-bg-hover:var(--kb-token--preset--kadence-singlebtn--primary--button-bg-hover);'
-				. '--global-palette-btn-hover:var(--kb-token--preset--kadence-singlebtn--primary--button-text-hover);'
-				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--primary--button-radius);'
-				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--primary--button-border-width);'
-				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--primary--button-border-style);'
-				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--primary--button-border-color);'
-				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--primary--button-padding);'
-				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--primary--button-margin);}',
+				. '--global-palette-btn-bg:var(--kb-token--preset--kadence-singlebtn--default--button-bg);'
+				. '--global-palette-btn:var(--kb-token--preset--kadence-singlebtn--default--button-text);'
+				. '--global-palette-btn-bg-hover:var(--kb-token--preset--kadence-singlebtn--default--button-bg-hover);'
+				. '--global-palette-btn-hover:var(--kb-token--preset--kadence-singlebtn--default--button-text-hover);'
+				. '--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--default--button-radius);'
+				. '--kb-btn-border-width:var(--kb-token--preset--kadence-singlebtn--default--button-border-width);'
+				. '--kb-btn-border-style:var(--kb-token--preset--kadence-singlebtn--default--button-border-style);'
+				. '--kb-btn-border-color:var(--kb-token--preset--kadence-singlebtn--default--button-border-color);'
+				. '--kb-btn-padding:var(--kb-token--preset--kadence-singlebtn--default--button-padding);'
+				. '--kb-btn-margin:var(--kb-token--preset--kadence-singlebtn--default--button-margin);}',
 			$css
 		);
 	}
@@ -137,16 +141,18 @@ final class Css_BuilderTest extends TestCase {
 	 * @return void
 	 */
 	public function testItProjectsACssVarBindingToItsVariable(): void {
+		$this->seedAccentPreset();
+
 		$css = $this->builder( $this->registry )->css( 'default' );
 
 		// The scoped rule points --kb-btn-radius at the per-preset var.
 		$this->assertStringContainsString(
-			'--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--secondary--button-radius);',
+			'--kb-btn-radius:var(--kb-token--preset--kadence-singlebtn--accent--button-radius);',
 			$css
 		);
 		// The canonical block defines that per-preset var.
 		$this->assertStringContainsString(
-			'--kb-token--preset--kadence-singlebtn--secondary--button-radius:',
+			'--kb-token--preset--kadence-singlebtn--accent--button-radius:',
 			$css
 		);
 	}
@@ -520,9 +526,9 @@ final class Css_BuilderTest extends TestCase {
 	public function testNonPerCornerPropertiesAreUnaffectedByTheCornerVarChange(): void {
 		$css = $this->builder( $this->registry )->css( 'default' );
 
-		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--primary--button-bg:var(--kb-token--semantic--color--button-primary-bg);', $css );
-		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--primary--button-bg--top', $css );
-		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--primary--button-bg--right', $css );
+		$this->assertStringContainsString( '--kb-token--preset--kadence-singlebtn--default--button-bg:var(--kb-token--semantic--color--button-bg);', $css );
+		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--default--button-bg--top', $css );
+		$this->assertStringNotContainsString( '--kb-token--preset--kadence-singlebtn--default--button-bg--right', $css );
 	}
 
 	/**
@@ -674,6 +680,45 @@ final class Css_BuilderTest extends TestCase {
 		];
 
 		$this->store->save_document( (string) wp_json_encode( $document ), Token_Store::default_slug() );
+	}
+
+	/**
+	 * Persist a user-created "accent" button preset into the active library, covering every bound property,
+	 * so the builder has a preset other than the shipped default to scope a `.kb-preset--*` rule to.
+	 *
+	 * @return void
+	 */
+	private function seedAccentPreset(): void {
+		/** @var Token_Store $store */
+		$store = $this->container->get( Token_Store::class );
+
+		$document = [
+			'$extensions' => [
+				'com.kadence.designTokens' => [
+					'presets' => [
+						'kadence/singlebtn' => [
+							'accent' => [
+								'label'  => 'Accent',
+								'tokens' => [
+									'button-bg'           => '{semantic.color.button-bg-hover}',
+									'button-text'         => '{semantic.color.button-text}',
+									'button-bg-hover'     => '{semantic.color.button-bg}',
+									'button-text-hover'   => '{semantic.color.button-text-hover}',
+									'button-radius'       => '{semantic.radius.control}',
+									'button-border-width' => '{semantic.border-width.default}',
+									'button-border-style' => '{semantic.border-style.default}',
+									'button-border-color' => '{semantic.color.border}',
+									'button-padding'      => [ '0.4em', '1em', '0.4em', '1em' ],
+									'button-margin'       => [ '0', '0', '0', '0' ],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$store->save_document( (string) wp_json_encode( $document ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/ProjectorTest.php
@@ -63,8 +63,8 @@ final class ProjectorTest extends TestCase {
 
 		$css = implode( '', (array) wp_styles()->get_data( 'kadence-blocks-global-variables', 'after' ) );
 
-		$this->assertStringContainsString( '.wp-block-kadence-singlebtn.kb-preset--primary{', $css );
-		$this->assertStringContainsString( '--global-palette1:var(--kb-token--preset--kadence-singlebtn--primary--button-bg', $css );
+		$this->assertStringContainsString( '.wp-block-kadence-singlebtn.kb-preset--default{', $css );
+		$this->assertStringContainsString( '--global-palette1:var(--kb-token--preset--kadence-singlebtn--default--button-bg', $css );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Json_Baseline_DocumentTest.php
@@ -37,8 +37,8 @@ final class Json_Baseline_DocumentTest extends TestCase {
 		$baseline = new Json_Baseline_Document( self::BASELINE_PATH, 'test-registered' );
 
 		// Shipped semantic tokens declarations.php registers must resolve, or the guard fails.
-		$this->assertTrue( $baseline->has( 'semantic.color.button-primary-bg' ) );
-		$this->assertTrue( $baseline->has( 'semantic.color.button-primary-text' ) );
+		$this->assertTrue( $baseline->has( 'semantic.color.button-bg' ) );
+		$this->assertTrue( $baseline->has( 'semantic.color.button-text' ) );
 	}
 
 	public function testHasIsTrueForPrimitiveAndCompositeLeaves(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/RegistrationHelperTest.php
@@ -51,8 +51,8 @@ final class RegistrationHelperTest extends TestCase {
 	}
 
 	public function testDeclarationsFileRegisteredTheExampleTokens(): void {
-		$this->assertTrue( $this->registry->has( 'semantic.color.button-primary-bg' ) );
-		$this->assertTrue( $this->registry->has( 'semantic.color.button-primary-text' ) );
+		$this->assertTrue( $this->registry->has( 'semantic.color.button-bg' ) );
+		$this->assertTrue( $this->registry->has( 'semantic.color.button-text' ) );
 	}
 
 	public function testDeclarationsFileRegisteredTheButtonPresetBindings(): void {

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PresetsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_PresetsTest.php
@@ -42,9 +42,8 @@ final class Effective_PresetsTest extends TestCase {
 		$node = $this->presets->block( self::BUTTON );
 
 		$this->assertIsArray( $node );
-		$this->assertSame( 'primary', $node['$default'] );
-		$this->assertArrayHasKey( 'primary', $node );
-		$this->assertArrayHasKey( 'secondary', $node );
+		$this->assertSame( 'default', $node['$default'] );
+		$this->assertArrayHasKey( 'default', $node );
 	}
 
 	/**
@@ -62,26 +61,25 @@ final class Effective_PresetsTest extends TestCase {
 		// The override-only preset appears next to the baseline ones.
 		$this->assertArrayHasKey( 'outline', $node );
 		$this->assertSame( 'Outline', $node['outline']['label'] );
-		$this->assertArrayHasKey( 'primary', $node );
-		$this->assertArrayHasKey( 'secondary', $node );
+		$this->assertArrayHasKey( 'default', $node );
 	}
 
 	/**
 	 * @return void
 	 */
 	public function testAStoredOverrideMergesIntoAPresetsTokensPerProperty(): void {
-		// Override just one property of the baseline "secondary" preset.
+		// Override just one property of the baseline "default" preset.
 		$this->store->save_document(
 			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
-			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+			. '"default":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
-		$secondary = $this->presets->block( self::BUTTON )['secondary'];
+		$default = $this->presets->block( self::BUTTON )['default'];
 
 		// The overridden property wins; the preset's other baseline tokens and its label survive.
-		$this->assertSame( '#000000', $secondary['tokens']['button-bg'] );
-		$this->assertSame( '{semantic.color.button-secondary-text}', $secondary['tokens']['button-text'] );
-		$this->assertSame( 'Secondary', $secondary['label'] );
+		$this->assertSame( '#000000', $default['tokens']['button-bg'] );
+		$this->assertSame( '{semantic.color.button-text}', $default['tokens']['button-text'] );
+		$this->assertSame( 'Default', $default['label'] );
 	}
 
 	/**
@@ -103,7 +101,7 @@ final class Effective_PresetsTest extends TestCase {
 		$section = $this->presets->for_overrides( $candidate );
 
 		$this->assertArrayHasKey( 'outline', $section[ self::BUTTON ] );
-		$this->assertArrayHasKey( 'primary', $section[ self::BUTTON ] );
+		$this->assertArrayHasKey( 'default', $section[ self::BUTTON ] );
 		// The store was never written.
 		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
 	}
@@ -126,15 +124,14 @@ final class Effective_PresetsTest extends TestCase {
 		$this->store->save_document(
 			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
 			. '"outline":{"label":"Outline","tokens":{"button-bg":"transparent"}},'
-			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+			. '"default":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
 		$user_created = $this->presets->user_created( self::BUTTON, 'default' );
 
 		$this->assertContains( 'outline', $user_created );
-		$this->assertNotContains( 'primary', $user_created );
-		// "secondary" shadows a baseline preset, so it is not user-created.
-		$this->assertNotContains( 'secondary', $user_created );
+		// "default" shadows the baseline preset, so it is not user-created.
+		$this->assertNotContains( 'default', $user_created );
 	}
 
 	/**
@@ -144,7 +141,7 @@ final class Effective_PresetsTest extends TestCase {
 	 * @return void
 	 */
 	public function testStoredTokensIsEmptyForABaselinePresetWithNoStoredOverridesRow(): void {
-		$this->assertSame( [], $this->presets->stored_tokens( self::BUTTON, 'secondary' ) );
+		$this->assertSame( [], $this->presets->stored_tokens( self::BUTTON, 'default' ) );
 	}
 
 	/**
@@ -156,10 +153,10 @@ final class Effective_PresetsTest extends TestCase {
 	public function testStoredTokensSurfacesOnlyTheOverriddenPropertyOfAPartiallyOverriddenPreset(): void {
 		$this->store->save_document(
 			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
-			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+			. '"default":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
-		$stored = $this->presets->stored_tokens( self::BUTTON, 'secondary' );
+		$stored = $this->presets->stored_tokens( self::BUTTON, 'default' );
 
 		$this->assertSame( [ 'button-bg' => '#000000' ], $stored );
 		$this->assertArrayNotHasKey( 'button-text', $stored );

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_ResolverTest.php
@@ -27,27 +27,23 @@ final class Preset_ResolverTest extends TestCase {
 		$this->resolver = $this->container->get( Preset_Resolver::class );
 	}
 
-	public function testItResolvesAliasBindingsForSecondary(): void {
-		$values = $this->resolver->resolve_literal( self::BUTTON, 'secondary' );
+	/**
+	 * Every aliased binding on the shipped preset flattens through the token graph to its primitive leaf.
+	 *
+	 * @return void
+	 */
+	public function testItFlattensMultiHopAliasesForTheDefaultPreset(): void {
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'default' );
 
-		// Aliases flatten through the token graph. Secondary is the dark/charcoal identity.
-		$this->assertSame( '#1A202C', $values['button-bg'] );           // {semantic.color.button-secondary-bg} -> neutral.900
-		$this->assertSame( '#ffffff', $values['button-text'] );         // {semantic.color.button-secondary-text} -> neutral.0
-		$this->assertSame( '#2D3748', $values['button-bg-hover'] );     // {semantic.color.button-secondary-bg-hover} -> neutral.700
-		$this->assertSame( '#ffffff', $values['button-text-hover'] );   // {semantic.color.button-secondary-text-hover} -> neutral.0
-		$this->assertSame( '0.1875rem', $values['button-radius'] );     // {semantic.radius.control} -> radius.sm (the button's long-standing 3px)
-	}
-
-	public function testItFlattensMultiHopAliasesForThePrimaryPreset(): void {
-		$values = $this->resolver->resolve_literal( self::BUTTON, 'primary' );
-
-		// button-bg -> {semantic.color.button-primary-bg} -> {primitive.color.brand.button} -> #3633e1
+		// button-bg -> {semantic.color.button-bg} -> {primitive.color.brand.button} -> #3633e1
 		$this->assertSame( '#3633e1', $values['button-bg'] );
-		// button-text -> {semantic.color.button-primary-text} -> {primitive.color.neutral.0} -> #ffffff
+		// button-text -> {semantic.color.button-text} -> {primitive.color.neutral.0} -> #ffffff
 		$this->assertSame( '#ffffff', $values['button-text'] );
-		// Hover -> {semantic.color.button-primary-bg-hover} -> {primitive.color.brand.button-hover} -> #2f2ffc
+		// Hover -> {semantic.color.button-bg-hover} -> {primitive.color.brand.button-hover} -> #2f2ffc
 		$this->assertSame( '#2f2ffc', $values['button-bg-hover'] );
 		$this->assertSame( '#ffffff', $values['button-text-hover'] );
+		// {semantic.radius.control} -> the button's long-standing 3px.
+		$this->assertSame( '0.1875rem', $values['button-radius'] );
 	}
 
 	/**
@@ -59,15 +55,15 @@ final class Preset_ResolverTest extends TestCase {
 	 * @return void
 	 */
 	public function testResolvePreservesAliasIndirection(): void {
-		$projected = $this->resolver->resolve( self::BUTTON, 'primary' );
+		$projected = $this->resolver->resolve( self::BUTTON, 'default' );
 
-		$this->assertSame( 'var(--kb-token--semantic--color--button-primary-bg)', $projected['button-bg'] );
-		$this->assertSame( 'var(--kb-token--semantic--color--button-primary-text)', $projected['button-text'] );
-		$this->assertSame( 'var(--kb-token--semantic--color--button-primary-bg-hover)', $projected['button-bg-hover'] );
+		$this->assertSame( 'var(--kb-token--semantic--color--button-bg)', $projected['button-bg'] );
+		$this->assertSame( 'var(--kb-token--semantic--color--button-text)', $projected['button-text'] );
+		$this->assertSame( 'var(--kb-token--semantic--color--button-bg-hover)', $projected['button-bg-hover'] );
 		$this->assertSame( 'var(--kb-token--semantic--radius--control)', $projected['button-radius'] );
 
 		// The literal form is still available for the concrete-value surfaces — both forms are exposed.
-		$this->assertSame( '#3633e1', $this->resolver->resolve_literal( self::BUTTON, 'primary' )['button-bg'] );
+		$this->assertSame( '#3633e1', $this->resolver->resolve_literal( self::BUTTON, 'default' )['button-bg'] );
 	}
 
 	/**
@@ -77,44 +73,43 @@ final class Preset_ResolverTest extends TestCase {
 	 */
 	public function testResolveAndResolveLiteralShareTheInclusionSet(): void {
 		$this->assertSame(
-			array_keys( $this->resolver->resolve_literal( self::BUTTON, 'secondary' ) ),
-			array_keys( $this->resolver->resolve( self::BUTTON, 'secondary' ) )
+			array_keys( $this->resolver->resolve_literal( self::BUTTON, 'default' ) ),
+			array_keys( $this->resolver->resolve( self::BUTTON, 'default' ) )
 		);
 	}
 
 	public function testResolveDefaultUsesTheDeclaredDefault(): void {
-		// The baseline's $default for the button is "primary"; resolve_default() returns literals.
+		// The baseline's $default for the button is "default"; resolve_default() returns literals.
 		$this->assertSame(
-			$this->resolver->resolve_literal( self::BUTTON, 'primary' ),
+			$this->resolver->resolve_literal( self::BUTTON, 'default' ),
 			$this->resolver->resolve_default( self::BUTTON )
 		);
 	}
 
 	public function testItListsTheDocumentsPresetNames(): void {
-		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON ) );
+		$this->assertSame( [ 'default' ], $this->resolver->names( self::BUTTON ) );
 	}
 
 	public function testDefaultPresetReadsTheDollarDefault(): void {
-		$this->assertSame( 'primary', $this->resolver->default_preset( self::BUTTON ) );
+		$this->assertSame( 'default', $this->resolver->default_preset( self::BUTTON ) );
 	}
 
 	public function testHasPreset(): void {
-		$this->assertTrue( $this->resolver->has_preset( self::BUTTON, 'secondary' ) );
+		$this->assertTrue( $this->resolver->has_preset( self::BUTTON, 'default' ) );
 		// "ghost" is not a V1 Button preset (the native Outline style covers it).
 		$this->assertFalse( $this->resolver->has_preset( self::BUTTON, 'ghost' ) );
 		// Unknown block is false, not an error.
-		$this->assertFalse( $this->resolver->has_preset( 'kadence/nope', 'primary' ) );
+		$this->assertFalse( $this->resolver->has_preset( 'kadence/nope', 'default' ) );
 	}
 
 	public function testItReadsAPresetLabelFromTheDocument(): void {
-		$this->assertSame( 'Secondary', $this->resolver->label( self::BUTTON, 'secondary' ) );
-		$this->assertSame( 'Primary', $this->resolver->label( self::BUTTON, 'primary' ) );
+		$this->assertSame( 'Default', $this->resolver->label( self::BUTTON, 'default' ) );
 	}
 
 	public function testLabelIsNullForAnUnknownPresetOrBlock(): void {
 		// A non-throwing lookup, mirroring has_preset().
 		$this->assertNull( $this->resolver->label( self::BUTTON, 'ghost' ) );
-		$this->assertNull( $this->resolver->label( 'kadence/nope', 'primary' ) );
+		$this->assertNull( $this->resolver->label( 'kadence/nope', 'default' ) );
 	}
 
 	public function testValuePropertiesAreTheUnionAcrossPresets(): void {
@@ -235,7 +230,7 @@ final class Preset_ResolverTest extends TestCase {
 	public function testItThrowsForAnUnknownBlock(): void {
 		$this->expectException( Unknown_Preset_Exception::class );
 
-		$this->resolver->resolve( 'kadence/not-a-block', 'primary' );
+		$this->resolver->resolve( 'kadence/not-a-block', 'default' );
 	}
 
 	public function testItThrowsForAnUnknownPreset(): void {
@@ -265,7 +260,7 @@ final class Preset_ResolverTest extends TestCase {
 			]
 		);
 
-		$this->assertSame( [ 'primary', 'secondary', 'accent' ], $this->resolver->names( self::BUTTON ) );
+		$this->assertSame( [ 'default', 'accent' ], $this->resolver->names( self::BUTTON ) );
 		$this->assertTrue( $this->resolver->has_preset( self::BUTTON, 'accent' ) );
 		$this->assertSame( 'Accent', $this->resolver->label( self::BUTTON, 'accent' ) );
 
@@ -309,9 +304,9 @@ final class Preset_ResolverTest extends TestCase {
 	 * @return void
 	 */
 	public function testAStoredOverrideWinsOverTheBaselinePresetValue(): void {
-		$this->seedPreset( Token_Store::default_slug(), 'secondary', 'Secondary', [ 'button-bg' => '#000000' ] );
+		$this->seedPreset( Token_Store::default_slug(), 'default', 'Default', [ 'button-bg' => '#000000' ] );
 
-		$values = $this->resolver->resolve_literal( self::BUTTON, 'secondary' );
+		$values = $this->resolver->resolve_literal( self::BUTTON, 'default' );
 
 		// The overridden property takes the stored value.
 		$this->assertSame( '#000000', $values['button-bg'] );
@@ -344,7 +339,7 @@ final class Preset_ResolverTest extends TestCase {
 
 		// The default library never saw the write.
 		$this->assertFalse( $this->resolver->has_preset( self::BUTTON, 'accent', 'default' ) );
-		$this->assertSame( [ 'primary', 'secondary' ], $this->resolver->names( self::BUTTON, 'default' ) );
+		$this->assertSame( [ 'default' ], $this->resolver->names( self::BUTTON, 'default' ) );
 	}
 
 	/**
@@ -510,7 +505,7 @@ final class Preset_ResolverTest extends TestCase {
 	 * @return void
 	 */
 	public function testAPresetWithNoResponsiveEntriesResolvesEmpty(): void {
-		$this->assertSame( [], $this->resolver->resolve_responsive( self::BUTTON, 'primary' ) );
+		$this->assertSame( [], $this->resolver->resolve_responsive( self::BUTTON, 'default' ) );
 	}
 
 	/**
@@ -703,7 +698,7 @@ final class Preset_ResolverTest extends TestCase {
 			'Aliased',
 			[
 				'button-shadow' => [
-					'color'   => '{semantic.color.button-primary-bg}',
+					'color'   => '{semantic.color.button-bg}',
 					'offsetX' => '0px',
 					'offsetY' => '2px',
 					'blur'    => '8px',
@@ -715,7 +710,7 @@ final class Preset_ResolverTest extends TestCase {
 		$values = $this->resolver->resolve( self::BUTTON, 'aliased-shadow' );
 
 		$this->assertSame(
-			'0px 2px 8px 0px var(--kb-token--semantic--color--button-primary-bg)',
+			'0px 2px 8px 0px var(--kb-token--semantic--color--button-bg)',
 			$values['button-shadow']
 		);
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Preset_Value_NormalizerTest.php
@@ -92,9 +92,9 @@ final class Preset_Value_NormalizerTest extends TestCase {
 	 * @return void
 	 */
 	public function testItLeavesAnExistingAliasUnchanged(): void {
-		$result = $this->normalizer->normalize( [ 'button-bg' => '{semantic.color.button-primary-bg}' ], self::SET );
+		$result = $this->normalizer->normalize( [ 'button-bg' => '{semantic.color.button-bg}' ], self::SET );
 
-		$this->assertSame( '{semantic.color.button-primary-bg}', $result['button-bg'] );
+		$this->assertSame( '{semantic.color.button-bg}', $result['button-bg'] );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -651,7 +651,7 @@ final class Token_ResolverTest extends TestCase {
 
 		$before = $resolver->resolve();
 
-		$this->assertSame( '#3633e1', $before->value( 'semantic.color.button-primary-bg' ) );
+		$this->assertSame( '#3633e1', $before->value( 'semantic.color.button-bg' ) );
 
 		$store->save_document(
 			(string) wp_json_encode(
@@ -672,7 +672,7 @@ final class Token_ResolverTest extends TestCase {
 
 		$after = $resolver->resolve();
 
-		$this->assertSame( '#FF0000', $after->value( 'semantic.color.button-primary-bg' ) );
+		$this->assertSame( '#FF0000', $after->value( 'semantic.color.button-bg' ) );
 	}
 
 	/**
@@ -686,8 +686,8 @@ final class Token_ResolverTest extends TestCase {
 		/** @var Token_Store $store */
 		$store = $this->container->get( Token_Store::class );
 
-		// Empty store: button-primary-bg resolves through the shipped baseline to brand.button (#3633e1).
-		$this->assertSame( '#3633e1', $resolver->resolve()->value( 'semantic.color.button-primary-bg' ) );
+		// Empty store: button-bg resolves through the shipped baseline to brand.button (#3633e1).
+		$this->assertSame( '#3633e1', $resolver->resolve()->value( 'semantic.color.button-bg' ) );
 
 		// Override brand.button; the write bumps the store version, invalidating the per-request memo.
 		$store->save_document(
@@ -707,7 +707,7 @@ final class Token_ResolverTest extends TestCase {
 			)
 		);
 
-		$this->assertSame( '#000000', $resolver->resolve()->value( 'semantic.color.button-primary-bg' ) );
+		$this->assertSame( '#000000', $resolver->resolve()->value( 'semantic.color.button-bg' ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/DocumentsControllerLabelsTest.php
@@ -35,7 +35,7 @@ final class DocumentsControllerLabelsTest extends TestCase {
 	 *
 	 * @var string
 	 */
-	private const BASELINE_ID = 'semantic.color.button-primary-bg';
+	private const BASELINE_ID = 'semantic.color.button-bg';
 
 	/**
 	 * @since TBD

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Feed_ControllerTest.php
@@ -135,7 +135,7 @@ final class Feed_ControllerTest extends TestCase {
 		$this->assertTrue( $data['active'] );
 		$this->assertTrue( $data['resolved'] );
 		$this->assertSame( Token_Store::default_slug(), $data['slug'] );
-		$this->assertSame( '#3633e1', $data['values']['semantic.color.button-primary-bg'] );
+		$this->assertSame( '#3633e1', $data['values']['semantic.color.button-bg'] );
 	}
 
 	/**
@@ -149,7 +149,7 @@ final class Feed_ControllerTest extends TestCase {
 			[
 				'semantic' => [
 					'color' => [
-						'button-primary-bg' => [
+						'button-bg' => [
 							'$type'  => 'color',
 							'$value' => '#0f7a3d',
 						],
@@ -170,7 +170,7 @@ final class Feed_ControllerTest extends TestCase {
 
 		$data = $response->get_data();
 		$this->assertSame( 'brand-b', $data['slug'] );
-		$this->assertSame( '#0f7a3d', $data['values']['semantic.color.button-primary-bg'] );
+		$this->assertSame( '#0f7a3d', $data['values']['semantic.color.button-bg'] );
 	}
 
 	/**
@@ -220,7 +220,7 @@ final class Feed_ControllerTest extends TestCase {
 				'$extensions' => [
 					'com.kadence.designTokens' => [
 						'tokenLabels' => [
-							'semantic.color.button-primary-bg' => 'Cozy Button',
+							'semantic.color.button-bg' => 'Cozy Button',
 						],
 					],
 				],
@@ -238,7 +238,7 @@ final class Feed_ControllerTest extends TestCase {
 
 		foreach ( $data['schema']['groups'] as $entries ) {
 			foreach ( $entries as $entry ) {
-				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-primary-bg' ) {
+				if ( ( $entry['id'] ?? '' ) === 'semantic.color.button-bg' ) {
 					$found = $entry;
 					break 2;
 				}
@@ -986,7 +986,7 @@ final class Feed_ControllerTest extends TestCase {
 			[
 				'semantic' => [
 					'color' => [
-						'button-primary-bg' => [
+						'button-bg' => [
 							'$type'  => 'color',
 							'$value' => '#0f7a3d',
 						],

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -146,7 +146,7 @@ final class PresetsControllerTest extends TestCase {
 		$blocks = wp_list_pluck( $response->get_data()['blocks'], 'default', 'block' );
 
 		$this->assertArrayHasKey( self::BUTTON, $blocks );
-		$this->assertSame( 'primary', $blocks[ self::BUTTON ] );
+		$this->assertSame( 'default', $blocks[ self::BUTTON ] );
 	}
 
 	/**
@@ -160,9 +160,8 @@ final class PresetsControllerTest extends TestCase {
 		$data = $response->get_data();
 
 		$this->assertSame( self::BUTTON, $data['block'] );
-		$this->assertSame( 'primary', $data['default'] );
-		$this->assertArrayHasKey( 'primary', $data['presets'] );
-		$this->assertArrayHasKey( 'secondary', $data['presets'] );
+		$this->assertSame( 'default', $data['default'] );
+		$this->assertArrayHasKey( 'default', $data['presets'] );
 	}
 
 	/**
@@ -202,8 +201,8 @@ final class PresetsControllerTest extends TestCase {
 	public function testGetItemReportsNoOverriddenPropertiesForAFreshBaselinePreset(): void {
 		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
 
-		$this->assertSame( [], $data['presets']['secondary']['overridden'] );
-		$this->assertNotEmpty( $data['presets']['secondary']['tokens'] );
+		$this->assertSame( [], $data['presets']['default']['overridden'] );
+		$this->assertNotEmpty( $data['presets']['default']['tokens'] );
 	}
 
 	/**
@@ -215,13 +214,13 @@ final class PresetsControllerTest extends TestCase {
 	public function testGetItemReflectsAPartialStoredOverrideInOverridden(): void {
 		$this->store->save_document(
 			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
-			. '"secondary":{"tokens":{"button-bg":"#000000"}}}}}}}'
+			. '"default":{"tokens":{"button-bg":"#000000"}}}}}}}'
 		);
 
 		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
 
-		$this->assertSame( [ 'button-bg' => true ], $data['presets']['secondary']['overridden'] );
-		$this->assertNotSame( '', $data['presets']['secondary']['tokens']['button-text'] );
+		$this->assertSame( [ 'button-bg' => true ], $data['presets']['default']['overridden'] );
+		$this->assertNotSame( '', $data['presets']['default']['tokens']['button-text'] );
 	}
 
 	/**
@@ -266,12 +265,14 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
-	 * Minting a NEW preset under a reserved slug is still refused: the per-preset item route could never
-	 * address it, so it would be undeletable. The Button ships no "default", so this is a creation.
+	 * Writing the reserved "default" slug is allowed when the block already ships a preset under it: the
+	 * write is a merge onto the shipped preset, not the creation of one the per-preset item route could
+	 * never address. Editing a block's built-in look is the ordinary case, so it must not hit the
+	 * reserved-slug guard.
 	 *
 	 * @return void
 	 */
-	public function testCreatingANewPresetUnderAReservedSlugIsRefused(): void {
+	public function testWritingTheShippedDefaultSlugIsAMergeNotARefusedCreation(): void {
 		$response = $this->controller->create_item(
 			$this->block_request(
 				WP_REST_Server::CREATABLE,
@@ -284,8 +285,13 @@ final class PresetsControllerTest extends TestCase {
 			)
 		);
 
-		$this->assertInstanceOf( WP_Error::class, $response );
-		$this->assertSame( 'rest_design_tokens_reserved_slug', $response->get_error_code() );
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+
+		$data = $response->get_data();
+
+		// It merged onto the shipped preset rather than minting a user-created one.
+		$this->assertArrayHasKey( 'default', $data['presets'] );
+		$this->assertNotContains( 'default', $data['userCreated'] );
 	}
 
 	/**
@@ -335,11 +341,10 @@ final class PresetsControllerTest extends TestCase {
 
 		$data = $response->get_data();
 
-		// The new preset lands while the baseline siblings and the default survive.
+		// The new preset lands while the baseline sibling and the default survive.
 		$this->assertArrayHasKey( 'outline', $data['presets'] );
-		$this->assertArrayHasKey( 'primary', $data['presets'] );
-		$this->assertArrayHasKey( 'secondary', $data['presets'] );
-		$this->assertSame( 'primary', $data['default'] );
+		$this->assertArrayHasKey( 'default', $data['presets'] );
+		$this->assertSame( 'default', $data['default'] );
 	}
 
 	/**
@@ -380,17 +385,17 @@ final class PresetsControllerTest extends TestCase {
 				WP_REST_Server::CREATABLE,
 				self::BUTTON,
 				[
-					'preset' => 'primary',
-					'label'  => 'Renamed Primary',
+					'preset' => 'default',
+					'label'  => 'Renamed Default',
 				]
 			)
 		);
 
 		$data = $response->get_data();
 
-		$this->assertNotContains( 'primary', $data['userCreated'] );
-		$this->assertSame( 'Renamed Primary', $data['presets']['primary']['label'] );
-		$this->assertNotEmpty( $data['presets']['primary']['tokens'] );
+		$this->assertNotContains( 'default', $data['userCreated'] );
+		$this->assertSame( 'Renamed Default', $data['presets']['default']['label'] );
+		$this->assertNotEmpty( $data['presets']['default']['tokens'] );
 	}
 
 	/**
@@ -531,7 +536,7 @@ final class PresetsControllerTest extends TestCase {
 		// The override "dashed" is dropped; "outline" survives. Baseline presets always remain visible.
 		$this->assertArrayNotHasKey( 'dashed', $data['presets'] );
 		$this->assertArrayHasKey( 'outline', $data['presets'] );
-		$this->assertArrayHasKey( 'primary', $data['presets'] );
+		$this->assertArrayHasKey( 'default', $data['presets'] );
 	}
 
 	/**
@@ -560,7 +565,7 @@ final class PresetsControllerTest extends TestCase {
 
 		// The override is gone; the block renders its baseline presets again.
 		$this->assertArrayNotHasKey( 'outline', $data['presets'] );
-		$this->assertArrayHasKey( 'primary', $data['presets'] );
+		$this->assertArrayHasKey( 'default', $data['presets'] );
 	}
 
 	/**
@@ -634,10 +639,12 @@ final class PresetsControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testSetDefaultToAnExistingPreset(): void {
-		$response = $this->controller->set_default( $this->default_request( self::BUTTON, 'secondary' ) );
+		$this->createAccentPreset();
+
+		$response = $this->controller->set_default( $this->default_request( self::BUTTON, 'accent' ) );
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertSame( 'secondary', $response->get_data()['default'] );
+		$this->assertSame( 'accent', $response->get_data()['default'] );
 	}
 
 	/**
@@ -658,7 +665,7 @@ final class PresetsControllerTest extends TestCase {
 		$data = $this->controller->get_default( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
 
 		$this->assertSame( self::BUTTON, $data['block'] );
-		$this->assertSame( 'primary', $data['default'] );
+		$this->assertSame( 'default', $data['default'] );
 	}
 
 	/**
@@ -1117,7 +1124,7 @@ final class PresetsControllerTest extends TestCase {
 				self::BUTTON,
 				[
 					'preset' => 'accent',
-					// #3633e1 matches the primary button background semantic; the rgba value matches nothing.
+					// #3633e1 matches the button background semantic; the rgba value matches nothing.
 					'tokens' => $this->button_tokens(
 						[
 							'button-bg'   => '#3633e1',
@@ -1330,250 +1337,6 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
-	 * Creating a preset named "default" is rejected: the slug is reserved for the block's default sub-route
-	 * and could never be deleted or set through the dedicated route.
-	 *
-	 * @return void
-	 */
-	public function testCreatingAPresetNamedDefaultIsRejected(): void {
-		$result = $this->controller->create_item(
-			$this->block_request(
-				WP_REST_Server::CREATABLE,
-				self::BUTTON,
-				[
-					'preset' => 'default',
-					'tokens' => $this->button_tokens(),
-				]
-			)
-		);
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'rest_design_tokens_reserved_slug', $result->get_error_code() );
-		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testAMalformedPresetShapeReturns422(): void {
-		$result = $this->controller->update_item(
-			$this->block_request( 'PUT', self::BUTTON, [ 'presets' => [ 'bad' => 'not-an-object' ] ] )
-		);
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
-		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testAnEmptyPresetSlugIsRejected(): void {
-		// An empty key in the presets map would store a preset node keyed by "" — reject it, mirroring the
-		// documents controller's empty dot-path-segment guard.
-		$result = $this->controller->update_item(
-			$this->block_request( 'PUT', self::BUTTON, [ 'presets' => [ '' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ] ] )
-		);
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
-		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
-		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testWritesAreDeniedToUsersWithoutTheCapability(): void {
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
-
-		$request = new WP_REST_Request( WP_REST_Server::CREATABLE );
-
-		$this->assertInstanceOf( WP_Error::class, $this->controller->create_item_permissions_check( $request ) );
-		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
-		$this->assertInstanceOf( WP_Error::class, $this->controller->delete_item_permissions_check( $request ) );
-	}
-
-	/**
-	 * A committed write re-hashes the library version so downstream caches invalidate.
-	 *
-	 * @return void
-	 */
-	public function testAWriteBumpsTheVersion(): void {
-		$this->store->save_document(
-			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
-			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
-		);
-
-		$version_before = $this->store->get_version( Token_Store::default_slug() );
-
-		$this->controller->create_item(
-			$this->block_request(
-				WP_REST_Server::CREATABLE,
-				self::BUTTON,
-				[
-					'preset' => 'dashed',
-					'tokens' => $this->button_tokens(),
-				]
-			)
-		);
-
-		$this->assertNotSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
-	}
-
-	/**
-	 * @return void
-	 */
-	public function testReadRoutesAreGatedByTheCapability(): void {
-		$request = new WP_REST_Request( WP_REST_Server::READABLE );
-
-		// Both read callbacks gate the routes (get_items for the collection, get_item for a single block and
-		// its default), so both must deny a user without the capability and allow one that has it.
-		$checks = [ 'get_items_permissions_check', 'get_item_permissions_check' ];
-
-		// A logged-out user is denied.
-		wp_set_current_user( 0 );
-
-		foreach ( $checks as $check ) {
-			$result = $this->controller->$check( $request );
-
-			$this->assertInstanceOf( WP_Error::class, $result, "$check should deny a logged-out user." );
-			$this->assertSame( 'rest_forbidden', $result->get_error_code() );
-		}
-
-		// An authenticated user without edit_theme_options is denied.
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
-
-		foreach ( $checks as $check ) {
-			$result = $this->controller->$check( $request );
-
-			$this->assertInstanceOf( WP_Error::class, $result, "$check should deny a subscriber." );
-			$this->assertSame( 'rest_forbidden', $result->get_error_code() );
-		}
-
-		// An administrator (edit_theme_options) is allowed.
-		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
-
-		foreach ( $checks as $check ) {
-			$this->assertTrue( $this->controller->$check( $request ), "$check should allow an administrator." );
-		}
-	}
-
-	// -------------------------------------------------------------------------
-	// preset display order
-	// -------------------------------------------------------------------------
-
-	/**
-	 * The order sub-route is registered with PUT and DELETE, alongside the rest of the block routes.
-	 *
-	 * @return void
-	 */
-	public function testTheOrderRouteIsRegistered(): void {
-		$namespace   = $this->controller_namespace();
-		$base        = $this->controller_rest_base();
-		$block_route = $this->controller_constant( 'BLOCK_ROUTE' );
-		$order_route = $this->controller_constant( 'ORDER_ROUTE' );
-
-		$route = "/$namespace/$base/$block_route/$order_route";
-
-		$this->assertArrayHasKey( $route, $this->rest_server->get_routes() );
-		$this->assertContains( 'PUT', $this->route_methods( $route ) );
-		$this->assertContains( 'DELETE', $this->route_methods( $route ) );
-	}
-
-	/**
-	 * A PUT to the order sub-route persists a new order for two BASELINE preset slugs (primary and
-	 * secondary) — the case fact 5 of the plan overview proves impossible through a PUT-the-collection
-	 * "reorder", since `Effective_Presets` always reads baseline-defined slugs back in baseline order
-	 * regardless of the order overrides were written in.
-	 *
-	 * @return void
-	 */
-	public function testSetOrderMovesBaselineSlugs(): void {
-		$response = $this->controller->set_order( $this->order_request( self::BUTTON, [ 'secondary', 'primary' ] ) );
-
-		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $response->get_data()['presets'] ) );
-
-		// The order survives a fresh read.
-		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
-		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $data['presets'] ) );
-	}
-
-	/**
-	 * A slug the block does not effectively define is pruned from the submitted order silently, rather
-	 * than rejected — the order write is advisory, mirroring the documents controller's token-order route.
-	 *
-	 * @return void
-	 */
-	public function testSetOrderSilentlyPrunesAnUnknownSlug(): void {
-		$response = $this->controller->set_order(
-			$this->order_request( self::BUTTON, [ 'secondary', 'does-not-exist', 'primary' ] )
-		);
-
-		$this->assertInstanceOf( WP_REST_Response::class, $response );
-		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $response->get_data()['presets'] ) );
-	}
-
-	/**
-	 * A version that no longer matches the stored version is rejected with HTTP 409, so a client working
-	 * from a stale read cannot silently clobber a concurrent write.
-	 *
-	 * @return void
-	 */
-	public function testSetOrderRejectsAStaleVersionWith409(): void {
-		$result = $this->controller->set_order(
-			$this->order_request( self::BUTTON, [ 'secondary', 'primary' ], 'a-stale-version' )
-		);
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'rest_design_tokens_conflict', $result->get_error_code() );
-		$this->assertSame( WP_Http::CONFLICT, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * A block with no registered preset bindings is a 404, mirroring every other block sub-route.
-	 *
-	 * @return void
-	 */
-	public function testSetOrderReturns404ForABlockThatAcceptsNoPresets(): void {
-		$result = $this->controller->set_order( $this->order_request( 'kadence/spacer', [ 'anything' ] ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
-	}
-
-	/**
-	 * DELETE on the order sub-route reverts a stored order to merge (baseline) order.
-	 *
-	 * @return void
-	 */
-	public function testDeleteOrderRevertsToMergeOrder(): void {
-		$this->controller->set_order( $this->order_request( self::BUTTON, [ 'secondary', 'primary' ] ) );
-
-		$version  = $this->store->get_version( Token_Store::default_slug() );
-		$response = $this->controller->delete_order( $this->order_request( self::BUTTON, [], $version ) );
-
-		$this->assertSame( WP_Http::OK, $response->get_status() );
-		$this->assertSame( [ 'primary', 'secondary' ], array_keys( $response->get_data()['presets'] ) );
-	}
-
-	/**
-	 * DELETE on the order sub-route is idempotent: a no-op, unchanged-version response when nothing is
-	 * stored for the block.
-	 *
-	 * @return void
-	 */
-	public function testDeleteOrderIsAnIdempotentNoOpWhenAbsent(): void {
-		$version_before = $this->store->get_version( Token_Store::default_slug() );
-
-		$response = $this->controller->delete_order( $this->order_request( self::BUTTON, [], $version_before ) );
-
-		$this->assertSame( WP_Http::OK, $response->get_status() );
-		$this->assertSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
-	}
-
-	/**
 	 * Creating a preset named "order" is rejected: the slug is reserved for the block's order sub-route and
 	 * could never be reordered or deleted through the dedicated route.
 	 *
@@ -1604,13 +1367,34 @@ final class PresetsControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testOrderedNamesAgreeBetweenTheControllerAndThePresetResolver(): void {
-		$this->controller->set_order( $this->order_request( self::BUTTON, [ 'secondary', 'primary' ] ) );
+		$this->createAccentPreset();
+		$this->controller->set_order( $this->order_request( self::BUTTON, [ 'accent', 'default' ] ) );
 
 		$data     = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
 		$resolver = $this->container->get( Preset_Resolver::class );
 
-		$this->assertSame( [ 'secondary', 'primary' ], array_keys( $data['presets'] ) );
-		$this->assertSame( [ 'secondary', 'primary' ], $resolver->names( self::BUTTON ) );
+		$this->assertSame( [ 'accent', 'default' ], array_keys( $data['presets'] ) );
+		$this->assertSame( [ 'accent', 'default' ], $resolver->names( self::BUTTON ) );
+	}
+
+	/**
+	 * Create a user "accent" preset through the controller, giving the block a second slug to order against
+	 * the shipped default.
+	 *
+	 * @return void
+	 */
+	private function createAccentPreset(): void {
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'accent',
+					'label'  => 'Accent',
+					'tokens' => $this->button_tokens(),
+				]
+			)
+		);
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/PresetsControllerTest.php
@@ -1337,6 +1337,231 @@ final class PresetsControllerTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testAMalformedPresetShapeReturns422(): void {
+		$result = $this->controller->update_item(
+			$this->block_request( 'PUT', self::BUTTON, [ 'presets' => [ 'bad' => 'not-an-object' ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAnEmptyPresetSlugIsRejected(): void {
+		// An empty key in the presets map would store a preset node keyed by "" — reject it, mirroring the
+		// documents controller's empty dot-path-segment guard.
+		$result = $this->controller->update_item(
+			$this->block_request( 'PUT', self::BUTTON, [ 'presets' => [ '' => [ 'tokens' => [ 'button-bg' => 'transparent' ] ] ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_invalid', $result->get_error_code() );
+		$this->assertSame( WP_Http::UNPROCESSABLE_ENTITY, $result->get_error_data()['status'] );
+		$this->assertSame( '', $this->store->get_document( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWritesAreDeniedToUsersWithoutTheCapability(): void {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE );
+
+		$this->assertInstanceOf( WP_Error::class, $this->controller->create_item_permissions_check( $request ) );
+		$this->assertInstanceOf( WP_Error::class, $this->controller->update_item_permissions_check( $request ) );
+		$this->assertInstanceOf( WP_Error::class, $this->controller->delete_item_permissions_check( $request ) );
+	}
+
+	/**
+	 * A committed write re-hashes the library version so downstream caches invalidate.
+	 *
+	 * @return void
+	 */
+	public function testAWriteBumpsTheVersion(): void {
+		$this->store->save_document(
+			'{"$extensions":{"com.kadence.designTokens":{"presets":{"kadence/singlebtn":{'
+			. '"outline":{"tokens":{"button-bg":"transparent"}}}}}}}'
+		);
+
+		$version_before = $this->store->get_version( Token_Store::default_slug() );
+
+		$this->controller->create_item(
+			$this->block_request(
+				WP_REST_Server::CREATABLE,
+				self::BUTTON,
+				[
+					'preset' => 'dashed',
+					'tokens' => $this->button_tokens(),
+				]
+			)
+		);
+
+		$this->assertNotSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReadRoutesAreGatedByTheCapability(): void {
+		$request = new WP_REST_Request( WP_REST_Server::READABLE );
+
+		// Both read callbacks gate the routes (get_items for the collection, get_item for a single block and
+		// its default), so both must deny a user without the capability and allow one that has it.
+		$checks = [ 'get_items_permissions_check', 'get_item_permissions_check' ];
+
+		// A logged-out user is denied.
+		wp_set_current_user( 0 );
+
+		foreach ( $checks as $check ) {
+			$result = $this->controller->$check( $request );
+
+			$this->assertInstanceOf( WP_Error::class, $result, "$check should deny a logged-out user." );
+			$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		}
+
+		// An authenticated user without edit_theme_options is denied.
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		foreach ( $checks as $check ) {
+			$result = $this->controller->$check( $request );
+
+			$this->assertInstanceOf( WP_Error::class, $result, "$check should deny a subscriber." );
+			$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+		}
+
+		// An administrator (edit_theme_options) is allowed.
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		foreach ( $checks as $check ) {
+			$this->assertTrue( $this->controller->$check( $request ), "$check should allow an administrator." );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// preset display order
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The order sub-route is registered with PUT and DELETE, alongside the rest of the block routes.
+	 *
+	 * @return void
+	 */
+	public function testTheOrderRouteIsRegistered(): void {
+		$namespace   = $this->controller_namespace();
+		$base        = $this->controller_rest_base();
+		$block_route = $this->controller_constant( 'BLOCK_ROUTE' );
+		$order_route = $this->controller_constant( 'ORDER_ROUTE' );
+
+		$route = "/$namespace/$base/$block_route/$order_route";
+
+		$this->assertArrayHasKey( $route, $this->rest_server->get_routes() );
+		$this->assertContains( 'PUT', $this->route_methods( $route ) );
+		$this->assertContains( 'DELETE', $this->route_methods( $route ) );
+	}
+
+	/**
+	 * A PUT to the order sub-route moves a BASELINE preset slug out of its baseline position — the case a
+	 * PUT-the-collection "reorder" cannot reach, since `Effective_Presets` always reads baseline-defined
+	 * slugs back in baseline order, ahead of stored ones, regardless of the order overrides were written in.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderMovesBaselineSlugs(): void {
+		$this->createAccentPreset();
+
+		$response = $this->controller->set_order( $this->order_request( self::BUTTON, [ 'accent', 'default' ] ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( [ 'accent', 'default' ], array_keys( $response->get_data()['presets'] ) );
+
+		// The order survives a fresh read.
+		$data = $this->controller->get_item( $this->block_request( WP_REST_Server::READABLE, self::BUTTON ) )->get_data();
+		$this->assertSame( [ 'accent', 'default' ], array_keys( $data['presets'] ) );
+	}
+
+	/**
+	 * A slug the block does not effectively define is pruned from the submitted order silently, rather
+	 * than rejected — the order write is advisory, mirroring the documents controller's token-order route.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderSilentlyPrunesAnUnknownSlug(): void {
+		$this->createAccentPreset();
+
+		$response = $this->controller->set_order(
+			$this->order_request( self::BUTTON, [ 'accent', 'does-not-exist', 'default' ] )
+		);
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( [ 'accent', 'default' ], array_keys( $response->get_data()['presets'] ) );
+	}
+
+	/**
+	 * A version that no longer matches the stored version is rejected with HTTP 409, so a client working
+	 * from a stale read cannot silently clobber a concurrent write.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderRejectsAStaleVersionWith409(): void {
+		$result = $this->controller->set_order(
+			$this->order_request( self::BUTTON, [ 'default' ], 'a-stale-version' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_conflict', $result->get_error_code() );
+		$this->assertSame( WP_Http::CONFLICT, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A block with no registered preset bindings is a 404, mirroring every other block sub-route.
+	 *
+	 * @return void
+	 */
+	public function testSetOrderReturns404ForABlockThatAcceptsNoPresets(): void {
+		$result = $this->controller->set_order( $this->order_request( 'kadence/spacer', [ 'anything' ] ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_design_tokens_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * DELETE on the order sub-route reverts a stored order to merge (baseline) order.
+	 *
+	 * @return void
+	 */
+	public function testDeleteOrderRevertsToMergeOrder(): void {
+		$this->createAccentPreset();
+		$this->controller->set_order( $this->order_request( self::BUTTON, [ 'accent', 'default' ] ) );
+
+		$version  = $this->store->get_version( Token_Store::default_slug() );
+		$response = $this->controller->delete_order( $this->order_request( self::BUTTON, [], $version ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( [ 'default', 'accent' ], array_keys( $response->get_data()['presets'] ) );
+	}
+
+	/**
+	 * DELETE on the order sub-route is idempotent: a no-op, unchanged-version response when nothing is
+	 * stored for the block.
+	 *
+	 * @return void
+	 */
+	public function testDeleteOrderIsAnIdempotentNoOpWhenAbsent(): void {
+		$version_before = $this->store->get_version( Token_Store::default_slug() );
+
+		$response = $this->controller->delete_order( $this->order_request( self::BUTTON, [], $version_before ) );
+
+		$this->assertSame( WP_Http::OK, $response->get_status() );
+		$this->assertSame( $version_before, $this->store->get_version( Token_Store::default_slug() ) );
+	}
+
+	/**
 	 * Creating a preset named "order" is rejected: the slug is reserved for the block's order sub-route and
 	 * could never be reordered or deleted through the dedicated route.
 	 *


### PR DESCRIPTION
The Button was the only block whose baseline presets were named **Primary** and **Secondary**.
Secondary is dropped and Primary becomes **Default**, so all six blocks now ship a single preset
slugged `default`.

The four `semantic.color.button-secondary-*` tokens existed only to feed the Secondary map, so they
go with it rather than shipping as dead entries in the token picker. The four that remain lose their
now-meaningless `primary` segment — `semantic.color.button-primary-bg` becomes
`semantic.color.button-bg`, and likewise for text, bg-hover and text-hover — matching the sibling
naming already used by `column-bg`, `heading-bg` and `image-bg`.

One behavior follows from the rename. `default` is reserved against the *creation* of a preset the
per-preset item route could never address, not against writing a slug the block already ships. The
Button was the sole block shipping no `default`, so it was the only place that write was refused; it
now merges onto the shipped preset like the other five. `Presets_Controller::guard_reserved_slugs()`
is unchanged apart from its docblock; the two tests that depended on the old asymmetry are reworked,
and the `order` slug still covers the refusal branch.

Three test groups needed real rework rather than a slug rename, because the Button was the only block
shipping two presets: the preset-ordering tests in `PresetsControllerTest` and the scoped-rule tests
in `Projection/Preset/Css_BuilderTest` now create a user `accent` preset and order or scope against
it, so the coverage survives.

**Gates:** `slic run wpunit Resources/Design_Tokens` 1666 tests green, `Blocks/SinglebtnTest` green,
Jest 1748 green, PHPStan no errors, `partial-phpcs.sh diff` clean, cspell clean.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [ ] Tested creating a new instance of this block.
- [ ] Tested with Dynamic content & Elements.
