### PR TITLE
[DTM] SOFT-4261 [1/4]: Extract the shared color popover

### DIFF
--- a/src/token-controls/__tests__/color-selection.test.js
+++ b/src/token-controls/__tests__/color-selection.test.js
@@ -1,0 +1,146 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import { colorSelection } from '../helpers/color-selection';
+
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+}));
+
+const GROUPS = [
+	{
+		id: 'accent',
+		label: 'Accent',
+		swatches: [
+			{
+				id: 'semantic.color.accent.main',
+				label: 'Main',
+				value: '#3182ce',
+				alias: '{semantic.color.accent.main}',
+			},
+		],
+	},
+	{
+		id: 'background',
+		label: 'Background',
+		swatches: [
+			{
+				id: 'semantic.color.background.base',
+				label: 'Base',
+				value: '#ffffff',
+				alias: '{semantic.color.background.base}',
+			},
+		],
+	},
+];
+
+describe('colorSelection', () => {
+	/**
+	 * Every group's swatches are flattened into one list, in group order, so the popover can hand
+	 * `TokenPopover` a single `tokens` array.
+	 *
+	 * @return {void}
+	 */
+	it("flattens every group's swatches in order", () => {
+		expect(colorSelection(GROUPS, '').allSwatches.map((entry) => entry.id)).toEqual([
+			'semantic.color.accent.main',
+			'semantic.color.background.base',
+		]);
+	});
+
+	/**
+	 * A bracket alias matching a swatch resolves to that entry, and the trigger shows the entry's
+	 * own label.
+	 *
+	 * @return {void}
+	 */
+	it('matches a bracket alias to its entry and labels it', () => {
+		const result = colorSelection(GROUPS, '{semantic.color.accent.main}');
+
+		expect(result.entry.id).toBe('semantic.color.accent.main');
+		expect(result.selectedLabel).toBe('Main');
+	});
+
+	/**
+	 * A bound alias no group defines is still a real color, so it reads as the muted "Default"
+	 * fallback rather than as raw dot-path text that would overflow the trigger.
+	 *
+	 * @return {void}
+	 */
+	it('labels an alias outside its own groups as Default', () => {
+		const result = colorSelection(GROUPS, '{semantic.color.notice.error}');
+
+		expect(result.entry).toBeFalsy();
+		expect(result.selectedLabel).toBe('Default');
+	});
+
+	/**
+	 * A raw literal matches no entry and gets no selected label — the trigger paints the literal on
+	 * its swatch instead of naming it.
+	 *
+	 * @return {void}
+	 */
+	it('gives a raw literal no entry and no label', () => {
+		const result = colorSelection(GROUPS, '#171717');
+
+		expect(result.entry).toBeFalsy();
+		expect(result.selectedLabel).toBeNull();
+	});
+
+	/**
+	 * The popover opens on Style Library for an alias or an unset value, and on Custom for a
+	 * literal — a literal could only have come from the Custom tab.
+	 *
+	 * @return {void}
+	 */
+	it("opens on the tab that matches the value's shape", () => {
+		expect(colorSelection(GROUPS, '{semantic.color.accent.main}').initialTab).toBe('style-library');
+		expect(colorSelection(GROUPS, '').initialTab).toBe('style-library');
+		expect(colorSelection(GROUPS, '#171717').initialTab).toBe('custom');
+	});
+
+	/**
+	 * A legacy `var(--...)` literal (the old editor's global-palette storage shape) is real and
+	 * working but `react-color` cannot parse it, so it must open on Style Library, never the
+	 * destructive Custom tab.
+	 *
+	 * @return {void}
+	 */
+	it('opens a CSS-variable literal on Style Library, not Custom', () => {
+		expect(colorSelection(GROUPS, 'var(--global-palette1)').initialTab).toBe('style-library');
+	});
+
+	/**
+	 * A CSS-variable literal matches no entry, so it must not be labeled as if it were a bound
+	 * token.
+	 *
+	 * @return {void}
+	 */
+	it('gives a CSS-variable literal no entry and no label', () => {
+		const result = colorSelection(GROUPS, 'var(--global-palette1)');
+
+		expect(result.entry).toBeFalsy();
+		expect(result.selectedLabel).toBeNull();
+	});
+
+	/**
+	 * CSS allows whitespace around the custom-property name and a fallback after it. Every such
+	 * spelling is still a CSS variable, and missing one would route a real color to the destructive
+	 * Custom tab.
+	 *
+	 * @param {string} value The CSS-variable spelling under test.
+	 *
+	 * @return {void}
+	 */
+	it.each([
+		['var( --global-palette1 )'],
+		['var(--global-palette1 , #fff)'],
+		['var(--global-palette1, #fff)'],
+		['VAR(--global-palette1)'],
+		['var(--caf\u00e9)'],
+		['var(--escaped\\ name)'],
+	])('opens %s on Style Library too', (value) => {
+		expect(colorSelection(GROUPS, value).initialTab).toBe('style-library');
+	});
+});

