### PR TITLE
[DTM] SOFT-4270 [1/2]: Reset the Default palette when it is also the active one

### DIFF
--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -507,6 +507,7 @@ describe('deletePaletteFlow', () => {
 			slug: SLUG,
 			id: 'sunset',
 			currentId: DEFAULT_ID,
+			isUserCreated: true,
 			onReceive,
 			refreshFeed,
 			onBusy,
@@ -529,6 +530,7 @@ describe('deletePaletteFlow', () => {
 				slug: SLUG,
 				id: 'sunset',
 				currentId: 'sunset',
+				isUserCreated: true,
 				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy: jest.fn(),
@@ -568,6 +570,7 @@ describe('deletePaletteFlow', () => {
 			slug: SLUG,
 			id: 'sunset',
 			currentId: 'sunset',
+			isUserCreated: true,
 			successorId: 'forest',
 			onReceive,
 			refreshFeed: jest.fn().mockResolvedValue(undefined),
@@ -583,8 +586,47 @@ describe('deletePaletteFlow', () => {
 		expect(onReceive).toHaveBeenCalledWith(deleteResponse);
 	});
 
-	it('surfaces the default-palette 400 message', async () => {
-		const failure = new Error('The default palette cannot be deleted.');
+	/**
+	 * The shipped state: the baseline default palette is also the live one. Resetting it needs no
+	 * successor — it stays in the listing and stays current — so the request must go out even
+	 * though `id` and `currentId` match and no successor was chosen.
+	 *
+	 * @return void
+	 */
+	it('resets the live baseline palette without asking for a successor', async () => {
+		client.deletePalette.mockResolvedValue(listingRows());
+		const onReceive = jest.fn();
+		const refreshFeed = jest.fn().mockResolvedValue(undefined);
+		const onError = jest.fn();
+
+		await deletePaletteFlow({
+			namespace: NAMESPACE,
+			slug: SLUG,
+			id: DEFAULT_ID,
+			currentId: DEFAULT_ID,
+			isUserCreated: false,
+			successorId: '',
+			onReceive,
+			refreshFeed,
+			onBusy: jest.fn(),
+			onError,
+		});
+
+		expect(client.setCurrentPalette).not.toHaveBeenCalled();
+		expect(client.deletePalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		expect(onReceive).toHaveBeenCalledWith(listingRows());
+		expect(refreshFeed).toHaveBeenCalledWith(SLUG);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * A failed request surfaces the server's own message inline and rejects with the original
+	 * error, so the modal can stay open on it.
+	 *
+	 * @return void
+	 */
+	it('surfaces the request failure message', async () => {
+		const failure = new Error('The palette could not be saved.');
 		client.deletePalette.mockRejectedValue(failure);
 		const onError = jest.fn();
 
@@ -593,6 +635,8 @@ describe('deletePaletteFlow', () => {
 				namespace: NAMESPACE,
 				slug: SLUG,
 				id: DEFAULT_ID,
+				currentId: DEFAULT_ID,
+				isUserCreated: false,
 				onReceive: jest.fn(),
 				refreshFeed: jest.fn(),
 				onBusy: jest.fn(),

--- a/src/style-library/__tests__/palette-reset-modal.test.js
+++ b/src/style-library/__tests__/palette-reset-modal.test.js
@@ -232,4 +232,46 @@ describe('Color Palette reset modal', () => {
 		expect(dialog().querySelector('select')).not.toBeNull();
 		expect(buttonByText(dialog(), 'Delete').disabled).toBe(true);
 	});
+
+	/**
+	 * The modal keeps describing the palette it was opened for while the delete settles. The
+	 * delete's own response drops the row from the listing before the confirm resolves, which
+	 * snaps `editingId` back to the default palette — props derived live at that point would flip
+	 * the still-open modal to the default palette's Reset copy for its closing frame.
+	 *
+	 * @return void
+	 */
+	it('keeps the Delete copy while the deleted palette leaves the listing', async () => {
+		const base = makePalettes();
+		const after = makePalettes();
+		let resolveDelete;
+		const palettes = makePalettes({
+			editingId: 'secondary',
+			activeId: 'secondary',
+			listing: { ...base.listing, currentId: 'secondary' },
+			// The write's `onReceive` lands the post-delete listing — the row gone, the default
+			// palette live again — in the same round trip that confirms it, so the screen
+			// re-renders against that state BEFORE this promise resolves and the modal closes.
+			deletePalette: jest.fn(() => {
+				usePalettes.mockReturnValue(after);
+				root.render(
+					<ColorPaletteScreen label="Color Palette" route={ROUTE} navigate={() => {}} library={LIBRARY} />
+				);
+				return new Promise((resolve) => {
+					resolveDelete = resolve;
+				});
+			}),
+		});
+
+		renderScreen(palettes);
+		act(() => buttonByText(container, 'Delete').click());
+		act(() => buttonByText(dialog(), 'Delete').click());
+
+		// The screen already reads the post-delete listing here, but the confirm has not resolved
+		// yet: the still-open modal must keep naming what was deleted.
+		expect(dialog().getAttribute('aria-label')).toBe('Delete "Secondary"?');
+
+		await act(async () => resolveDelete());
+		expect(dialog()).toBeNull();
+	});
 });

--- a/src/style-library/__tests__/palette-reset-modal.test.js
+++ b/src/style-library/__tests__/palette-reset-modal.test.js
@@ -1,0 +1,235 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ColorPaletteScreen } from '../components/pages/ColorPaletteScreen';
+import { usePalettes } from '../hooks/use-palettes';
+
+// A factory, not bare automocking — `use-palettes.js` pulls in `../api/client`, which imports
+// `@wordpress/api-fetch` (externalized to the `wp.apiFetch` global in production, not an installed
+// npm dependency), so automocking would fail to resolve it. This screen only reads the hook's
+// return value.
+jest.mock('../hooks/use-palettes', () => ({
+	usePalettes: jest.fn(),
+}));
+
+// Same cross-module-copy rationale as `palette-inheritance.test.js`: `@wordpress/components`' own
+// nested `react`/`react-dom` copy trips React's "Invalid hook call" guard under the top-level
+// renderer this test uses. The stand-ins mirror that file's, so the two screen tests mount the same
+// way — `SelectControl` matters most here, since its absence is what this file asserts.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isBusy, isDestructive, variant, icon, ...props }) => <button {...props}>{children}</button>,
+	Notice: ({ children, isDismissible, onRemove, status, ...props }) => <div {...props}>{children}</div>,
+	DropdownMenu: () => null,
+	MenuGroup: ({ children }) => <div>{children}</div>,
+	MenuItem: ({ children, ...props }) => <button {...props}>{children}</button>,
+	Dropdown: ({ renderToggle }) => renderToggle({ isOpen: false, onToggle: () => {} }),
+	Spinner: () => <span className="components-spinner" />,
+	ExternalLink: ({ children, ...props }) => <a {...props}>{children}</a>,
+	Tooltip: ({ children }) => children,
+	Modal: ({ children, title, onRequestClose }) => (
+		<div role="dialog" aria-label={title}>
+			{children}
+		</div>
+	),
+	TextControl: (props) => <input {...props} />,
+	SelectControl: ({ children, options, ...props }) => (
+		<select {...props}>
+			{(options ?? []).map((option) => (
+				<option key={option.value} value={option.value}>
+					{option.label}
+				</option>
+			))}
+		</select>
+	),
+}));
+
+// `@wordpress/icons` nests its own `react` copy for the same reason; the glyphs are only passed
+// through as props here.
+jest.mock('@wordpress/icons', () => ({
+	Icon: (props) => <span className="components-icon" {...props} />,
+	dragHandle: 'dragHandle',
+	moreVertical: 'moreVertical',
+	plus: 'plus',
+	check: 'check',
+	chevronDown: 'chevronDown',
+}));
+
+const LIBRARY = { feed: {}, slug: 'default', version: 1, rest: {}, refreshFeed: jest.fn() };
+const ROUTE = { screen: 'color-palette', scope: 'default', item: '' };
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	jest.clearAllMocks();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Build a `usePalettes` stub sitting in the shipped state: the baseline default palette is the one
+ * being edited AND the live one, with one user-created palette alongside it.
+ *
+ * @param {Object} [overrides] Fields merged over the defaults — e.g. `{ editingId: 'secondary' }`.
+ *
+ * @since TBD
+ *
+ * @return {Object} The `usePalettes` stub.
+ */
+function makePalettes(overrides = {}) {
+	return {
+		listing: {
+			defaultId: 'default',
+			currentId: 'default',
+			palettes: [
+				{ id: 'default', label: 'Default', groups: [] },
+				{ id: 'secondary', label: 'Secondary', groups: [] },
+			],
+			userCreated: ['secondary'],
+		},
+		activeId: 'default',
+		editingId: 'default',
+		isEditingActive: true,
+		palette: { groups: [] },
+		isLoading: false,
+		isBusy: false,
+		openError: null,
+		activateError: null,
+		createError: null,
+		renameError: null,
+		deleteError: null,
+		structureError: null,
+		clearOpenError: jest.fn(),
+		clearActivateError: jest.fn(),
+		clearCreateError: jest.fn(),
+		clearRenameError: jest.fn(),
+		clearDeleteError: jest.fn(),
+		clearStructureError: jest.fn(),
+		openPalette: jest.fn(() => Promise.resolve()),
+		activatePalette: jest.fn(() => Promise.resolve()),
+		createPalette: jest.fn(() => Promise.resolve()),
+		renamePalette: jest.fn(() => Promise.resolve()),
+		deletePalette: jest.fn(() => Promise.resolve()),
+		saveSwatchEdits: jest.fn(() => Promise.resolve()),
+		removeSwatch: jest.fn(() => Promise.resolve()),
+		resetSwatch: jest.fn(() => Promise.resolve()),
+		isSwatchCustom: jest.fn(() => false),
+		addColor: jest.fn(() => Promise.resolve()),
+		addingGroupIds: [],
+		addGroup: jest.fn(() => Promise.resolve()),
+		reorderSwatches: jest.fn(() => Promise.resolve()),
+		renameGroup: jest.fn(() => Promise.resolve()),
+		removeGroup: jest.fn(() => Promise.resolve()),
+		...overrides,
+	};
+}
+
+/**
+ * Render the screen against a `usePalettes` stub.
+ *
+ * @param {Object} palettes The stub returned by `makePalettes`.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function renderScreen(palettes) {
+	usePalettes.mockReturnValue(palettes);
+
+	act(() =>
+		root.render(<ColorPaletteScreen label="Color Palette" route={ROUTE} navigate={() => {}} library={LIBRARY} />)
+	);
+}
+
+/**
+ * The one button whose text matches, searched inside `scope`.
+ *
+ * @param {Element} scope The element to search under.
+ * @param {string}  text  The exact button label.
+ *
+ * @since TBD
+ *
+ * @return {?Element} The button, or null when nothing matches.
+ */
+function buttonByText(scope, text) {
+	return [...scope.querySelectorAll('button')].find((button) => button.textContent === text) ?? null;
+}
+
+/**
+ * The open modal.
+ *
+ * @since TBD
+ *
+ * @return {?Element} The dialog element, or null while none is open.
+ */
+function dialog() {
+	return container.querySelector('[role="dialog"]');
+}
+
+describe('Color Palette reset modal', () => {
+	/**
+	 * The shipped state — the baseline default palette open and live — offers a Reset, and
+	 * confirming it calls through to the hook with no successor. The screen never asks for one
+	 * because a reset leaves the palette in place and still live.
+	 *
+	 * @return void
+	 */
+	it('confirms a reset of the live default palette with no successor', async () => {
+		const palettes = makePalettes();
+
+		renderScreen(palettes);
+		act(() => buttonByText(container, 'Reset').click());
+
+		expect(dialog().getAttribute('aria-label')).toBe('Reset "Default"?');
+		expect(dialog().querySelector('select')).toBeNull();
+
+		await act(async () => buttonByText(dialog(), 'Reset').click());
+
+		expect(palettes.deletePalette).toHaveBeenCalledWith('default', '');
+	});
+
+	/**
+	 * The same screen still demands a successor for a real delete: a user-created palette that is
+	 * also the live one has to hand the active pointer somewhere before it goes away, so the
+	 * dropdown renders and the confirm button stays disabled until it is answered.
+	 *
+	 * @return void
+	 */
+	it('asks for a successor before deleting the live user-created palette', () => {
+		const base = makePalettes();
+		const palettes = makePalettes({
+			editingId: 'secondary',
+			activeId: 'secondary',
+			// A third palette keeps the choice open. With only one candidate left the modal picks it
+			// for the user and renders no dropdown at all, which would hide what this asserts.
+			listing: {
+				...base.listing,
+				currentId: 'secondary',
+				palettes: [...base.listing.palettes, { id: 'sunset', label: 'Sunset', groups: [] }],
+				userCreated: ['secondary', 'sunset'],
+			},
+		});
+
+		renderScreen(palettes);
+		act(() => buttonByText(container, 'Delete').click());
+
+		expect(dialog().getAttribute('aria-label')).toBe('Delete "Secondary"?');
+		expect(dialog().querySelector('select')).not.toBeNull();
+		expect(buttonByText(dialog(), 'Delete').disabled).toBe(true);
+	});
+});

--- a/src/style-library/__tests__/use-palettes.test.js
+++ b/src/style-library/__tests__/use-palettes.test.js
@@ -90,7 +90,9 @@ const listingRows = (overrides = {}) => [
 		label: 'Sunset',
 		is_default: false,
 		is_current: overrides.currentId === SUNSET_ID,
-		user_created: false,
+		// The palette the shipped baseline does NOT define, so it is the one that is really removed
+		// rather than reset. Deleting it is what the delete tests below mean by a delete.
+		user_created: true,
 		_embedded: { self: [selectedView()] },
 	},
 ];
@@ -339,6 +341,27 @@ describe('usePalettes', () => {
 		expect(client.deletePalette).toHaveBeenCalledWith(NAMESPACE, SUNSET_ID, SLUG);
 		expect(probe.latest().listing.palettes.map((row) => row.id)).toEqual([DEFAULT_ID]);
 		expect(notify.notifySuccess).toHaveBeenCalledWith('Palette deleted.');
+	});
+
+	/**
+	 * Resetting the baseline default palette while it is also the live one issues the DELETE with
+	 * no successor activation, and announces a reset rather than a deletion.
+	 *
+	 * @return void
+	 */
+	it('removePalette resets the live default palette and announces it as a reset', async () => {
+		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.deletePalette.mockResolvedValueOnce(listingRows());
+
+		const probe = mountProbe();
+		await probe.render();
+
+		await act(async () => probe.latest().deletePalette(DEFAULT_ID, ''));
+
+		expect(client.setCurrentPalette).not.toHaveBeenCalled();
+		expect(client.deletePalette).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, SLUG);
+		expect(probe.latest().listing.palettes.map((row) => row.id)).toEqual([DEFAULT_ID, SUNSET_ID]);
+		expect(notify.notifySuccess).toHaveBeenCalledWith('Palette reset.');
 	});
 
 	it('removePalette does not notify success when the write fails', async () => {

--- a/src/style-library/api/client.js
+++ b/src/style-library/api/client.js
@@ -285,8 +285,10 @@ export function deleteSwatch(namespace, id, token, slug) {
 }
 
 /**
- * Delete a palette. The library's default palette cannot be deleted — the server refuses with a
- * 400 — and the response on success is the fresh palette listing.
+ * Delete a palette. A palette the shipped baseline defines — the library's default among them — is
+ * not removed: the request drops its overrides and it stays in the listing under its baseline
+ * colors, which is what the UI offers as a Reset. The response is the fresh palette listing either
+ * way.
  *
  * @param {string} namespace REST namespace.
  * @param {string} id        The palette id.

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -153,7 +153,12 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 
 	// Plain UI state, not route state — a half-typed modal must not enter browser history.
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
-	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+	// A snapshot of the palette the delete modal was opened for, not just an open flag: the
+	// delete's own response drops the row from the listing before the confirm resolves, which
+	// snaps `editingId` back to the default palette while the modal is still open — props derived
+	// live at that point would flip its Delete copy to the default palette's Reset copy for the
+	// closing frame.
+	const [deleteTarget, setDeleteTarget] = useState(null);
 	const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
 	// Carries the whole mapped group entry (`{ id, label, items }`), not just an id, so the modals
 	// can seed the label and count the swatches without a second lookup.
@@ -312,7 +317,15 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 						// Reuses DeleteLibraryModal's own styling — the same red text-link treatment, no
 						// new rule needed for a class this app already ships.
 						className="kadence-blocks-style-library__delete-library-action"
-						onClick={() => setIsDeleteOpen(true)}
+						onClick={() =>
+							setDeleteTarget({
+								id: palettes.editingId,
+								label: paletteDisplayLabel(editingRow),
+								isUserCreated: isEditingUserCreated,
+								successors: paletteSuccessorOptions(palettes.listing, palettes.editingId),
+								isActive: palettes.isEditingActive,
+							})
+						}
 					>
 						{isEditingUserCreated ? __('Delete', 'kadence-blocks') : __('Reset', 'kadence-blocks')}
 					</Button>
@@ -429,23 +442,23 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 					}
 				/>
 			)}
-			{isDeleteOpen && (
+			{deleteTarget && (
 				<DeletePaletteModal
-					label={paletteDisplayLabel(editingRow)}
-					isUserCreated={isEditingUserCreated}
-					successors={paletteSuccessorOptions(palettes.listing, palettes.editingId)}
-					isActive={palettes.isEditingActive}
+					label={deleteTarget.label}
+					isUserCreated={deleteTarget.isUserCreated}
+					successors={deleteTarget.successors}
+					isActive={deleteTarget.isActive}
 					isBusy={palettes.isBusy}
 					error={palettes.deleteError}
 					onClose={() => {
-						setIsDeleteOpen(false);
+						setDeleteTarget(null);
 						palettes.clearDeleteError();
 					}}
 					onConfirm={(successorId) =>
 						palettes
-							.deletePalette(palettes.editingId, successorId)
+							.deletePalette(deleteTarget.id, successorId)
 							.then(() => {
-								setIsDeleteOpen(false);
+								setDeleteTarget(null);
 								palettes.clearDeleteError();
 							})
 							// Swallowed: a request failure already lands in `deleteError`, rendered inline —

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -287,10 +287,9 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 					</>
 				}
 				secondaryAction={
-					// Unlike Delete, available on the default palette too — the server only refuses
-					// DELETING it (`delete_item()`'s explicit default-id guard), not relabeling it
-					// (`update_item()` carries no such guard). Always targets the palette being edited,
-					// exactly like Delete, for the same open/activate-split reason.
+					// Available on the default palette too — no palette write carries a default-id guard.
+					// Always targets the palette being edited, exactly like Delete, for the same
+					// open/activate-split reason.
 					<RenamePaletteModal
 						id={palettes.editingId}
 						currentLabel={paletteDisplayLabel(editingRow)}
@@ -305,8 +304,8 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 					// Always targets the palette being edited, never `activeId`: under the open/activate
 					// split you can be editing a palette that isn't live, and acting on the live one instead
 					// would silently re-tint the site as a side effect of cleaning up an unrelated draft.
-					// The `$default` palette is offered too — as a Reset, since the server refuses to remove
-					// it but does drop its overrides.
+					// The `$default` palette is offered too — as a Reset, since the same request drops its
+					// overrides but leaves the palette itself in the listing.
 					<Button
 						isDestructive
 						variant="link"

--- a/src/style-library/helpers/palette-flows.js
+++ b/src/style-library/helpers/palette-flows.js
@@ -316,6 +316,13 @@ export function createPaletteFlow({
  * Delete a palette, first handing the active pointer to a successor when the palette being deleted
  * is the live one. Mirrors `deleteLibraryFlow`.
  *
+ * Only a user-created palette is really removed. The same request against a palette the shipped
+ * baseline defines — the default among them — drops its overrides and leaves the palette in the
+ * listing, still `$current`, so it is a reset and has nothing to hand the active pointer to. That
+ * is the server's own reading of DELETE (`Palettes_Controller::delete_item()`), and the successor
+ * gate below has to match it: comparing ids alone would refuse to reset the live default palette,
+ * and the request would never be issued.
+ *
  * Activation runs before the delete: left alone the server resolves a dangling `$current` to
  * `$default`, so the site would briefly wear a palette nobody chose.
  *
@@ -325,6 +332,9 @@ export function createPaletteFlow({
  * @param {string}   args.id          The palette id to delete.
  * @param {string}   args.currentId   The listing's `$current` palette id, which decides whether a
  *                                    successor is required at all.
+ * @param {boolean}  args.isUserCreated Whether the palette is removable rather than resettable. A
+ *                                    baseline palette resets in place, so it needs no successor
+ *                                    even while it is the live one.
  * @param {string}   [args.successorId] The palette to make current first. Required only when
  *                                    deleting the current palette.
  * @param {Function} args.onReceive   Called with the FINAL write's own raw response (the delete's,
@@ -345,13 +355,16 @@ export function deletePaletteFlow({
 	slug,
 	id,
 	currentId,
+	isUserCreated,
 	successorId,
 	onReceive,
 	refreshFeed,
 	onBusy,
 	onError,
 }) {
-	const needsSuccessor = id === currentId;
+	// Same gate `DeletePaletteModal` renders its successor dropdown behind, so the modal and the
+	// request it triggers agree on when a successor is needed.
+	const needsSuccessor = id === currentId && isUserCreated;
 
 	if (needsSuccessor && !successorId) {
 		const message = __('Choose which palette your site should use instead.', 'kadence-blocks');
@@ -377,9 +390,9 @@ export function deletePaletteFlow({
 
 /**
  * Rename a palette: re-send its own effective view under the SAME id with a new label. Available
- * for any palette, including the default — the server only refuses DELETING the default palette,
- * not relabeling it (`Palettes_Controller::update_item()` carries no default-id guard, unlike
- * `delete_item()`).
+ * for any palette, including the default — `Palettes_Controller::update_item()` carries no
+ * default-id guard, and neither does any other palette write: the default palette is relabeled,
+ * edited, and reset like the rest, it just cannot be removed from the listing.
  *
  * `id` is never re-derived from `label` here — that is the one deliberate divergence from
  * `createPaletteFlow`, which mints an id from the typed label because it is minting a NEW palette.

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -13,6 +13,7 @@ import {
 	applyOptimisticOverlay,
 	customColorTokenId,
 	isCustomColorToken,
+	isUserCreatedPalette,
 	newSwatchValue,
 	nextCustomColorSlug,
 	reorderGroupSwatches,
@@ -379,23 +380,30 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				return busy;
 			}
 
+			// Decides both halves of what this call means: only a user-created palette is removed and
+			// can need a successor, while a baseline one is reset in place and stays in the listing.
+			const isUserCreated = isUserCreatedPalette(listing, id);
+
 			setDeleteError(null);
 			return deletePaletteFlow({
 				namespace,
 				slug,
 				id,
 				currentId: listing.currentId,
+				isUserCreated,
 				successorId,
 				onReceive,
 				refreshFeed,
 				onBusy: setIsBusy,
 				onError: setDeleteError,
 			}).then((result) => {
-				notifySuccess(__('Palette deleted.', 'kadence-blocks'));
+				notifySuccess(
+					isUserCreated ? __('Palette deleted.', 'kadence-blocks') : __('Palette reset.', 'kadence-blocks')
+				);
 				return result;
 			});
 		},
-		[namespace, slug, listing.currentId, onReceive, refreshFeed]
+		[namespace, slug, listing, onReceive, refreshFeed]
 	);
 
 	const saveSwatchEdits = useCallback(


### PR DESCRIPTION
## Summary

The Default palette could not be reset. Clicking **Reset** on the Default palette while it was also the active one issued no request at all: the modal stayed open showing "Choose which palette your site should use instead." — a demand for a successor palette, with no control rendered to pick one in. The only way out was Cancel.

The modal and the flow behind it disagreed about when a successor is needed. `DeletePaletteModal` had it right — a reset leaves the palette in place and still active, so it renders no successor dropdown and confirms with an empty successor:

```js
const needsSuccessor = isActive && isUserCreated;
```

`deletePaletteFlow` compared ids only, with no user-created dimension, so for the Default palette while it was active it rejected before `deletePalette()` was ever called. `usePalettes`'s `removePalette` passed `currentId` but never the user-created flag, so the flow had no way to tell a reset from a delete.

The server was already correct: `Palettes_Controller::delete_item()` resets a palette the baseline defines and only reassigns `$current` when the palette actually goes away. The request the UI refused to send would have succeeded. **No PHP changes here** — this is the client half.

## What changed

* `deletePaletteFlow` takes `isUserCreated` and gates on `id === currentId && isUserCreated`, the same line the modal draws and the same one `deleteLibraryFlow` already draws with `!isDefaultLibrary(slug)`.
* `removePalette` derives that flag with `isUserCreatedPalette(listing, id)` and announces **"Palette reset."** rather than "Palette deleted." when the palette is one the baseline defines.
* Four comments citing a `delete_item()` default-id guard that no longer exists are corrected — `deletePalette`'s doc in `api/client.js`, two in `ColorPaletteScreen`, and one in `renamePaletteFlow`.

## Tests

* `palette-flows.test.js` — a new case for resetting the live baseline palette (the shipped state, and the one that was broken); the stale `surfaces the default-palette 400 message` case replaced with a plain request-failure case, since the server no longer returns that 400; `isUserCreated` added to the three existing delete cases so they keep exercising the successor path.
* `use-palettes.test.js` — a reset case asserting the DELETE goes out with no successor activation and the notice reads "Palette reset.". The shared fixture's Sunset row is now `user_created: true`, which is what it always meant; without that its sibling's "Palette deleted." assertion would silently flip.
* `palette-reset-modal.test.js` (new) — at the screen level: confirming Reset on the live Default palette reaches the hook with no successor and renders no successor control, while deleting a live user-created palette still renders the dropdown and keeps the confirm button disabled until it is answered.

Restoring the old `id === currentId` gate fails four of these, so the coverage does catch the bug.

## Test plan

* [x] `npx wp-scripts test-unit-js --testPathPattern "src/style-library"` — 66 suites, 928 tests pass.
* [x] eslint and cspell clean on every changed file.
* [x] Manual, on the shipped state (Default palette open and active): clicking Reset now issues `DELETE /kb-design-tokens/v1/palettes/default` (200), the stored override is dropped, the notice reads "Palette reset.", and after a reload the palette is still in the listing and still marked Active.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resetting a shipped palette now removes its customizations while keeping the palette available.
  * Default palettes can be reset without selecting a replacement.
  * User-created palette deletion continues to require a replacement when deleting the active palette.

* **Bug Fixes**
  * Improved palette reset and deletion messaging.
  * Updated reset and deletion behavior for more consistent palette listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->