### PR TITLE
[DTM] SOFT-4261 [2/4]: Add the compact swatch color control

### DIFF
--- a/src/token-controls/__tests__/ColorSwatchControl.test.js
+++ b/src/token-controls/__tests__/ColorSwatchControl.test.js
@@ -1,0 +1,223 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ColorSwatchControl } from '../controls/ColorSwatchControl';
+
+// Matches `ColorControl.test.js`'s stand-in: `@wordpress/components` resolves its own nested `react`
+// copy, a different module instance than the top-level `react-dom/client` this test renders with,
+// which trips React's "Invalid hook call" guard. `Dropdown` renders both its toggle and its content
+// at once so a test can reach the popover's rows without simulating a real open click.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isPressed, showTooltip, ...props }) => <button {...props}>{children}</button>,
+	Dropdown: ({ renderToggle, renderContent }) => (
+		<>
+			{renderToggle({ isOpen: false, onToggle: () => {} })}
+			{renderContent({ onClose: () => {} })}
+		</>
+	),
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+	RangeControl: ({ label }) => <div>{label}</div>,
+	SelectControl: ({ label }) => <div>{label}</div>,
+	TabPanel: ({ children, tabs }) => (
+		<div data-testid="tab-panel">
+			{tabs.map((tab) => (
+				<div key={tab.name} data-tab={tab.name}>
+					{children(tab)}
+				</div>
+			))}
+		</div>
+	),
+	Tooltip: ({ children }) => children,
+	__experimentalNumberControl: ({ label }) => <div>{label}</div>,
+}));
+
+jest.mock('@wordpress/icons', () => ({
+	check: 'check',
+	globe: 'globe',
+	settings: 'settings',
+	undo: 'undo',
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+}));
+
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	sprintf: (format, ...args) => format.replace(/%s/g, () => args.shift()),
+}));
+
+jest.mock('../molecules/ColorPicker', () => ({
+	ColorPicker: ({ color, onChange }) => (
+		<button type="button" data-testid="color-picker" data-color={color ?? ''} onClick={() => onChange('#abcdef')} />
+	),
+}));
+
+jest.mock('../styles/token-controls.scss', () => ({}), { virtual: true });
+
+const GROUPS = [
+	{
+		id: 'accent',
+		label: 'Accent',
+		swatches: [
+			{
+				id: 'semantic.color.accent.main',
+				label: 'Main',
+				value: '#3182ce',
+				alias: '{semantic.color.accent.main}',
+			},
+		],
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Mount the control with the given prop overrides.
+ *
+ * @param {Object} props Prop overrides merged over the defaults.
+ *
+ * @return {void}
+ */
+function render(props = {}) {
+	act(() => {
+		root.render(
+			createElement(ColorSwatchControl, {
+				label: 'Top Border Color',
+				value: '',
+				groups: GROUPS,
+				onPick: jest.fn(),
+				onCustom: jest.fn(),
+				...props,
+			})
+		);
+	});
+}
+
+describe('ColorSwatchControl', () => {
+	/**
+	 * The trigger is a bare swatch button carrying its name only as an accessible label — the border
+	 * row has no room for the visible label and value text `ColorControl`'s own trigger renders.
+	 *
+	 * @return {void}
+	 */
+	it('renders a bare swatch trigger named by aria-label, with no visible text', () => {
+		render();
+
+		const toggle = container.querySelector('.kb-color-swatch-control__button');
+
+		expect(toggle).toBeTruthy();
+		expect(toggle.getAttribute('aria-label')).toBe('Top Border Color');
+		expect(toggle.textContent).toBe('');
+		expect(toggle.querySelector('.kb-color-swatch')).toBeTruthy();
+	});
+
+	/**
+	 * A read-only host disables the trigger so the popover cannot be opened at all.
+	 *
+	 * @return {void}
+	 */
+	it('disables the trigger when disabled', () => {
+		render({ disabled: true });
+
+		expect(container.querySelector('.kb-color-swatch-control__button').disabled).toBe(true);
+	});
+
+	/**
+	 * The popover shows the grouped Style Library list, and picking a swatch hands back that
+	 * entry's bracket alias.
+	 *
+	 * @return {void}
+	 */
+	it('picks a grouped swatch by its alias', () => {
+		const onPick = jest.fn();
+		render({ onPick });
+
+		expect(container.querySelector('.kb-color-control__group-label').textContent).toBe('Accent');
+
+		act(() => {
+			container.querySelector('.kb-color-control__item').click();
+		});
+
+		expect(onPick).toHaveBeenCalledWith('{semantic.color.accent.main}');
+	});
+
+	/**
+	 * The Custom tab writes a raw literal through `onCustom`, not through `onPick`.
+	 *
+	 * @return {void}
+	 */
+	it('writes a literal from the Custom tab', () => {
+		const onCustom = jest.fn();
+		render({ onCustom });
+
+		act(() => {
+			container.querySelector('[data-testid="color-picker"]').click();
+		});
+
+		expect(onCustom).toHaveBeenCalledWith('#abcdef');
+	});
+
+	/**
+	 * The Custom tab is seeded from the bound entry through the host's `resolveLiteral`, so it opens
+	 * on the token's current color rather than empty.
+	 *
+	 * @return {void}
+	 */
+	it('seeds the Custom tab from the bound entry via resolveLiteral', () => {
+		render({ value: '{semantic.color.accent.main}', resolveLiteral: (entry) => entry.value });
+
+		expect(container.querySelector('[data-testid="color-picker"]').getAttribute('data-color')).toBe('#3182ce');
+	});
+
+	/**
+	 * A legacy `var(--...)` literal is not handed to `ColorPicker` as its seed — `react-color`
+	 * cannot parse it and would render black, then overwrite the stored color with a hex on the
+	 * first touch. The Custom tab opens neutral instead.
+	 *
+	 * @return {void}
+	 */
+	it('does not seed the Custom tab with a CSS-variable literal', () => {
+		render({ value: 'var(--global-palette1)' });
+
+		expect(container.querySelector('[data-testid="color-picker"]').getAttribute('data-color')).toBe('');
+	});
+
+	/**
+	 * The Clear row renders only when the host passes `onClear`, and is inert while the slot is
+	 * already unset.
+	 *
+	 * @return {void}
+	 */
+	it('renders Clear only with onClear, disabled while unset', () => {
+		render();
+		expect(container.querySelector('.kb-color-control__clear')).toBeFalsy();
+
+		const onClear = jest.fn();
+		render({ onClear, value: '#171717' });
+
+		const clear = container.querySelector('.kb-color-control__clear');
+		expect(clear.disabled).toBe(false);
+
+		act(() => clear.click());
+		expect(onClear).toHaveBeenCalled();
+	});
+});

--- a/src/token-controls/__tests__/ColorSwatchControl.test.js
+++ b/src/token-controls/__tests__/ColorSwatchControl.test.js
@@ -48,7 +48,12 @@ jest.mock('@wordpress/icons', () => ({
 
 jest.mock('@wordpress/i18n', () => ({
 	__: (text) => text,
-	sprintf: (format, ...args) => format.replace(/%s/g, () => args.shift()),
+	sprintf: (format, ...args) => {
+		let next = 0;
+		return format.replace(/%(?:(\d+)\$)?s/g, (match, position) =>
+			position ? args[Number(position) - 1] : args[next++]
+		);
+	},
 }));
 
 jest.mock('../molecules/ColorPicker', () => ({
@@ -128,6 +133,20 @@ describe('ColorSwatchControl', () => {
 		expect(toggle.getAttribute('aria-label')).toBe('Top Border Color');
 		expect(toggle.textContent).toBe('');
 		expect(toggle.querySelector('.kb-color-swatch')).toBeTruthy();
+	});
+
+	/**
+	 * With a token bound, the accessible name carries the selected color's own name too — the trigger
+	 * shows no visible text, so this is the only place a screen reader can hear what is set.
+	 *
+	 * @return {void}
+	 */
+	it('names the selected color in the accessible name', () => {
+		render({ value: '{semantic.color.accent.main}' });
+
+		expect(container.querySelector('.kb-color-swatch-control__button').getAttribute('aria-label')).toBe(
+			'Top Border Color: Main'
+		);
 	});
 
 	/**

--- a/src/token-controls/controls/ColorSwatchControl.js
+++ b/src/token-controls/controls/ColorSwatchControl.js
@@ -1,0 +1,92 @@
+/**
+ * The compact color token control: a bare round swatch that opens the same popover `ColorControl`
+ * opens, with no label, no value text, and no binding indicator beside it.
+ *
+ * `BorderControl`'s row is one composite box — swatch, style preview, width field — with no room for
+ * `ColorControl`'s full trigger row, and a border's color carries no preset binding of its own, so
+ * there is no Reset glyph to render. The field's name therefore rides on `aria-label` rather than on
+ * visible text, the way the Style Library's own swatch toggles already name themselves.
+ *
+ * The popover body itself is `ColorPopover`, shared with `ColorControl` — the two controls differ
+ * only in what opens the popover.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Dropdown } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { ColorPopover } from '../molecules/ColorPopover';
+import { ColorSwatch } from '../atoms/ColorSwatch';
+import { colorSelection } from '../helpers/color-selection';
+import { isTokenAlias } from '../helpers/token-summary';
+import '../styles/token-controls.scss';
+
+/**
+ * Render a compact color token control.
+ *
+ * @param {Object}    props                  The component props.
+ * @param {string}    props.label            The field's accessible name (e.g. "Top Border Color").
+ *                                            Never rendered as visible text.
+ * @param {*}         props.value            The current slot value: a bracket alias or a raw literal.
+ * @param {Array}     props.groups           `[{ id, label, swatches: [{ id, label, value, alias }] }]`
+ *                                            — the active palette's groups, host-resolved.
+ * @param {?Function} [props.onClear]        Clears the slot back to unset. Omit for no Clear row.
+ * @param {Function}  props.onPick           Called with a token entry's `alias` when one is chosen.
+ * @param {Function}  props.onCustom         Called with a literal color from the Custom tab.
+ * @param {?Function} [props.resolveLiteral] `(entry) => string` — the host's hook for seeding the
+ *                                            Custom tab from a currently-bound token entry.
+ * @param {boolean}   [props.disabled]       Whether the control is read-only.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The rendered control.
+ */
+export function ColorSwatchControl({
+	label,
+	value,
+	groups,
+	onClear = null,
+	onPick,
+	onCustom,
+	resolveLiteral,
+	disabled = false,
+}) {
+	const { entry } = colorSelection(groups, value);
+
+	return (
+		<Dropdown
+			className="kb-color-swatch-control"
+			// Deliberately the same class `ColorControl` gives its own popover: it IS the same popover,
+			// and a second class would let the two sizings drift apart.
+			contentClassName="kb-color-control__popover"
+			popoverProps={{ placement: 'left-start' }}
+			renderToggle={({ isOpen, onToggle }) => (
+				<button
+					type="button"
+					className="kb-color-swatch-control__button"
+					aria-label={label}
+					aria-expanded={isOpen}
+					disabled={disabled}
+					onClick={onToggle}
+				>
+					<ColorSwatch entry={entry} value={!entry && !isTokenAlias(value) ? value : null} />
+				</button>
+			)}
+			renderContent={({ onClose }) => (
+				<ColorPopover
+					value={value}
+					groups={groups}
+					onClear={onClear}
+					onPick={onPick}
+					onCustom={onCustom}
+					resolveLiteral={resolveLiteral}
+					onClose={onClose}
+				/>
+			)}
+		/>
+	);
+}

--- a/src/token-controls/controls/ColorSwatchControl.js
+++ b/src/token-controls/controls/ColorSwatchControl.js
@@ -15,6 +15,7 @@
  * WordPress dependencies
  */
 import { Dropdown } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -55,7 +56,8 @@ export function ColorSwatchControl({
 	resolveLiteral,
 	disabled = false,
 }) {
-	const { entry } = colorSelection(groups, value);
+	const selection = colorSelection(groups, value);
+	const { entry, selectedLabel } = selection;
 
 	return (
 		<Dropdown
@@ -68,7 +70,19 @@ export function ColorSwatchControl({
 				<button
 					type="button"
 					className="kb-color-swatch-control__button"
-					aria-label={label}
+					// The trigger renders no visible text, so the current selection has nowhere else to be
+					// announced — `ColorControl` shows it as its own `selectedLabel`. Composed into the
+					// accessible name so a screen reader hears what is set, not just which field this is.
+					aria-label={
+						selectedLabel
+							? sprintf(
+									/* translators: 1: the field's name. 2: the selected color's name. */
+									__('%1$s: %2$s', 'kadence-blocks'),
+									label,
+									selectedLabel
+								)
+							: label
+					}
 					aria-expanded={isOpen}
 					disabled={disabled}
 					onClick={onToggle}
@@ -80,6 +94,7 @@ export function ColorSwatchControl({
 				<ColorPopover
 					value={value}
 					groups={groups}
+					selection={selection}
 					onClear={onClear}
 					onPick={onPick}
 					onCustom={onCustom}

--- a/src/token-controls/helpers/side-labels.js
+++ b/src/token-controls/helpers/side-labels.js
@@ -16,7 +16,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * The translated name of one border side.
@@ -36,4 +36,29 @@ export function sideLabel(side) {
 	};
 
 	return names[side] ?? side;
+}
+
+/**
+ * The accessible name for one border row's color field.
+ *
+ * The composed phrase lives here rather than in each host for the reason this file exists at all: a
+ * translator sees one string instead of two identical ones, and the two hosts cannot drift on how a
+ * border color names itself. The linked row has no side of its own, so it takes the bare name.
+ *
+ * @param {?string} side The row's bare side key, or `null` while the sides are linked.
+ *
+ * @since TBD
+ *
+ * @return {string} The field's accessible name.
+ */
+export function borderColorLabel(side) {
+	if (!side) {
+		return __('Border Color', 'kadence-blocks');
+	}
+
+	return sprintf(
+		/* translators: %s: the border side, already translated — Top, Right, Bottom or Left. */
+		__('%s Border Color', 'kadence-blocks'),
+		sideLabel(side)
+	);
 }

--- a/src/token-controls/helpers/side-labels.js
+++ b/src/token-controls/helpers/side-labels.js
@@ -1,0 +1,39 @@
+/**
+ * The translated name of a border side.
+ *
+ * `BorderControl` is what names its rows — it is the control that hands a row's bare side key
+ * (`top`, `right`, `bottom`, `left`) to `renderColor` as `label` in the first place (see
+ * `BorderControl.js`) — so the side vocabulary belongs here rather than in either host's own color
+ * field, and both hosts (the block editor's `border-color.js`, the Style Library's `BorderField.js`)
+ * translate a row's side name through the same function instead of drifting into two.
+ *
+ * Those keys are display text, not just object keys, once a row names itself in a locale other than
+ * English, so capitalizing the raw key leaves it in English. The four are spelled out here per side
+ * rather than derived because they are a closed set and a translator needs the whole phrase in front
+ * of them to render "Top Border Color" naturally in a language that orders it differently.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The translated name of one border side.
+ *
+ * @param {string} side The side key: `top`, `right`, `bottom` or `left`.
+ *
+ * @since TBD
+ *
+ * @return {string} The translated side name, or the key itself when it is not one of the four.
+ */
+export function sideLabel(side) {
+	const names = {
+		top: __('Top', 'kadence-blocks'),
+		right: __('Right', 'kadence-blocks'),
+		bottom: __('Bottom', 'kadence-blocks'),
+		left: __('Left', 'kadence-blocks'),
+	};
+
+	return names[side] ?? side;
+}

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -27,6 +27,7 @@ export { BoxControl } from './controls/BoxControl';
 export { BoxShadowControl } from './controls/BoxShadowControl';
 export { ColorControl } from './controls/ColorControl';
 export { ColorControlGroup } from './controls/ColorControlGroup';
+export { ColorSwatchControl } from './controls/ColorSwatchControl';
 export { ScalarControl } from './controls/ScalarControl';
 export { ColorPicker } from './molecules/ColorPicker';
 
@@ -64,5 +65,6 @@ export {
 	writeSlot,
 } from './helpers/value-shapes';
 export { tokenCssVar } from './helpers/token-css-var';
+export { sideLabel } from './helpers/side-labels';
 export { mapPaletteToColorControlGroups } from './helpers/palette-groups';
 export { DEFAULT_COMPOSITE, parseResolvedShadow } from './helpers/shadow-shorthand';

--- a/src/token-controls/index.js
+++ b/src/token-controls/index.js
@@ -65,6 +65,6 @@ export {
 	writeSlot,
 } from './helpers/value-shapes';
 export { tokenCssVar } from './helpers/token-css-var';
-export { sideLabel } from './helpers/side-labels';
+export { borderColorLabel, sideLabel } from './helpers/side-labels';
 export { mapPaletteToColorControlGroups } from './helpers/palette-groups';
 export { DEFAULT_COMPOSITE, parseResolvedShadow } from './helpers/shadow-shorthand';

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -1175,3 +1175,36 @@
 		border-radius: 0 0 2px 2px;
 	}
 }
+
+/*
+ * The compact color trigger: a borderless 20px button whose only child is the round swatch. All the
+ * chrome `.kb-color-control__trigger` draws (border, background, hover, open state) is deliberately
+ * absent — this control sits inside `BorderControl`'s own bordered row box, which already draws it.
+ */
+.kb-color-swatch-control {
+	display: inline-flex;
+	flex: 0 0 auto;
+}
+
+.kb-color-swatch-control__button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	padding: 0;
+	border: 0;
+	border-radius: 50%;
+	background: none;
+	cursor: pointer;
+
+	&:focus-visible {
+		outline: 2px solid var(--wp-admin-theme-color, #007cba);
+		outline-offset: 1px;
+	}
+
+	&:disabled {
+		cursor: default;
+		opacity: 0.5;
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ColorSwatchControl`, the trigger that lets a border row open the popover the previous slice extracted.

`BorderControl`'s row is one composite box — swatch, style preview, width field — with no room for `ColorControl`'s full row (a static attribute label plus the selected token's label, and a `BindingIndicator` beside it). This control is the same popover behind a bare 20px swatch: no visible text at all, its name carried on `aria-label`, and no binding indicator, since a border color carries no preset binding of its own and has no Reset to render.

It reuses `kb-color-control__popover` as its `contentClassName` deliberately — it is the same popover, and a second class would let the two sizings drift.

Also adds `sideLabel()`, which maps a border side key (`top`, `right`, …) to a translated name. `BorderControl` is what names a row's side and hands it to `renderColor`, so the vocabulary belongs in the library; both hosts consume it in the next two slices. The four sides are spelled out rather than derived so translators get whole phrases to work with.

## Wired to nothing yet

Neither host renders this control until the following slices. This one adds it, exports it, styles it, and tests it in isolation.

## Test plan

- `npx wp-scripts test-unit-js src/token-controls` — 25 suites, 370 tests green
- `ColorSwatchControl.test.js` covers the bare trigger (asserting no visible text, not merely that a node exists), `aria-label`, the disabled state, a grouped pick returning the entry's alias, a Custom-tab write going to `onCustom` rather than `onPick`, the Custom tab seeding through `resolveLiteral`, and the Clear row's presence and disabled state

Part of a 4-PR chain, on top of the shared popover extraction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessible color swatch control for selecting design tokens or custom colors.
  * Supports clearing selections, disabled states, literal color resolution, and keyboard focus styling.
  * Added localized labels for border sides.
* **Bug Fixes**
  * Added comprehensive automated coverage for color selection, custom colors, CSS variables, disabled behavior, and clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->