### PR TITLE
[DTM] SOFT-4261 [4/4]: Open the shared color popover from a border row in the Style Library

### DIFF
--- a/src/style-library/__tests__/ColorSelectField.test.js
+++ b/src/style-library/__tests__/ColorSelectField.test.js
@@ -224,7 +224,7 @@ describe('ColorSelectField', () => {
 	});
 
 	/**
-	 * `field.readOnly` disables the control the same way it disables `TokenColorSelectField`.
+	 * `field.readOnly` makes the control non-interactive, matching every other read-only field.
 	 *
 	 * @return {void}
 	 */

--- a/src/style-library/__tests__/ColorSelectField.test.js
+++ b/src/style-library/__tests__/ColorSelectField.test.js
@@ -8,12 +8,8 @@ import { createRoot } from 'react-dom/client';
 /**
  * Internal dependencies
  */
-import {
-	ColorSelectField,
-	resolveLiteral,
-	toControlValue,
-	toStoredValue,
-} from '../components/molecules/fields/ColorSelectField';
+import { ColorSelectField } from '../components/molecules/fields/ColorSelectField';
+import { resolveLiteral, toControlValue, toStoredValue } from '../helpers/color-values';
 import { getDesignTokensFeed } from '../helpers/tokens';
 
 const NAMESPACE = 'kb-design-tokens/v1';

--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -250,7 +250,13 @@ describe('BorderField', () => {
 		expect(latestBorderControlProps.disabled).toBe(true);
 	});
 
