### PR TITLE
[DTM] SOFT-4261 [3/4]: Open the shared color popover from a border row in the block editor

### DIFF
--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -95,7 +95,7 @@ import { EditorBoxControl } from '../../extension/design-tokens/components/Edito
 import { EditorScalarControl } from '../../extension/design-tokens/components/EditorScalarControl';
 import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
 import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
-import { renderBorderColor } from '../../extension/design-tokens/components/border-color';
+import { BorderColorField } from '../../extension/design-tokens/components/border-color';
 import { tokenDimension } from '../../extension/design-tokens/token-dimension';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
 import { ColorControl, ColorControlGroup } from '../../token-controls';
@@ -116,7 +116,7 @@ import {
 	getColorClassName,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useState, useRef } from '@wordpress/element';
 
 import {
 	ToolbarGroup,
@@ -316,6 +316,9 @@ function KadenceAdvancedHeading(props) {
 	const resetToken = (attr) => resetAttr(attr, setAttributes, tokenBinding[attr]?.kind, metadata.attributes);
 	// One fetch of the block's effective palette groups, shared by every `ColorControl` on this block.
 	const colorGroups = useColorGroups(clientId);
+	// `BorderControl` forwards `renderColor` down through `SlotGrid`'s `renderSlot`, so this is
+	// defined once per render rather than inline at each of the border panels below.
+	const renderBorderColor = useCallback((row) => <BorderColorField {...row} groups={colorGroups} />, [colorGroups]);
 
 	// Empty when the token registry is inactive, which is what keeps each plain control below as the
 	// fallback rather than leaving the heading without it.

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -53,7 +53,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { tooltip as tooltipIcon } from '@kadence/icons';
 import { link as linkIcon } from '@wordpress/icons';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import {
 	RichText,
 	InspectorControls,
@@ -97,7 +97,7 @@ import { EditorBoxControl } from '../../extension/design-tokens/components/Edito
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
 import { EditorShadowControl, hasVisibleShadow } from '../../extension/design-tokens/components/EditorShadowControl';
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
-import { renderBorderColor } from '../../extension/design-tokens/components/border-color';
+import { BorderColorField } from '../../extension/design-tokens/components/border-color';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
 import { ColorControl, ColorControlGroup } from '../../token-controls';
 import { BUTTON_MARGIN_FALLBACK, BUTTON_PADDING_FALLBACK } from '../../token-controls/helpers/button-box-defaults';
@@ -300,6 +300,9 @@ export default function KadenceButtonEdit(props) {
 	// One fetch of the block's effective palette groups, shared by every `ColorControl` instance on
 	// this block — the palette data is identical for all fourteen of them.
 	const colorGroups = useColorGroups(clientId);
+	// `BorderControl` forwards `renderColor` down through `SlotGrid`'s `renderSlot`, so this is
+	// defined once per render rather than inline at each of the border panels below.
+	const renderBorderColor = useCallback((row) => <BorderColorField {...row} groups={colorGroups} />, [colorGroups]);
 
 	const borderRadiusPresetValue = presetValueForDevice(
 		tokenBinding.borderRadius?.presetValue,

--- a/src/extension/design-tokens/components/__tests__/border-color.test.js
+++ b/src/extension/design-tokens/components/__tests__/border-color.test.js
@@ -1,0 +1,187 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { BorderColorField } from '../border-color';
+
+// Mirrors `ColorSwatchControl.test.js`'s stand-in: `@wordpress/components` resolves its own nested
+// `react` copy, a different module instance than the top-level `react-dom/client` this test renders
+// with, which trips React's "Invalid hook call" guard. `Dropdown` renders both its toggle and its
+// content at once so a test can reach the popover's rows without simulating a real open click.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isPressed, showTooltip, ...props }) => <button {...props}>{children}</button>,
+	Dropdown: ({ renderToggle, renderContent }) => (
+		<>
+			{renderToggle({ isOpen: false, onToggle: () => {} })}
+			{renderContent({ onClose: () => {} })}
+		</>
+	),
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+	RangeControl: ({ label }) => <div>{label}</div>,
+	SelectControl: ({ label }) => <div>{label}</div>,
+	TabPanel: ({ children, tabs }) => (
+		<div>
+			{tabs.map((tab) => (
+				<div key={tab.name} data-tab={tab.name}>
+					{children(tab)}
+				</div>
+			))}
+		</div>
+	),
+	Tooltip: ({ children }) => children,
+	__experimentalNumberControl: ({ label }) => <div>{label}</div>,
+}));
+
+jest.mock('@wordpress/icons', () => ({
+	check: 'check',
+	globe: 'globe',
+	settings: 'settings',
+	undo: 'undo',
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+}));
+
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	sprintf: (format, ...args) => {
+		let next = 0;
+		return format.replace(/%(?:(\d+)\$)?s/g, (match, position) =>
+			position ? args[Number(position) - 1] : args[next++]
+		);
+	},
+}));
+
+jest.mock('../../../../token-controls/molecules/ColorPicker', () => ({
+	ColorPicker: ({ onChange }) => (
+		<button type="button" data-testid="color-picker" onClick={() => onChange('#abcdef')} />
+	),
+}));
+
+jest.mock('../../../../token-controls/styles/token-controls.scss', () => ({}), { virtual: true });
+
+const GROUPS = [
+	{
+		id: 'accent',
+		label: 'Accent',
+		swatches: [
+			{
+				id: 'semantic.color.accent.main',
+				label: 'Main',
+				value: '#3182ce',
+				alias: '{semantic.color.accent.main}',
+			},
+		],
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Mount the field with the given prop overrides.
+ *
+ * @param {Object} props Prop overrides merged over the defaults.
+ *
+ * @return {void}
+ */
+function render(props = {}) {
+	act(() => {
+		root.render(
+			createElement(BorderColorField, {
+				value: '',
+				onChange: jest.fn(),
+				label: null,
+				groups: GROUPS,
+				...props,
+			})
+		);
+	});
+}
+
+describe('BorderColorField', () => {
+	/**
+	 * A token pick reaches `onChange` as the entry's bracket alias, which is the shape this host
+	 * already stores for a border color.
+	 *
+	 * @return {void}
+	 */
+	it('writes a picked token as its bracket alias', () => {
+		const onChange = jest.fn();
+		render({ onChange });
+
+		act(() => {
+			container.querySelector('.kb-color-control__item').click();
+		});
+
+		expect(onChange).toHaveBeenCalledWith('{semantic.color.accent.main}');
+	});
+
+	/**
+	 * A Custom-tab color reaches the same `onChange` as a raw literal, never converted to an alias.
+	 *
+	 * @return {void}
+	 */
+	it('writes a custom color as a raw literal', () => {
+		const onChange = jest.fn();
+		render({ onChange });
+
+		act(() => {
+			container.querySelector('[data-testid="color-picker"]').click();
+		});
+
+		expect(onChange).toHaveBeenCalledWith('#abcdef');
+	});
+
+	/**
+	 * Clear returns the side to unset. This is new surface rather than preserved surface — the
+	 * widget this replaced passed `hideClear`, so a border color could not be unset at all.
+	 *
+	 * @return {void}
+	 */
+	it('clears the side back to unset', () => {
+		const onChange = jest.fn();
+		render({ onChange, value: '#171717' });
+
+		act(() => {
+			container.querySelector('.kb-color-control__clear').click();
+		});
+
+		expect(onChange).toHaveBeenCalledWith('');
+	});
+
+	/**
+	 * An unlinked row names its own side so the four swatches, which carry no visible text, do not
+	 * read as four copies of one field; the linked row takes the bare name.
+	 *
+	 * @return {void}
+	 */
+	it('names the row by its side, and generically while linked', () => {
+		render({ label: 'top' });
+		expect(container.querySelector('.kb-color-swatch-control__button').getAttribute('aria-label')).toBe(
+			'Top Border Color'
+		);
+
+		render({ label: null });
+		expect(container.querySelector('.kb-color-swatch-control__button').getAttribute('aria-label')).toBe(
+			'Border Color'
+		);
+	});
+});

--- a/src/extension/design-tokens/components/border-color.js
+++ b/src/extension/design-tokens/components/border-color.js
@@ -1,81 +1,65 @@
 /**
- * The default `renderColor` for `EditorBorderControl`.
+ * The block editor's color field for one `BorderControl` row.
  *
- * Kept out of `EditorBorderControl.js` for the reason `shadow-color.js` is kept out of
- * `EditorShadowControl.js`: it is the one piece that reaches for `@kadence/components`, whose
- * `dist/cjs` build ships bare `import` statements Jest cannot parse, so importing it into the
- * component would make that component untestable in isolation.
+ * Sits beside `color-literal.js` and `use-color-groups.js`, the two halves of a `ColorControl`'s
+ * data in this host, because it is the editor's own adapter rather than part of the host-agnostic
+ * control library: it knows how a border side is named in this editor and how a token resolves
+ * against this document.
+ *
+ * Border color is bundled with width and style inside one nested attribute, so it has no
+ * `ColorControl` row of its own; this renders the compact `ColorSwatchControl` into the slot
+ * `BorderControl` leaves for it, opening the same grouped popover every other color control opens.
  */
 
 /**
  * WordPress dependencies
  */
-import { PopColorControl } from '@kadence/components';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * The translated name of one border side.
- *
- * `BorderControl` names its rows in English (`top`, `right`, …) because those are the keys of the
- * value it edits, not display text. Capitalizing the key leaves it in English, so the side is spelled
- * out here per side rather than derived — the four are a closed set, and a translator needs the whole
- * phrase in front of them to render "Top Border Color" naturally in a language that orders it
- * differently.
- *
- * @param {string} side The side key: `top`, `right`, `bottom` or `left`.
- *
- * @since TBD
- *
- * @return {string} The translated side name, or the key itself when it is not one of the four.
+ * Internal dependencies
  */
-function sideLabel(side) {
-	const names = {
-		top: __('Top', 'kadence-blocks'),
-		right: __('Right', 'kadence-blocks'),
-		bottom: __('Bottom', 'kadence-blocks'),
-		left: __('Left', 'kadence-blocks'),
-	};
-
-	return names[side] ?? side;
-}
+import { ColorSwatchControl, sideLabel } from '../../../token-controls';
+import { resolveColorLiteral } from '../color-literal';
 
 /**
- * Render the shared color field for one border row.
+ * Render the color field for one border row.
  *
- * `BorderControl`'s row anatomy calls this once per row with that row's own resolved color scalar
- * (via `readSlot()`), never the whole four-element axis, the same way it reads `width` and `style`
- * per row — so this only ever renders a single swatch per call.
+ * `BorderControl`'s row anatomy calls its `renderColor` once per row with that row's own resolved
+ * color scalar (via `readSlot()`), never the whole four-element axis, so this only ever renders a
+ * single swatch per call.
  *
- * Border color has no token picker of its own: it is bundled with width and style inside one nested
- * attribute, which a single-value control cannot represent without redesigning `BorderControl`. This
- * wires the existing color-picking mechanism back in unchanged; palette colors still resolve to token
- * aliases through the global `PopColorControl` filter.
- *
- * @param {Object}   props          The render-prop's argument.
- * @param {*}        props.value    The row's own resolved color scalar.
- * @param {Function} props.onChange Called with the next color scalar.
- * @param {?string}  [props.label]  The row's own bare side name (e.g. "top"), or `null` while linked.
+ * @param {Object}    props            The component props.
+ * @param {*}         props.value      The row's own resolved color scalar.
+ * @param {Function}  props.onChange   Called with the next color scalar.
+ * @param {?string}   [props.label]    The row's own bare side name (e.g. "top"), or `null` while
+ *                                      linked.
+ * @param {boolean}   [props.disabled] Whether the row is read-only.
+ * @param {Array}     props.groups     The block's effective palette groups, from `useColorGroups()`.
  *
  * @since TBD
  *
  * @return {JSX.Element} The rendered color field.
  */
-export function renderBorderColor({ value, onChange, label }) {
+export function BorderColorField({ value, onChange, label, disabled = false, groups }) {
 	return (
-		<PopColorControl
-			swatchLabel={
+		<ColorSwatchControl
+			label={
 				label
 					? sprintf(
 							/* translators: %s: the border side, already translated — Top, Right, Bottom or Left. */
 							__('%s Border Color', 'kadence-blocks'),
 							sideLabel(label)
 						)
-					: undefined
+					: __('Border Color', 'kadence-blocks')
 			}
 			value={value || ''}
-			default={''}
-			hideClear={true}
-			onChange={onChange}
+			groups={groups}
+			onPick={onChange}
+			onCustom={onChange}
+			onClear={() => onChange('')}
+			resolveLiteral={resolveColorLiteral}
+			disabled={disabled}
 		/>
 	);
 }

--- a/src/extension/design-tokens/components/border-color.js
+++ b/src/extension/design-tokens/components/border-color.js
@@ -3,8 +3,9 @@
  *
  * Sits beside `color-literal.js` and `use-color-groups.js`, the two halves of a `ColorControl`'s
  * data in this host, because it is the editor's own adapter rather than part of the host-agnostic
- * control library: it knows how a border side is named in this editor and how a token resolves
- * against this document.
+ * control library: it knows how a token resolves against this document. The row's accessible name
+ * comes from `borderColorLabel()` in the library, shared with the Style Library so the two hosts
+ * cannot drift on how a border color names itself.
  *
  * Border color is bundled with width and style inside one nested attribute, so it has no
  * `ColorControl` row of its own; this renders the compact `ColorSwatchControl` into the slot
@@ -12,14 +13,9 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
-import { ColorSwatchControl, sideLabel } from '../../../token-controls';
+import { ColorSwatchControl, borderColorLabel } from '../../../token-controls';
 import { resolveColorLiteral } from '../color-literal';
 
 /**
@@ -44,15 +40,7 @@ import { resolveColorLiteral } from '../color-literal';
 export function BorderColorField({ value, onChange, label, disabled = false, groups }) {
 	return (
 		<ColorSwatchControl
-			label={
-				label
-					? sprintf(
-							/* translators: %s: the border side, already translated — Top, Right, Bottom or Left. */
-							__('%s Border Color', 'kadence-blocks'),
-							sideLabel(label)
-						)
-					: __('Border Color', 'kadence-blocks')
-			}
+			label={borderColorLabel(label)}
 			value={value || ''}
 			groups={groups}
 			onPick={onChange}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -852,39 +852,6 @@
 	.kadence-blocks-style-library__field-token-color-select-label {
 		display: none;
 	}
-
-	// The block editor's `PopColorControl`: drop the base-control wrapper's own margin/padding so
-	// the swatch button it renders (`SinglePopColorControl`, via `.single-pop-color`) is the only
-	// thing that takes up space.
-	.components-base-control.kadence-pop-color-control {
-		margin: 0;
-	}
-
-	.kadence-pop-color-container {
-		gap: 0;
-	}
-
-	.kadence-pop-color-label {
-		display: none;
-	}
-}
-
-/*
- * `@kadence/components`' `SinglePopColorControl` draws its own swatch (`.kadence-pop-color-indicate`,
- * inside `.kadence-pop-color-icon-indicate`, inside `.kadence-pop-color-control` — see
- * `single-pop-color-control/index.js:305-312` and `pop-color-control/index.js:55`) at a fixed 28x28,
- * via `pop-color-control/editor.scss`'s own
- * `.kadence-pop-color-control .kadence-pop-color-icon-indicate .kadence-pop-color-indicate` rule —
- * three classes, (0,3,0). Nesting the override inside `.kb-border-control__swatch` alone only adds
- * one class on top of that same three-class chain's tail, tying rather than beating it — a tie a
- * later-loaded CSS file could still lose depending on enqueue order. Written here as a standalone
- * rule qualified by both `.kb-border-control__box` and `.kb-border-control__swatch` (both real
- * ancestors — see `BorderControl.js`'s row markup) reaches four classes, (0,4,0), which wins outright
- * regardless of load order.
- */
-.kb-border-control__box .kb-border-control__swatch .kadence-pop-color-icon-indicate .kadence-pop-color-indicate {
-	width: 20px;
-	height: 20px;
 }
 
 /*


### PR DESCRIPTION
## Summary

Switches the block editor's border color from `PopColorControl` to the shared `ColorSwatchControl`, so a border's color opens the same grouped popover as every other color control in the product.

`border-color.js` exported a plain `renderBorderColor` function with no access to palette data. It now exports a `BorderColorField` component taking `groups`. Both blocks that use it already call `useColorGroups(clientId)`, so each defines the render prop once:

```js
const renderBorderColor = useCallback((row) => <BorderColorField {...row} groups={colorGroups} />, [colorGroups]);
```

That local shadows what the import used to provide, so all seven `renderColor={renderBorderColor}` sites are untouched — six in `singlebtn`, one in `advancedheading`.

The file's docblock previously explained that it was kept out of `EditorBorderControl.js` because `@kadence/components`' `dist/cjs` build ships bare `import` statements Jest cannot parse. Dropping `PopColorControl` removes that constraint, so the docblock is rewritten: the file stays where it is because it is the editor's color adapter, beside `shadow-color.js`.

## Stored values are unchanged

`register-color-control-filters.js` already rewrote token-backed palette swatches to their `{alias}`, so `PopColorControl` was writing bracket aliases into `borderStyle.color` — exactly what the new control speaks. Colors stored as raw literals keep working: they match no entry and the swatch paints them directly.

## One narrowing worth a reviewer's attention

The border color loses `PopColorControl`'s wider swatch set — custom colors, recents, and the native picker grid — in exchange for the palette's four groups plus a Custom tab. That is the point of the change, but it is a shorter list than what ships today.

A legacy color stored as `var(--global-palette1)` is handled by the guard added in the first PR of this chain: it opens on Style Library rather than the Custom tab, and the swatch still paints it.

## CSS

Deletes the rules that existed only to strip `PopColorControl`'s chrome inside `.kb-border-control__swatch`, including the standalone `(0,4,0)` specificity override of its 28×28 swatch. Box shadow still renders `PopColorControl`, and its rules are untouched.

<img width="1480" height="812" alt="screenshot-1788205187480-22" src="https://github.com/user-attachments/assets/ce9225ad-f381-4c27-817c-01a7dadd7c55" />

## Test plan

- `npx wp-scripts test-unit-js src/token-controls src/extension src/blocks` — 60 suites, 929 tests green
- Verified in the editor on `kadence/singlebtn` and `kadence/advancedheading`: the grouped popover opens, a pick writes the token alias to all four sides and paints on the canvas, unlinked mode gives four swatches with distinct accessible names, per-side writes stay isolated, the Custom tab seeds from the bound token, and Clear affects only its own side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated border color controls across heading and button settings with a more consistent color selection experience.
  * Added support for color palettes, custom colors, clearing selections, and disabled states.
  * Improved border color labels and handling for individual sides.

* **Style**
  * Refined color swatch styling for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->