### PR TITLE
[DTM] Give the editor's color controls the same bottom spacing as their neighbors

### DIFF
--- a/src/blocks/advancedheading/edit.js
+++ b/src/blocks/advancedheading/edit.js
@@ -98,7 +98,8 @@ import { resolveColorLiteral } from '../../extension/design-tokens/color-literal
 import { renderBorderColor } from '../../extension/design-tokens/components/border-color';
 import { tokenDimension } from '../../extension/design-tokens/token-dimension';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
-import { ColorControl, ColorControlGroup } from '../../token-controls';
+import { ColorControl } from '../../token-controls';
+import { EditorColorControlGroup } from '../../extension/design-tokens/components/EditorColorControlGroup';
 import { presetFontVariant } from './preset-font-variant';
 import metadata from './block.json';
 /**
@@ -1871,7 +1872,7 @@ function KadenceAdvancedHeading(props) {
 								{showSettings('colorSettings', 'kadence/advancedheading') && (
 									<>
 										{!enableTextGradient && (
-											<ColorControlGroup>
+											<EditorColorControlGroup>
 												{/* Every write clears the matching `*Class` attribute. Those carry
 												    legacy global-palette CLASSES the heading emits on its own
 												    element, so they beat the color these controls write and a stale
@@ -1920,7 +1921,7 @@ function KadenceAdvancedHeading(props) {
 													}
 													resolveLiteral={resolveColorLiteral}
 												/>
-											</ColorControlGroup>
+											</EditorColorControlGroup>
 										)}
 										<ToggleControl
 											style={{ marginTop: '10px' }}

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -99,7 +99,9 @@ import { EditorShadowControl, hasVisibleShadow } from '../../extension/design-to
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
 import { renderBorderColor } from '../../extension/design-tokens/components/border-color';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
-import { ColorControl, ColorControlGroup } from '../../token-controls';
+import { EditorColorControl } from '../../extension/design-tokens/components/EditorColorControl';
+import { EditorColorControlGroup } from '../../extension/design-tokens/components/EditorColorControlGroup';
+import { ColorControl } from '../../token-controls';
 import { BUTTON_MARGIN_FALLBACK, BUTTON_PADDING_FALLBACK } from '../../token-controls/helpers/button-box-defaults';
 import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
 import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
@@ -1224,7 +1226,7 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundHoverType && (
-															<ColorControl
+															<EditorColorControl
 																label={__('Color Hover', 'kadence-blocks')}
 																value={colorHover ? colorHover : ''}
 																groups={colorGroups}
@@ -1259,7 +1261,7 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundHoverType && (
-															<ColorControl
+															<EditorColorControl
 																label={__('Background Color', 'kadence-blocks')}
 																value={backgroundHover ? backgroundHover : ''}
 																groups={colorGroups}
@@ -1371,7 +1373,7 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === textBackgroundType && (
-															<ColorControl
+															<EditorColorControl
 																label={__('Color', 'kadence-blocks')}
 																value={color ? color : ''}
 																groups={colorGroups}
@@ -1404,7 +1406,7 @@ export default function KadenceButtonEdit(props) {
 															/>
 														)}
 														{'normal' === backgroundType && (
-															<ColorControl
+															<EditorColorControl
 																label={__('Background Color', 'kadence-blocks')}
 																value={background ? background : ''}
 																groups={colorGroups}
@@ -1502,7 +1504,7 @@ export default function KadenceButtonEdit(props) {
 												<HoverToggleControl
 													hover={
 														<>
-															<ColorControl
+															<EditorColorControl
 																label={__('Color Hover', 'kadence-blocks')}
 																value={
 																	colorTransparentHover ? colorTransparentHover : ''
@@ -1543,7 +1545,7 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundTransparentHoverType && (
-																<ColorControl
+																<EditorColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={
 																		backgroundTransparentHover
@@ -1650,7 +1652,7 @@ export default function KadenceButtonEdit(props) {
 													}
 													normal={
 														<>
-															<ColorControl
+															<EditorColorControl
 																label={__('Color', 'kadence-blocks')}
 																value={colorTransparent ? colorTransparent : ''}
 																groups={colorGroups}
@@ -1685,7 +1687,7 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundTransparentType && (
-																<ColorControl
+																<EditorColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={
 																		backgroundTransparent
@@ -1793,7 +1795,7 @@ export default function KadenceButtonEdit(props) {
 												<HoverToggleControl
 													hover={
 														<>
-															<ColorControl
+															<EditorColorControl
 																label={__('Color Hover', 'kadence-blocks')}
 																value={colorStickyHover ? colorStickyHover : ''}
 																groups={colorGroups}
@@ -1830,7 +1832,7 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundStickyHoverType && (
-																<ColorControl
+																<EditorColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={
 																		backgroundStickyHover
@@ -1932,7 +1934,7 @@ export default function KadenceButtonEdit(props) {
 													}
 													normal={
 														<>
-															<ColorControl
+															<EditorColorControl
 																label={__('Color', 'kadence-blocks')}
 																value={colorSticky ? colorSticky : ''}
 																groups={colorGroups}
@@ -1967,7 +1969,7 @@ export default function KadenceButtonEdit(props) {
 																/>
 															)}
 															{'normal' === backgroundStickyType && (
-																<ColorControl
+																<EditorColorControl
 																	label={__('Background Color', 'kadence-blocks')}
 																	value={backgroundSticky ? backgroundSticky : ''}
 																	groups={colorGroups}
@@ -2280,7 +2282,7 @@ export default function KadenceButtonEdit(props) {
 											}}
 											units={['px', 'em', 'rem']}
 										/>
-										<ColorControlGroup>
+										<EditorColorControlGroup>
 											<ColorControl
 												label={__('Icon Color', 'kadence-blocks')}
 												value={iconColor ? iconColor : ''}
@@ -2299,7 +2301,7 @@ export default function KadenceButtonEdit(props) {
 												onClear={() => setAttributes({ iconColorHover: '' })}
 												resolveLiteral={resolveColorLiteral}
 											/>
-										</ColorControlGroup>
+										</EditorColorControlGroup>
 										<ResponsiveMeasureRangeControl
 											label={__('Icon Padding', 'kadence-blocks')}
 											value={undefined !== iconPadding ? iconPadding : ['', '', '', '']}

--- a/src/extension/design-tokens/components/EditorColorControl.js
+++ b/src/extension/design-tokens/components/EditorColorControl.js
@@ -1,0 +1,43 @@
+/**
+ * The block editor's adapter for `src/token-controls`' `ColorControl`.
+ *
+ * Much thinner than `EditorBorderControl`/`EditorBoxControl`/`EditorShadowControl` — `ColorControl`
+ * already takes exactly the value/token contract its callers hold (a bracket alias or literal, the
+ * palette's `groups`, `resolveColorLiteral`), so there is no per-device storage shape or unit to
+ * bridge. This adapter exists for one reason:
+ *
+ * - **wraps itself in `TokenControlRow`** (no `heading`, purely for its `.kb-token-control-row`
+ *   spacing) — `ColorControl` renders no `ControlShell` (its label and `BindingIndicator` live
+ *   inside its own trigger row instead of a header above it; see its own docblock), so unlike
+ *   `EditorBoxControl`'s `BoxControl` it never gets `TokenControlRow`'s margin by any other path.
+ *   Without this wrapper a standalone color row sits flush against whatever the block renders next,
+ *   where every other `Editor*` control keeps a gap. With no `heading` passed, `TokenControlRow`
+ *   renders no header of its own (see its docblock: `attr`/`binding` can be omitted for a control
+ *   that already carries its own indicator, used purely for the row spacing) — `ColorControl`'s
+ *   inline `BindingIndicator` stays the only mark on screen, not a second one layered over it.
+ *
+ * Every other prop passes through untouched.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { ColorControl } from '../../../token-controls';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
+
+/**
+ * Render a color token control wrapped in the editor's row spacing.
+ *
+ * @param {Object} props `ColorControl`'s own props, forwarded untouched.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The wrapped control.
+ */
+export function EditorColorControl(props) {
+	return (
+		<TokenControlRow stacked>
+			<ColorControl {...props} />
+		</TokenControlRow>
+	);
+}