-	it('renders the color sub-field through the existing TokenColorSelectField, not a new component', () => {
+	/**
+	 * The color sub-field is the shared compact swatch control, so a border's color opens the same
+	 * grouped Style Library / Custom popover every other color control opens.
+	 *
+	 * @return {void}
+	 */
+	it('renders the color sub-field through the shared ColorSwatchControl', () => {
 		act(() => {
 			root.render(
 				createElement(BorderField, {
@@ -261,9 +267,9 @@ describe('BorderField', () => {
 			);
 		});
 
-		const element = latestBorderControlProps.renderColor({ value: '', onChange: jest.fn() });
+		const element = latestBorderControlProps.renderColor({ value: '', onChange: jest.fn(), label: null });
 
-		expect(element.type.name).toBe('TokenColorSelectField');
+		expect(element.type.name).toBe('ColorSwatchControl');
 	});
 
 	it('a width pick writes only the width path, a style change writes only the style path, color stays where it was', () => {

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -22,10 +22,13 @@
  * `BoxControl` — so this adapter fixes the unit at `px` (the only unit the `border-width` scale's
  * tokens use) rather than tracking one the way `BoxTokenField` tracks radius/spacing's unit.
  *
- * Color is out of this plan's scope (see `BorderControl`'s own docblock): `renderColor` wraps the
- * same `TokenColorSelectField` the Button screen's Color panel already renders for text/background,
- * rather than building or importing anything new. Color's own path carries no breakpoint envelope —
- * a border color has never varied by breakpoint here, so its path always stores the plain value.
+ * Color's own sub-field is the shared `ColorSwatchControl` — `renderColor` wraps it here the same
+ * way the block editor's own `BorderControl` host does, so a border's color opens the same grouped
+ * Style Library / Custom popover `ColorSelectField` opens, bridged through the
+ * `toControlValue`/`toStoredValue`/`resolveLiteral` pair `helpers/color-values.js` shares with that
+ * field, since this host stores a bare token id, not a bracket alias. Color's own path carries no
+ * breakpoint envelope — a border color has never varied by breakpoint here, so its path always
+ * stores the plain value.
  *
  * Link state is owned here, controlled, exactly the way `BoxTokenField` owns it for radius/spacing
  * — not derived from whether the stored value happens to be a scalar or a four-slot list.
@@ -39,15 +42,10 @@
  */
 
 /**
- * External dependencies
- */
-import { upperFirst } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -66,7 +64,9 @@ import { boundTokenIds, withoutSemanticSlots } from './BoxTokenField';
 import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
 import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
 import { isSlotList, readSlot } from '../../../../token-controls/helpers/value-shapes';
-import { TokenColorSelectField } from './TokenColorSelectField';
+import { ColorSwatchControl, sideLabel } from '../../../../token-controls';
+import { resolveLiteral, toControlValue, toStoredValue } from '../../../helpers/color-values';
+import { useActivePaletteGroups } from '../../../hooks/use-active-palette-groups';
 
 /**
  * The only unit border width is stored in — the `border-width` scale's tokens (`1px`, `2px`,
@@ -243,6 +243,8 @@ export function BorderField({ field, values, originalValues, onValueChange }) {
 	// Shared, not local: this switches every responsive control in the panel at once.
 	const [breakpoint, setBreakpoint] = useBreakpoint(PRESET_BREAKPOINTS[0]);
 
+	const groups = useActivePaletteGroups();
+
 	const widthPath = `${field.path}-width`;
 	const stylePath = `${field.path}-style`;
 	const colorPath = `${field.path}-color`;
@@ -331,19 +333,29 @@ export function BorderField({ field, values, originalValues, onValueChange }) {
 			label={field.label}
 			widthTokens={widthTokens}
 			defaultValue={field.defaultValue}
-			renderColor={({ value: color, onChange: onColorChange, label: sideLabel }) => (
-				<TokenColorSelectField
-					// `sideLabel` is the row's bare side name ("top", "right", …), or `null` while linked.
-					// Capitalized and used as the field's own name so unlinked mode's four swatches — one
-					// per row now instead of sharing the linked "Color" name — read as distinct fields to
-					// a screen reader, matching `styleLabel`'s per-side naming a few lines up in
-					// `BorderControl`.
-					field={{
-						label: sideLabel ? upperFirst(sideLabel) : __('Color', 'kadence-blocks'),
-						readOnly: field.readOnly,
-					}}
-					value={color}
-					onChange={onColorChange}
+			renderColor={({ value: color, onChange: onColorChange, label: side }) => (
+				<ColorSwatchControl
+					// `side` is the row's bare side name ("top", "right", …), or `null` while linked. Each
+					// row gets a distinct accessible name so unlinked mode's four swatches — which carry no
+					// visible text at all — do not read as four copies of the same field.
+					label={
+						side
+							? sprintf(
+									/* translators: %s: the border side, already translated — Top, Right, Bottom or Left. */
+									__('%s Border Color', 'kadence-blocks'),
+									sideLabel(side)
+								)
+							: __('Border Color', 'kadence-blocks')
+					}
+					// This host stores a BARE token id, never a bracket alias, so the value is bridged in
+					// both directions with the same pair `ColorSelectField` already uses.
+					value={toControlValue(color)}
+					groups={groups}
+					onPick={(alias) => onColorChange(toStoredValue(alias))}
+					onCustom={(literal) => onColorChange(literal)}
+					onClear={() => onColorChange('')}
+					resolveLiteral={resolveLiteral}
+					disabled={field.readOnly}
 				/>
 			)}
 			breakpoints={responsive ? PRESET_BREAKPOINTS : null}

--- a/src/style-library/components/molecules/fields/BorderField.js
+++ b/src/style-library/components/molecules/fields/BorderField.js
@@ -45,7 +45,6 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -64,7 +63,7 @@ import { boundTokenIds, withoutSemanticSlots } from './BoxTokenField';
 import { useBreakpoint } from '../../../../token-controls/context/breakpoint';
 import { parseCssLength } from '../../../../token-controls/helpers/parse-css-length';
 import { isSlotList, readSlot } from '../../../../token-controls/helpers/value-shapes';
-import { ColorSwatchControl, sideLabel } from '../../../../token-controls';
+import { ColorSwatchControl, borderColorLabel } from '../../../../token-controls';
 import { resolveLiteral, toControlValue, toStoredValue } from '../../../helpers/color-values';
 import { useActivePaletteGroups } from '../../../hooks/use-active-palette-groups';
 
@@ -338,15 +337,7 @@ export function BorderField({ field, values, originalValues, onValueChange }) {
 					// `side` is the row's bare side name ("top", "right", …), or `null` while linked. Each
 					// row gets a distinct accessible name so unlinked mode's four swatches — which carry no
 					// visible text at all — do not read as four copies of the same field.
-					label={
-						side
-							? sprintf(
-									/* translators: %s: the border side, already translated — Top, Right, Bottom or Left. */
-									__('%s Border Color', 'kadence-blocks'),
-									sideLabel(side)
-								)
-							: __('Border Color', 'kadence-blocks')
-					}
+					label={borderColorLabel(side)}
 					// This host stores a BARE token id, never a bracket alias, so the value is bridged in
 					// both directions with the same pair `ColorSelectField` already uses.
 					value={toControlValue(color)}

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -15,8 +15,9 @@
  * shadow, so this adapter reads and writes `field.path`'s value directly, with no breakpoint
  * envelope — unlike `BorderField`/`BoxTokenField`.
  *
- * Color is out of this plan's scope, exactly as in `BorderField`: `renderColor` wraps the same
- * `TokenColorSelectField` the Button screen's Color panel already renders.
+ * Color stays out of scope here — a shadow's color packs opacity into the same value, which the
+ * shared color popover has no place for — so `renderColor` still wraps `TokenColorSelectField`.
+ * `BorderField` no longer does; this is now the only field that renders it.
  */
 
 /**

--- a/src/style-library/components/molecules/fields/ColorSelectField.js
+++ b/src/style-library/components/molecules/fields/ColorSelectField.js
@@ -10,84 +10,23 @@
  * Value format bridge: a `token-color-select`-style field stores a BARE token id (e.g.
  * `semantic.color.accent.main`), never a bracket alias — the stored attribute shape does not
  * change here. `ColorControl` itself only understands a bracket alias (`{semantic.color.accent.main}`)
- * or a raw literal, so this adapter translates at the write boundary: `isTokenId()` (the same
- * `primitive.`/`semantic.` prefix check `token-controls` already exports) tells a bare id apart from
- * a literal on read, and a pick's alias has its brackets stripped back off before it is written.
+ * or a raw literal, so `resolveLiteral`/`toControlValue`/`toStoredValue` (in
+ * `helpers/color-values.js`, shared with `BorderField`'s color axis) translate at the write
+ * boundary — see that file's own docblock for the full reasoning.
  *
- * Palette source: unlike the block editor, which has to resolve a block's own possibly-pinned
- * `kbPalette`, the Button preset page has no per-row palette override to consider — it always shows
- * the SITE's active palette, `listing.currentId` in `usePalettes()`'s own vocabulary. Reading that
- * requires only the same store selector `usePalettes()` itself calls (`getPaletteListing`, via
- * `useSelect`) — not the full hook, which also wires `route`/`navigate` and every palette WRITE flow
- * this read-only field never needs, and which `SettingsForm`'s field contract has no slot to pass in
- * regardless (a field only ever receives `field`/`value`/`onChange`/`values`/`onValueChange`, matching
- * `TokenColorSelectField`'s own self-sourcing of the pickable pool via `getDesignTokensFeed()`).
- *
- * `resolveLiteral` needs no CSS-variable read the way the block editor's `resolveColorLiteral` does:
- * `mapPaletteToColorControlGroups()` already carries each swatch's resolved `$value` literal
- * (sourced from the palette's own effective view, not a JS-recomputed one), so the Custom tab seeds
- * directly from the entry already in `groups`.
+ * Palette source: the read lives in `useActivePaletteGroups`, shared with `BorderField` — both hosts
+ * of a color control need the SITE's active palette and neither has a per-row override to resolve,
+ * so the shared hook reads only the store selector `usePalettes()` itself calls (`getPaletteListing`),
+ * not the full hook, which also wires `route`/`navigate` and every palette WRITE flow a read-only
+ * field never needs.
  */
-
-/**
- * WordPress dependencies
- */
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { ColorControl, isTokenId, mapPaletteToColorControlGroups } from '../../../../token-controls';
-import { getDesignTokensFeed } from '../../../helpers/tokens';
-// `STORE_NAME` comes from `store/constants` directly, not `store` (the index every hook imports
-// it from) — the index's module body calls `register(createReduxStore(...))`, pulling in
-// `store/resolvers.js` and, through it, `api/client.js`'s `@wordpress/api-fetch` import. That is
-// fine inside a hook, which only ever runs after the app root has already registered the store
-// once, but `field-types.js` (this field's registry entry) is a much wider dependency: several
-// existing field/schema tests import it without ever booting the app, and registering the store a
-// second time from here would import `@wordpress/api-fetch` into every one of them, a package this
-// repo only ships as the `wp.apiFetch` runtime global, not an installed npm dependency.
-import { EMPTY_LISTING, STORE_NAME } from '../../../store/constants';
-
-/**
- * Resolve a token entry's literal from its own already-shaped `value` — see this file's docblock
- * for why no CSS-variable read is needed here, unlike the block-editor host's adapter.
- *
- * @param {Object} entry The token entry (`{ id, label, value, alias }`) to resolve.
- *
- * @since TBD
- *
- * @return {string} The entry's resolved literal.
- */
-export function resolveLiteral(entry) {
-	return entry.value;
-}
-
-/**
- * Bridge a stored bare token id (or raw literal) into `ColorControl`'s own value contract.
- *
- * @param {string} value The stored value: a bare token id, a raw literal, or empty.
- *
- * @since TBD
- *
- * @return {string} The bracket alias for a token id, the literal unchanged, or ''.
- */
-export function toControlValue(value) {
-	return isTokenId(value) ? `{${value}}` : value || '';
-}
-
-/**
- * Bridge `ColorControl`'s picked alias back into the bare id this field stores.
- *
- * @param {string} alias The bracket alias `onPick` handed back (e.g. `{semantic.color.accent.main}`).
- *
- * @since TBD
- *
- * @return {string} The bare token id.
- */
-export function toStoredValue(alias) {
-	return alias.slice(1, -1);
-}
+import { ColorControl } from '../../../../token-controls';
+import { resolveLiteral, toControlValue, toStoredValue } from '../../../helpers/color-values';
+import { useActivePaletteGroups } from '../../../hooks/use-active-palette-groups';
 
 /**
  * Render a color-select field.
@@ -104,17 +43,7 @@ export function toStoredValue(alias) {
  * @return {JSX.Element} The field.
  */
 export function ColorSelectField({ field, value, onChange }) {
-	const feed = getDesignTokensFeed();
-	const namespace = feed?.rest?.namespace;
-	const slug = feed?.slug;
-
-	const listing = useSelect(
-		(select) => (namespace && slug ? select(STORE_NAME).getPaletteListing(namespace, slug) : EMPTY_LISTING),
-		[namespace, slug]
-	);
-
-	const activeRow = listing.palettes.find((row) => row.id === listing.currentId) ?? null;
-	const groups = mapPaletteToColorControlGroups(activeRow);
+	const groups = useActivePaletteGroups();
 
 	return (
 		<ColorControl

--- a/src/style-library/components/molecules/fields/ColorSelectField.js
+++ b/src/style-library/components/molecules/fields/ColorSelectField.js
@@ -3,9 +3,9 @@
  * screen's Text / Background rows): the same trigger-plus-popover control the block editor's
  * `singlebtn` inspector uses, bridged to this host's own palette data and stored-value shape.
  *
- * `TokenColorSelectField.js` stays in place unchanged — it is still `BorderField`/`BoxShadowField`'s
- * own color sub-field, out of this control's scope (see the color-control design's border/shadow
- * exclusion). This is a second, additive field type, not a replacement.
+ * `TokenColorSelectField.js` stays in place unchanged — it is now `BoxShadowField`'s own color
+ * sub-field alone, shadow being out of this control's scope (a shadow's color packs opacity into the
+ * same value). This is a second, additive field type, not a replacement.
  *
  * Value format bridge: a `token-color-select`-style field stores a BARE token id (e.g.
  * `semantic.color.accent.main`), never a bracket alias — the stored attribute shape does not

--- a/src/style-library/helpers/color-values.js
+++ b/src/style-library/helpers/color-values.js
@@ -1,0 +1,63 @@
+/**
+ * The value bridge between a Style Library color field's stored shape and `token-controls`' own
+ * `ColorControl`/`ColorSwatchControl` value contract.
+ *
+ * Shared by `ColorSelectField.js` (a preset's Text/Background rows) and `BorderField.js`'s color
+ * axis (see its own docblock) — both fields store a BARE token id (e.g.
+ * `semantic.color.accent.main`), never a bracket alias, so both need the same translation at the
+ * write boundary: `isTokenId()` (the same `primitive.`/`semantic.` prefix check `token-controls`
+ * already exports) tells a bare id apart from a literal on read, and a pick's alias has its brackets
+ * stripped back off before it is written. Pulled out here rather than left on `ColorSelectField` —
+ * its original home — once `BorderField` needed the same bridge too and importing it from a sibling
+ * field component it otherwise has nothing to do with was the wrong shape; this mirrors
+ * `use-active-palette-groups.js`, the palette read the same two fields already share.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { isTokenId } from '../../token-controls';
+
+/**
+ * Resolve a token entry's literal from its own already-shaped `value`.
+ *
+ * No CSS-variable read is needed here, unlike the block-editor host's `resolveColorLiteral`:
+ * `mapPaletteToColorControlGroups()` already carries each swatch's resolved `$value` literal
+ * (sourced from the palette's own effective view, not a JS-recomputed one), so the Custom tab seeds
+ * directly from the entry already in `groups`.
+ *
+ * @param {Object} entry The token entry (`{ id, label, value, alias }`) to resolve.
+ *
+ * @since TBD
+ *
+ * @return {string} The entry's resolved literal.
+ */
+export function resolveLiteral(entry) {
+	return entry.value;
+}
+
+/**
+ * Bridge a stored bare token id (or raw literal) into `ColorControl`'s own value contract.
+ *
+ * @param {string} value The stored value: a bare token id, a raw literal, or empty.
+ *
+ * @since TBD
+ *
+ * @return {string} The bracket alias for a token id, the literal unchanged, or ''.
+ */
+export function toControlValue(value) {
+	return isTokenId(value) ? `{${value}}` : value || '';
+}
+
+/**
+ * Bridge `ColorControl`'s picked alias back into the bare id this field stores.
+ *
+ * @param {string} alias The bracket alias `onPick` handed back (e.g. `{semantic.color.accent.main}`).
+ *
+ * @since TBD
+ *
+ * @return {string} The bare token id.
+ */
+export function toStoredValue(alias) {
+	return alias.slice(1, -1);
+}

--- a/src/style-library/hooks/use-active-palette-groups.js
+++ b/src/style-library/hooks/use-active-palette-groups.js
@@ -1,0 +1,56 @@
+/**
+ * The site's active palette, shaped as a color control's `groups` prop.
+ *
+ * Unlike the block editor, which has to resolve a block's own possibly-pinned `kbPalette`, the Style
+ * Library has no per-row palette override to consider — it always shows the SITE's active palette,
+ * `listing.currentId` in `usePalettes()`'s own vocabulary. Reading that requires only the same store
+ * selector `usePalettes()` itself calls, not the full hook, which also wires `route`/`navigate` and
+ * every palette WRITE flow a read-only field never needs.
+ *
+ * A hook rather than a helper because a field cannot call `useSelect` from inside a render prop —
+ * `BorderField` needs the groups in its own body to hand down to `BorderControl`'s `renderColor`.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { mapPaletteToColorControlGroups } from '../../token-controls';
+import { getDesignTokensFeed } from '../helpers/tokens';
+// `STORE_NAME` comes from `store/constants` directly, not `store` (the index every hook imports
+// it from) — the index's module body calls `register(createReduxStore(...))`, pulling in
+// `store/resolvers.js` and, through it, `api/client.js`'s `@wordpress/api-fetch` import. That is
+// fine inside a hook, which only ever runs after the app root has already registered the store
+// once, but `field-types.js` (the registry entry for the fields that call this) is a much wider
+// dependency: several existing field/schema tests import it without ever booting the app, and
+// registering the store a second time from here would import `@wordpress/api-fetch` into every one
+// of them, a package this repo only ships as the `wp.apiFetch` runtime global, not an installed npm
+// dependency.
+import { EMPTY_LISTING, STORE_NAME } from '../store/constants';
+
+/**
+ * Read the site's active palette as color-control groups.
+ *
+ * @since TBD
+ *
+ * @return {Array} `[{ id, label, swatches: [{ id, label, value, alias }] }]`, empty when the feed or
+ *         the listing is not available.
+ */
+export function useActivePaletteGroups() {
+	const feed = getDesignTokensFeed();
+	const namespace = feed?.rest?.namespace;
+	const slug = feed?.slug;
+
+	const listing = useSelect(
+		(select) => (namespace && slug ? select(STORE_NAME).getPaletteListing(namespace, slug) : EMPTY_LISTING),
+		[namespace, slug]
+	);
+
+	const activeRow = listing.palettes.find((row) => row.id === listing.currentId) ?? null;
+
+	return mapPaletteToColorControlGroups(activeRow);
+}

--- a/src/token-controls/controls/BorderControl.js
+++ b/src/token-controls/controls/BorderControl.js
@@ -3,8 +3,8 @@
  * caller.
  *
  * Border is not a `BoxControl` the way radius and spacing are — it carries two properties per side
- * (width, style) instead of one, and a third (color) this control deliberately does not touch
- * (color is being reworked separately; see `renderColor`). `SlotGrid` still applies unmodified: its
+ * (width, style) instead of one, and a third (color) this control deliberately does not own — the
+ * caller supplies it via `renderColor`. `SlotGrid` still applies unmodified: its
  * `renderSlot` render-prop was already generic, so this control renders a one-box row per slot
  * instead of `BoxControl`'s single `TokenSelector`.
  *
@@ -32,10 +32,9 @@
  * contract; this control simply calls it once per row (once for the linked row, once per side
  * when unlinked)
  * with that row's own resolved color scalar instead of the whole axis, the same way it already
- * reads `width`/`style` per row. A caller's existing `renderColor` — whether it renders a bare
- * swatch or a small swatch-plus-label field like the Style Library's `TokenColorSelectField` —
- * already renders something compact enough to sit in that slot once it only ever receives a scalar
- * (never a four-element list), so no new render-prop was needed.
+ * reads `width`/`style` per row. Both hosts' `renderColor` render the same compact
+ * `ColorSwatchControl`, which already fits that slot once it only ever receives a scalar (never a
+ * four-element list), so no new render-prop was needed.
  */
 
 /**

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -825,11 +825,9 @@
 
 /*
  * The color swatch: sized and rounded to a 20px circle around whatever `renderColor` returns.
- * `renderColor`'s own chrome (padding, border, a visible name label) is stripped back here — the
- * row already carries the box border, and the reference row shows only the swatch, not a labeled
- * field. This only reaches for the swatch's already-established markup (the block editor's
- * `@kadence/components` `PopColorControl`/`SinglePopColorControl` and the Style Library's
- * `TokenColorSelectField`); it does not add any new color-picking UI.
+ * Both hosts pass `ColorSwatchControl`, which already draws a bare 20px round swatch with no
+ * border, padding, or visible name label of its own, so this box only has to size and center it —
+ * no chrome-stripping rules are needed here the way a labeled field would require.
  */
 .kb-border-control__swatch {
 	display: inline-flex;
@@ -838,20 +836,6 @@
 	justify-content: center;
 	width: 20px;
 	height: 20px;
-
-	// The Style Library's `TokenColorSelectField`: drop its bordered/padded toggle chrome and its
-	// visible name label, leaving just the round swatch it already draws at 20px.
-	.kadence-blocks-style-library__field-token-color-select-toggle {
-		width: 20px;
-		height: 20px;
-		padding: 0;
-		border: 0;
-		gap: 0;
-	}
-
-	.kadence-blocks-style-library__field-token-color-select-label {
-		display: none;
-	}
 }
 
 /*


### PR DESCRIPTION
## Summary

Switches the Style Library's border color from `TokenColorSelectField` — a flat, ungrouped menu with no Custom tab — to the shared `ColorSwatchControl`, completing the chain. Both hosts now open the same popover from a border row.

## The value shape differs between hosts

The block editor stores a bracket alias (`{semantic.color.accent.main}`). This host stores a **bare token id** (`semantic.color.accent.main`) — what `TokenColorSelectField` wrote, and what the preset's `${field.path}-color` key holds. `ColorSwatchControl` only speaks bracket aliases, so the value is bridged in both directions, and a Custom-tab literal passes through untouched (running a raw hex through `toStoredValue` would slice off its first and last characters).

Those three functions previously lived in `ColorSelectField.js` and were imported by `BorderField` from its sibling. They move to `src/style-library/helpers/color-values.js`, matching what this chain already did for the palette read, so neither field depends on the other's file.

## Shared palette read

`useActivePaletteGroups()` extracts the active-palette lookup out of `ColorSelectField`. `BorderField` needs it in its own component body, since a hook cannot be called from inside the `renderColor` render prop. The comment explaining why `STORE_NAME` comes from `store/constants` rather than `store` moves with it — that reasoning is the whole point of the odd-looking import.

## Translated side names

`BorderField` used `upperFirst(side)` on the raw English key, so its four unlinked swatches read "Top/Right/Bottom/Left" in every locale. Both hosts now use the shared `sideLabel()` and the same Title Case wording.

## Scope

`TokenColorSelectField` stays — `BoxShadowField` still renders it. Box shadow keeps its existing widgets in both hosts, deliberately: its color slot packs opacity into the same value, which needs its own decision.

`BorderControl.js`'s docblock is corrected here (prose only, no code): it said color "is being reworked separately", which contradicted the same docblock's later paragraph now that the rework has landed. The `.kb-border-control__swatch` comment is updated for the same reason, and the last chrome-stripping rules are deleted.

<img width="1535" height="800" alt="screenshot-1788203677209-21" src="https://github.com/user-attachments/assets/4c133ccb-b6c7-4481-bd72-0b613d42b9cc" />

## Test plan

- `npx wp-scripts test-unit-js src` — 125 suites, 1856 tests green
- `border-shadow-field-rendering.test.js`'s case pinning `TokenColorSelectField` now asserts `ColorSwatchControl`; `ColorSelectField.test.js` passes unmodified, since the extraction moved code rather than behavior
- Verified on the Button preset screen: the same popover opens, and a pick survives Save and a full reload — the popover reopens on the Style Library tab with the chosen swatch checked, confirming the bare-token-id round trip. Box shadow's color row still renders `TokenColorSelectField`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated border color controls to use a consistent color swatch interface.
  * Improved color selection across style fields, including palette tokens, custom values, clearing, and read-only states.
  * Ensured selected colors display correctly whether they come from a palette or a literal value.
  * Added clearer, side-specific labels to improve accessibility when editing border colors.
* **Documentation**
  * Updated BorderControl guidance to reflect the current color swatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->