--- a/src/token-controls/controls/ColorControl.js
+++ b/src/token-controls/controls/ColorControl.js
@@ -66,7 +66,8 @@ export function ColorControl({
 	resolveLiteral,
 	disabled = false,
 }) {
-	const { entry, selectedLabel } = colorSelection(groups, value);
+	const selection = colorSelection(groups, value);
+	const { entry, selectedLabel } = selection;
 
 	return (
 		<div className="kb-color-control">
@@ -92,6 +93,7 @@ export function ColorControl({
 						<ColorPopover
 							value={value}
 							groups={groups}
+							selection={selection}
 							onClear={onClear}
 							onPick={onPick}
 							onCustom={onCustom}

--- a/src/token-controls/controls/ColorControl.js
+++ b/src/token-controls/controls/ColorControl.js
@@ -5,28 +5,24 @@
  *
  * No `ControlShell` — its header-above-body split does not fit a control whose label lives inside
  * the trigger row itself, the way `BorderControl`'s width `TokenSelector` does. Composes `Dropdown`
- * and `TokenPopover` directly, passing `ColorGroupList` through `TokenPopover`'s `renderList` prop
- * for a grouped Style Library tab (Accent/Contrast/Background/Notices) instead of the flat token
- * list every other control shows, and the relocated `ColorPicker` through `renderCustom` for the
- * Custom tab.
+ * with `ColorPopover`, the popover body that shows a grouped Style Library tab (Accent/Contrast/
+ * Background/Notices) and a Custom tab for raw colors. The popover lives in `ColorPopover` because
+ * `ColorSwatchControl` opens the same one behind a different, compact trigger.
  */
 
 /**
  * WordPress dependencies
  */
-import { Button, Dropdown } from '@wordpress/components';
-import { Icon, undo } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { Dropdown } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { BindingIndicator } from '../atoms/BindingIndicator';
 import { ColorSwatch } from '../atoms/ColorSwatch';
-import { ColorGroupList } from '../molecules/ColorGroupList';
-import { ColorPicker } from '../molecules/ColorPicker';
-import { TokenPopover } from '../molecules/TokenPopover';
-import { findTokenEntry, isTokenAlias } from '../helpers/token-summary';
+import { ColorPopover } from '../molecules/ColorPopover';
+import { colorSelection } from '../helpers/color-selection';
+import { isTokenAlias } from '../helpers/token-summary';
 import '../styles/token-controls.scss';
 
 /**
@@ -70,15 +66,7 @@ export function ColorControl({
 	resolveLiteral,
 	disabled = false,
 }) {
-	const allSwatches = groups.flatMap((group) => group.swatches);
-	const entry = findTokenEntry(allSwatches, value);
-	// A bound alias that resolves to no entry in this control's own groups (e.g. a button preset's
-	// text/background default, a token from outside the Accent/Contrast/Background palette) is still
-	// a real, working color — just not one this control can name. Reading it back as raw dot-path
-	// text would overflow the trigger and read as broken; "Default" matches every other token
-	// control's muted fallback for "set, but not to one of my own pickable options."
-	const selectedLabel = entry ? entry.label : isTokenAlias(value) ? __('Default', 'kadence-blocks') : null;
-	const initialTab = isTokenAlias(value) || !value ? 'style-library' : 'custom';
+	const { entry, selectedLabel } = colorSelection(groups, value);
 
 	return (
 		<div className="kb-color-control">
@@ -101,37 +89,13 @@ export function ColorControl({
 						</button>
 					)}
 					renderContent={({ onClose }) => (
-						<TokenPopover
+						<ColorPopover
 							value={value}
-							tokens={allSwatches}
-							initialTab={initialTab}
-							renderList={({ onPick: pick, onClose: close }) => (
-								<>
-									{onClear && (
-										<Button
-											className="kadence-token-field__reset kb-color-control__clear"
-											disabled={!value}
-											onClick={() => {
-												onClear();
-												close();
-											}}
-										>
-											<span className="kadence-token-field__reset-label">
-												{__('Clear', 'kadence-blocks')}
-											</span>
-											<Icon className="kadence-token-field__reset-icon" icon={undo} size={20} />
-										</Button>
-									)}
-									<ColorGroupList groups={groups} value={value} onPick={pick} onClose={close} />
-								</>
-							)}
-							renderCustom={() => (
-								<ColorPicker
-									color={entry && resolveLiteral ? resolveLiteral(entry) : entry ? '' : value}
-									onChange={onCustom}
-								/>
-							)}
+							groups={groups}
+							onClear={onClear}
 							onPick={onPick}
+							onCustom={onCustom}
+							resolveLiteral={resolveLiteral}
 							onClose={onClose}
 						/>
 					)}

--- a/src/token-controls/helpers/color-selection.js
+++ b/src/token-controls/helpers/color-selection.js
@@ -1,0 +1,54 @@
+/**
+ * The state a color trigger and its popover both derive from the active palette's groups and the
+ * slot's current value.
+ *
+ * A plain function rather than a hook or a component method: this repo ships no
+ * `@testing-library/react` / `react-test-renderer` dependency, so a component's real logic has to
+ * live somewhere a test can call directly — the same split `colorSwatchStyle` (`atoms/ColorSwatch.js`)
+ * and `toStoredValue`/`toControlValue` (`src/style-library/helpers/color-values.js`) already use.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { findTokenEntry, isCssVariableReference, isTokenAlias } from './token-summary';
+
+/**
+ * Derive a color control's trigger and popover state.
+ *
+ * @param {Array} groups `[{ id, label, swatches: [{ id, label, value, alias }] }]` — the active
+ *                        palette's groups, host-resolved.
+ * @param {*}     value  The current slot value: a bracket alias (`{token.id}`, a token pick) or a
+ *                        raw literal (hex/rgba, a Custom-tab pick).
+ *
+ * @since TBD
+ *
+ * @return {{allSwatches: Array, entry: ?Object, selectedLabel: ?string, initialTab: string}} The
+ *         flattened swatch list, the matched token entry (or null), the label a trigger shows for
+ *         the current selection (or null when there is nothing to name), and which tab the popover
+ *         opens on.
+ */
+export function colorSelection(groups, value) {
+	const allSwatches = groups.flatMap((group) => group.swatches);
+	const entry = findTokenEntry(allSwatches, value);
+
+	return {
+		allSwatches,
+		entry,
+		// A bound alias that resolves to no entry in these groups (e.g. a button preset's default, a
+		// token from outside the Accent/Contrast/Background palette) is still a real, working color —
+		// just not one this control can name. Reading it back as raw dot-path text would overflow the
+		// trigger and read as broken; "Default" matches every other token control's muted fallback.
+		selectedLabel: entry ? entry.label : isTokenAlias(value) ? __('Default', 'kadence-blocks') : null,
+		// A CSS-variable literal is real and working but `react-color` cannot parse it (it renders
+		// black) and there is no path back to the original value once the picker overwrites it — so it
+		// is routed to Style Library, never to the destructive Custom tab, exactly like an unresolved
+		// alias.
+		initialTab: isTokenAlias(value) || isCssVariableReference(value) || !value ? 'style-library' : 'custom',
+	};
+}

--- a/src/token-controls/helpers/token-summary.js
+++ b/src/token-controls/helpers/token-summary.js
@@ -35,6 +35,40 @@ export function isTokenAlias(value) {
 }
 
 /**
+ * A CSS custom-property reference, e.g. `var(--global-palette1)`.
+ *
+ * The old editor's per-row color widget commonly stored a Kadence global-palette color this way.
+ * It is a real, working color — the browser resolves it at paint time — but neither a bracket alias
+ * nor a hex/rgba literal `react-color` can parse, so it needs its own shape check wherever a value
+ * is routed by kind.
+ *
+ * Deliberately permissive, because the two ways of being wrong are not equally costly: failing to
+ * recognize a real reference routes a working color to the Custom tab, where it is shown as black
+ * and overwritten on the first interaction, while over-matching only opens the Style Library tab on
+ * something that was not a variable after all. So this accepts every spelling CSS itself allows —
+ * `var` is ASCII case-insensitive like every CSS function name, whitespace may surround the
+ * custom-property name, the name may contain non-ASCII or backslash-escaped characters, and a
+ * fallback may follow a comma and span lines.
+ *
+ * @since TBD
+ */
+const CSS_VAR_PATTERN = /^var\(\s*--(?:\\.|[^\s,()\\])+\s*(?:,[\s\S]*)?\)$/i;
+
+/**
+ * Whether a slot value is a CSS custom-property reference rather than a token alias or a plain
+ * literal.
+ *
+ * @param {*} value The slot value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} True when the value is a `var(--...)` reference.
+ */
+export function isCssVariableReference(value) {
+	return typeof value === 'string' && CSS_VAR_PATTERN.test(value.trim());
+}
+
+/**
  * Whether a slot holds anything at all.
  *
  * @param {*} value The slot value.

--- a/src/token-controls/molecules/ColorPopover.js
+++ b/src/token-controls/molecules/ColorPopover.js
@@ -39,13 +39,28 @@ import { isCssVariableReference } from '../helpers/token-summary';
  * @param {?Function} [props.resolveLiteral] `(entry) => string` — the host's hook for seeding the
  *                                            Custom tab from a currently-bound token entry.
  * @param {Function}  props.onClose          Closes the popover after a choice.
+ * @param {?Object}   [props.selection]      The already-derived `colorSelection(groups, value)`.
+ *                                            A control's trigger derives it anyway to render its own
+ *                                            swatch, so passing it here keeps the palette from being
+ *                                            flattened a second time on every render, and keeps
+ *                                            `colorSelection` the single place the derivation
+ *                                            happens. Omit it and this derives its own.
  *
  * @since TBD
  *
  * @return {JSX.Element} The rendered popover body.
  */
-export function ColorPopover({ value, groups, onClear = null, onPick, onCustom, resolveLiteral, onClose }) {
-	const { allSwatches, entry, initialTab } = colorSelection(groups, value);
+export function ColorPopover({
+	value,
+	groups,
+	onClear = null,
+	onPick,
+	onCustom,
+	resolveLiteral,
+	onClose,
+	selection = null,
+}) {
+	const { allSwatches, entry, initialTab } = selection ?? colorSelection(groups, value);
 
 	return (
 		<TokenPopover

--- a/src/token-controls/molecules/ColorPopover.js
+++ b/src/token-controls/molecules/ColorPopover.js
@@ -1,0 +1,93 @@
+/**
+ * The popover body every color control opens: a grouped `Style Library` tab (the active palette's
+ * Accent/Contrast/Background/Notices groups, in place of the flat token list every other control
+ * shows) and a `Custom` tab holding the relocated `ColorPicker`.
+ *
+ * Split out of `ColorControl` so a control with a different trigger can open the same popover.
+ * `ColorControl`'s trigger is a full row — a swatch, the attribute's own static label, and the
+ * selected token's label — which does not fit `BorderControl`'s compact row; `ColorSwatchControl`'s
+ * is a bare 20px swatch, which cannot carry a `BindingIndicator`. What the two share is everything
+ * below the trigger, and that is what lives here.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { Icon, undo } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ColorGroupList } from './ColorGroupList';
+import { ColorPicker } from './ColorPicker';
+import { TokenPopover } from './TokenPopover';
+import { colorSelection } from '../helpers/color-selection';
+import { isCssVariableReference } from '../helpers/token-summary';
+
+/**
+ * Render a color picker's popover body.
+ *
+ * @param {Object}    props                  The component props.
+ * @param {*}         props.value            The current slot value: a bracket alias or a raw literal.
+ * @param {Array}     props.groups           `[{ id, label, swatches: [{ id, label, value, alias }] }]`
+ *                                            — the active palette's groups, host-resolved.
+ * @param {?Function} [props.onClear]        Clears the slot back to unset. Omit for no Clear row.
+ * @param {Function}  props.onPick           Called with a token entry's `alias` when one is chosen.
+ * @param {Function}  props.onCustom         Called with a literal color from the Custom tab.
+ * @param {?Function} [props.resolveLiteral] `(entry) => string` — the host's hook for seeding the
+ *                                            Custom tab from a currently-bound token entry.
+ * @param {Function}  props.onClose          Closes the popover after a choice.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered popover body.
+ */
+export function ColorPopover({ value, groups, onClear = null, onPick, onCustom, resolveLiteral, onClose }) {
+	const { allSwatches, entry, initialTab } = colorSelection(groups, value);
+
+	return (
+		<TokenPopover
+			value={value}
+			tokens={allSwatches}
+			initialTab={initialTab}
+			renderList={({ onPick: pick, onClose: close }) => (
+				<>
+					{onClear && (
+						<Button
+							className="kadence-token-field__reset kb-color-control__clear"
+							disabled={!value}
+							onClick={() => {
+								onClear();
+								close();
+							}}
+						>
+							<span className="kadence-token-field__reset-label">{__('Clear', 'kadence-blocks')}</span>
+							<Icon className="kadence-token-field__reset-icon" icon={undo} size={20} />
+						</Button>
+					)}
+					<ColorGroupList groups={groups} value={value} onPick={pick} onClose={close} />
+				</>
+			)}
+			renderCustom={() => (
+				<ColorPicker
+					// A CSS-variable literal (the old editor's legacy palette storage shape) is not something
+					// `react-color` can parse — handing it over renders black and the first touch overwrites a
+					// working color, with no way back. Seeding '' instead opens the picker neutral; the swatch
+					// still paints the real color since it renders the literal via CSS `background`.
+					color={
+						entry && resolveLiteral
+							? resolveLiteral(entry)
+							: entry || isCssVariableReference(value)
+								? ''
+								: value
+					}
+					onChange={onCustom}
+				/>
+			)}
+			onPick={onPick}
+			onClose={onClose}
+		/>
+	);
+}


### PR DESCRIPTION
## Summary

`ColorControl` held its popover body inline: a `TokenPopover` composed with `ColorGroupList` for the grouped Style Library tab, the relocated `ColorPicker` for the Custom tab, and a `Clear` row. Nothing else in the library could open that popover.

This slice lifts that body into a `ColorPopover` molecule, and the state a trigger and its popover both derive from `groups` + `value` into a pure `colorSelection()` helper. `ColorControl` keeps its own full trigger row and now composes `Dropdown` with `ColorPopover`.

The helper is a plain function rather than a hook because this repo ships no `@testing-library/react` / `react-test-renderer`, so a component's real logic has to live somewhere a test can call directly — the same split `colorSwatchStyle` already uses.

## Legacy CSS-variable colors

`colorSelection()` also routes a `var(--…)` value away from the Custom tab. The editor's older per-row color widget commonly stored a Kadence global-palette color that way. It is truthy and not a bracket alias, so it would otherwise open on Custom, where `react-color` cannot parse it, renders black, and the first interaction overwrites a working palette color with a hex. Such a value now opens on Style Library and is never handed to the picker as a seed; the swatch still paints it, since CSS resolves the variable in a `background`.

The pattern deliberately tolerates whitespace (`var( --x )`, `var(--x , #fff)`) — missing a spelling would route a real color down the destructive path this check exists to prevent.

## Behavior

No behavior change to `ColorControl`. `ColorControl.test.js` is untouched and still passes, which is the regression proof for the extraction.

## Test plan

- `npx wp-scripts test-unit-js src/token-controls` — 24 suites, 363 tests green
- `ColorControl.test.js` passes unmodified
- `color-selection.test.js` covers alias matching, the `Default` fallback for an out-of-group alias, literal passthrough, initial-tab selection, and the CSS-variable cases

Part of a 4-PR chain. Next: the compact swatch control that opens this same popover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable color-selection popover with Style Library tokens and a Custom color picker.
  * Added support for selecting, clearing, and displaying color tokens, aliases, raw values, and CSS-variable references.
  * Improved initial tab selection based on the current color value.

* **Bug Fixes**
  * Improved handling of unresolved aliases, whitespace, and fallback values in CSS variables.

* **Tests**
  * Added coverage for color swatches, aliases, labels, tabs, raw values, and CSS-variable formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->