--- a/src/extension/design-tokens/components/EditorColorControlGroup.js
+++ b/src/extension/design-tokens/components/EditorColorControlGroup.js
@@ -1,0 +1,39 @@
+/**
+ * The block editor's adapter for `src/token-controls`' `ColorControlGroup`.
+ *
+ * A separate component from `EditorColorControl` rather than a prop on it, mirroring
+ * `ColorControlGroup` itself living beside `ColorControl` as its own file in `token-controls`: a
+ * group wraps several `ColorControl`s at once, so wrapping happens around the group, not around each
+ * child — `ColorControlGroup` already collapses the shared border between its children into one box,
+ * and a `TokenControlRow` per child would reopen the border AND pad each row apart, undoing that.
+ * Reusable across every block that stacks a Color/Hover Color pair (or similar) this way, rather than
+ * asking each call site to remember to wrap the group element itself instead of its children.
+ *
+ * As with `EditorColorControl`, no `heading` is passed — `TokenControlRow` contributes only the
+ * `.kb-token-control-row` spacing to whatever follows the group, with no second header or indicator
+ * layered over the group's own children.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { ColorControlGroup } from '../../../token-controls';
+import { TokenControlRow } from '../../token-indicators/components/TokenControlRow';
+
+/**
+ * Render a no-gap group of color token controls wrapped in the editor's row spacing.
+ *
+ * @param {Object} props          The component props.
+ * @param {*}      props.children The `ColorControl`s to stack, forwarded untouched.
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The wrapped group.
+ */
+export function EditorColorControlGroup({ children }) {
+	return (
+		<TokenControlRow stacked>
+			<ColorControlGroup>{children}</ColorControlGroup>
+		</TokenControlRow>
+	);
+}


### PR DESCRIPTION
## Summary

In a block's inspector, the color controls have no bottom gap to whatever follows them — "Background Color" sits flush against the "Border" label beneath it, while Border, Border Radius and Box Shadow each keep a clear margin.

Every other editor token control gets that gap from wrapping itself in `TokenControlRow`, whose `.kb-token-control-row:not(:last-child) { margin-bottom: 16px; }` supplies it:

- `EditorBoxControl.js` — `<TokenControlRow stacked>`
- `EditorBorderControl.js` — `<TokenControlRow stacked>`
- `EditorShadowControl.js` — `<TokenControlRow stacked>`

`ColorControl` is never wrapped in one, so it has no margin at all. It cannot wrap itself: it lives in the host-agnostic `src/token-controls/`, and importing from `src/extension/` would invert the library/host dependency direction the codebase deliberately maintains.

## Fix

Adds the missing sibling adapter, `EditorColorControl`, which wraps `ColorControl` in `TokenControlRow` and forwards every prop untouched — the pattern `TokenControlRow`'s own docblock describes:

> `attr`/`binding` can be omitted entirely … for a control with no bound attribute to track at all — used this way purely for the `.kb-token-control-row` spacing/`stacked` layout, e.g. by the `Editor*` design-token controls that already carry their own indicator internally.

That fits `ColorControl`, which renders its own `BindingIndicator` inline. With no `heading`, `TokenControlRow`'s header block renders nothing, so no second indicator appears.

`EditorColorControlGroup` does the same for `ColorControlGroup`. The group stacks its children flush with shared borders, so the wrapper goes around the **group**, never its children — a separate component rather than an inline wrap at each call site, so a future call site cannot wrap the children by mistake.

Call sites: `singlebtn` has 12 standalone controls plus one group; `advancedheading` has one group holding both of its controls.

## No CSS

An earlier attempt did this with two rules in `token-controls.scss`, including one scoped to a Style Library class to cancel the margin where `SettingsForm`'s flex `gap` already spaces fields. That put host-specific knowledge in the shared stylesheet. This approach needs none of it — `TokenControlRow` lives in the editor extension, so the Style Library never sees it. `token-controls.scss` has zero diff.

## Follow-up, not included

Every call site already computes a `tokenBinding.<key>` object, which is the shape `TokenControlRow`'s `attr`/`binding` props expect, so these controls could also get the "highlight edits" tint the other `Editor*` controls have. It needs a `heading` too, so it is its own change.

## Test plan

- `npx wp-scripts test-unit-js src/token-controls src/extension src/blocks` — 58 suites, 915 tests green
- Verified no double indicator: `TokenControlRow`'s header is `{heading ? (...) : null}`, and no `heading` is passed
- `stacked` matches the three sibling adapters; without it the base `.kb-token-control-row` is a centered row-direction flex, which does not let the full-width color trigger fill correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated heading and button color settings with a more consistent editor experience.
  - Improved spacing and presentation for color controls without adding redundant labels or indicators.
  - Preserved existing color options and behavior across normal, hover, transparent, and sticky button styles.
  - Maintained separate icon color controls for precise customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->