### PR TITLE
[DTM] SOFT-4270 [2/2]: Badge the Default palette's swatches and let them reset

### DIFF
--- a/src/style-library/__tests__/color-palette-settings.test.js
+++ b/src/style-library/__tests__/color-palette-settings.test.js
@@ -375,6 +375,65 @@ describe('ColorPaletteSettings destructive action', () => {
 	});
 
 	/**
+	 * A settled reset closes the panel. The panel's draft still holds the value the reset just
+	 * undid — `useSettingsPanel` seeds once per item and deliberately ignores later external
+	 * writes — so leaving it open would offer a Save that writes that value straight back.
+	 *
+	 * @return {void}
+	 */
+	it('closes the panel once a reset settles', async () => {
+		const write = deferred();
+		const palettes = makePalettes(write, {
+			isSwatchCustom: jest.fn(() => false),
+			editingId: 'secondary',
+			listing: { defaultId: 'default' },
+			palette: OVERRIDDEN_PALETTE,
+		});
+		const navigate = renderColorPaletteSettings(palettes);
+
+		act(() => {
+			findButton('Reset').click();
+		});
+
+		expect(navigate).not.toHaveBeenCalled();
+
+		await act(async () => {
+			write.resolve();
+			await write.promise;
+		});
+
+		expect(navigate).toHaveBeenCalledWith({ item: '' });
+	});
+
+	/**
+	 * A failed reset leaves the panel open, so the value the write did not change is still in front
+	 * of the user along with the error.
+	 *
+	 * @return {void}
+	 */
+	it('leaves the panel open when a reset fails', async () => {
+		const write = deferred();
+		const palettes = makePalettes(write, {
+			isSwatchCustom: jest.fn(() => false),
+			editingId: 'secondary',
+			listing: { defaultId: 'default' },
+			palette: OVERRIDDEN_PALETTE,
+		});
+		const navigate = renderColorPaletteSettings(palettes);
+
+		act(() => {
+			findButton('Reset').click();
+		});
+
+		await act(async () => {
+			write.reject(new Error('Conflict'));
+			await write.promise.catch(() => {});
+		});
+
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	/**
 	 * A built-in swatch changed away from its shipped value offers Reset on the DEFAULT palette
 	 * too — the server restores the shipped color there rather than dropping the row. It is not a
 	 * custom swatch, so it still offers no Delete. This matches the pill the card itself shows,

--- a/src/style-library/__tests__/color-palette-settings.test.js
+++ b/src/style-library/__tests__/color-palette-settings.test.js
@@ -375,13 +375,14 @@ describe('ColorPaletteSettings destructive action', () => {
 	});
 
 	/**
-	 * A built-in swatch shows neither Delete nor Reset while editing the DEFAULT palette itself —
-	 * there is nothing to revert to (the default palette has no inherited value to fall back on)
-	 * and it is not a custom swatch to delete.
+	 * A built-in swatch changed away from its shipped value offers Reset on the DEFAULT palette
+	 * too — the server restores the shipped color there rather than dropping the row. It is not a
+	 * custom swatch, so it still offers no Delete. This matches the pill the card itself shows,
+	 * so the panel and the card never disagree about the same swatch.
 	 *
 	 * @return {void}
 	 */
-	it('shows neither destructive button for a built-in swatch on the default palette', () => {
+	it('offers Reset but not Delete for a changed built-in swatch on the default palette', () => {
 		const write = deferred();
 		renderColorPaletteSettings(
 			makePalettes(write, {
@@ -393,7 +394,7 @@ describe('ColorPaletteSettings destructive action', () => {
 		);
 
 		expect(findButton('Delete')).toBeNull();
-		expect(findButton('Reset')).toBeNull();
+		expect(findButton('Reset')).not.toBeNull();
 	});
 
 	/**

--- a/src/style-library/__tests__/palette-flows.test.js
+++ b/src/style-library/__tests__/palette-flows.test.js
@@ -845,8 +845,14 @@ describe('revertSwatchFlow', () => {
 		expect(flowArgs.onBusy).toHaveBeenNthCalledWith(2, false);
 	});
 
-	it('surfaces the error and rejects when the backend refuses the revert (e.g. targeting the default palette)', async () => {
-		const failure = new Error('A swatch of the default palette cannot be reverted.');
+	/**
+	 * A failed revert surfaces the server's message and leaves the store and feed untouched, so the
+	 * card keeps showing the value the write did not change.
+	 *
+	 * @return void
+	 */
+	it('surfaces the error and rejects when the revert fails', async () => {
+		const failure = new Error('The palette could not be saved.');
 		client.deleteSwatch.mockRejectedValue(failure);
 		const flowArgs = baseArgs();
 

--- a/src/style-library/__tests__/palette-inheritance.test.js
+++ b/src/style-library/__tests__/palette-inheritance.test.js
@@ -156,17 +156,21 @@ function makePalettes(overrides = {}) {
 /**
  * Render the screen against a `usePalettes` stub.
  *
- * @param {Object} palettes The stub returned by `makePalettes`.
+ * @param {Object}   palettes           The stub returned by `makePalettes`.
+ * @param {Object}   [overrides]        Render overrides.
+ * @param {Object}   [overrides.route]  The route to render with, for the tests that need an open
+ *                                      settings panel (`route.item`).
+ * @param {Function} [overrides.navigate] The route navigator spy.
  *
  * @since TBD
  *
  * @return {void}
  */
-function renderScreen(palettes) {
+function renderScreen(palettes, { route = ROUTE, navigate = () => {} } = {}) {
 	usePalettes.mockReturnValue(palettes);
 
 	act(() =>
-		root.render(<ColorPaletteScreen label="Color Palette" route={ROUTE} navigate={() => {}} library={LIBRARY} />)
+		root.render(<ColorPaletteScreen label="Color Palette" route={route} navigate={navigate} library={LIBRARY} />)
 	);
 }
 
@@ -241,6 +245,35 @@ describe('Color Palette inheritance pills', () => {
 		await act(async () => container.querySelector(`.${PILL_CLASS}--reset`).click());
 
 		expect(palettes.resetSwatch).toHaveBeenCalledWith('accent.two');
+	});
+
+	/**
+	 * With the settings panel open on the same swatch, a settled reset closes it — the panel's draft
+	 * still holds the value the reset just undid, and its Save would write that value back.
+	 *
+	 * @return void
+	 */
+	it('closes the settings panel when the card resets the swatch it has open', async () => {
+		const navigate = jest.fn();
+
+		renderScreen(makePalettes(), { route: { ...ROUTE, item: 'accent.two' }, navigate });
+		await act(async () => container.querySelector(`.${PILL_CLASS}--reset`).click());
+
+		expect(navigate).toHaveBeenCalledWith({ item: '' });
+	});
+
+	/**
+	 * A panel open on a DIFFERENT swatch is left alone — nothing about it went stale.
+	 *
+	 * @return void
+	 */
+	it('leaves a settings panel open on another swatch alone', async () => {
+		const navigate = jest.fn();
+
+		renderScreen(makePalettes(), { route: { ...ROUTE, item: 'accent.one' }, navigate });
+		await act(async () => container.querySelector(`.${PILL_CLASS}--reset`).click());
+
+		expect(navigate).not.toHaveBeenCalled();
 	});
 
 	/**

--- a/src/style-library/__tests__/palette-inheritance.test.js
+++ b/src/style-library/__tests__/palette-inheritance.test.js
@@ -277,6 +277,36 @@ describe('Color Palette inheritance pills', () => {
 	});
 
 	/**
+	 * The card's select button stays live during a write, so the open swatch can change while a
+	 * reset is still in flight. The decision to close reads the swatch that is open when the write
+	 * SETTLES, not the one captured when it started — otherwise the reset closes whatever the user
+	 * opened next.
+	 *
+	 * @return void
+	 */
+	it('leaves a panel opened on another swatch during the write alone', async () => {
+		let settle;
+		const write = new Promise((resolve) => {
+			settle = resolve;
+		});
+		const palettes = makePalettes({ resetSwatch: jest.fn(() => write) });
+		const navigate = jest.fn();
+
+		renderScreen(palettes, { route: { ...ROUTE, item: 'accent.two' }, navigate });
+		act(() => container.querySelector(`.${PILL_CLASS}--reset`).click());
+
+		// The user picks a different swatch before the reset comes back.
+		renderScreen(palettes, { route: { ...ROUTE, item: 'accent.one' }, navigate });
+
+		await act(async () => {
+			settle();
+			await write;
+		});
+
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	/**
 	 * Clicking Reset reverts that one swatch through the hook, naming the swatch's own token.
 	 *
 	 * The click is awaited inside an async `act()`, not the plain synchronous form used elsewhere in

--- a/src/style-library/__tests__/palette-inheritance.test.js
+++ b/src/style-library/__tests__/palette-inheritance.test.js
@@ -190,15 +190,57 @@ describe('Color Palette inheritance pills', () => {
 	});
 
 	/**
-	 * The default palette defines the values, so its cards have nothing to inherit and show no
-	 * pill at all.
+	 * The default palette has no other palette to follow, so its cards measure against the shipped
+	 * value instead: an untouched swatch says it is the default, a changed one offers the way back.
+	 * Neither says "From" — there is nothing to be from.
 	 *
 	 * @return void
 	 */
-	it('shows no pill while the default palette is being edited', () => {
+	it('states the default and offers Reset while the default palette is being edited', () => {
 		renderScreen(makePalettes({ editingId: 'default' }));
 
-		expect(container.querySelectorAll(`.${PILL_CLASS}`)).toHaveLength(0);
+		const pills = [...container.querySelectorAll(`.${PILL_CLASS}`)];
+
+		expect(pills).toHaveLength(2);
+		expect(pills[0].textContent).toBe('Default');
+		expect(pills[0].tagName).toBe('SPAN');
+		expect(pills[1].textContent).toBe('Reset');
+		expect(pills[1].tagName).toBe('BUTTON');
+	});
+
+	/**
+	 * A color someone added has no shipped value behind it, so it can neither claim to be a default
+	 * nor be reset to one, and its card carries no pill at all.
+	 *
+	 * @return void
+	 */
+	it('gives a user-added color on the default palette no pill', () => {
+		renderScreen(
+			makePalettes({
+				editingId: 'default',
+				isSwatchCustom: jest.fn((token) => 'accent.two' === token),
+			})
+		);
+
+		const pills = [...container.querySelectorAll(`.${PILL_CLASS}`)];
+
+		expect(pills).toHaveLength(1);
+		expect(pills[0].textContent).toBe('Default');
+	});
+
+	/**
+	 * Resetting on the default palette goes through the same hook call as anywhere else — the
+	 * server decides that "undo" there means restoring the shipped color.
+	 *
+	 * @return void
+	 */
+	it('resets a changed swatch on the default palette through the hook', async () => {
+		const palettes = makePalettes({ editingId: 'default' });
+
+		renderScreen(palettes);
+		await act(async () => container.querySelector(`.${PILL_CLASS}--reset`).click());
+
+		expect(palettes.resetSwatch).toHaveBeenCalledWith('accent.two');
 	});
 
 	/**

--- a/src/style-library/__tests__/palette-reset-modal.test.js
+++ b/src/style-library/__tests__/palette-reset-modal.test.js
@@ -142,17 +142,21 @@ function makePalettes(overrides = {}) {
 /**
  * Render the screen against a `usePalettes` stub.
  *
- * @param {Object} palettes The stub returned by `makePalettes`.
+ * @param {Object}   palettes             The stub returned by `makePalettes`.
+ * @param {Object}   [overrides]          Render overrides.
+ * @param {Object}   [overrides.route]    The route to render with, for the tests that need an open
+ *                                        settings panel (`route.item`).
+ * @param {Function} [overrides.navigate] The route navigator spy.
  *
  * @since TBD
  *
  * @return {void}
  */
-function renderScreen(palettes) {
+function renderScreen(palettes, { route = ROUTE, navigate = () => {} } = {}) {
 	usePalettes.mockReturnValue(palettes);
 
 	act(() =>
-		root.render(<ColorPaletteScreen label="Color Palette" route={ROUTE} navigate={() => {}} library={LIBRARY} />)
+		root.render(<ColorPaletteScreen label="Color Palette" route={route} navigate={navigate} library={LIBRARY} />)
 	);
 }
 
@@ -201,6 +205,23 @@ describe('Color Palette reset modal', () => {
 		await act(async () => buttonByText(dialog(), 'Reset').click());
 
 		expect(palettes.deletePalette).toHaveBeenCalledWith('default', '');
+	});
+
+	/**
+	 * A palette reset rewrites every swatch, so a settings panel left open would be editing a value
+	 * the reset just replaced — and `useSettingsPanel` seeds once per item, so it cannot follow the
+	 * change. Closing it is the same reasoning as a single swatch's reset, one level up.
+	 *
+	 * @return void
+	 */
+	it('closes an open settings panel once the palette reset settles', async () => {
+		const navigate = jest.fn();
+
+		renderScreen(makePalettes(), { route: { ...ROUTE, item: 'accent.one' }, navigate });
+		act(() => buttonByText(container, 'Reset').click());
+		await act(async () => buttonByText(dialog(), 'Reset').click());
+
+		expect(navigate).toHaveBeenCalledWith({ item: '' });
 	});
 
 	/**

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -911,14 +911,25 @@ describe('swatchPillVariant', () => {
 	});
 
 	/**
-	 * A user-added color still inherits its value from the default palette when viewed anywhere
-	 * else, so the custom flag changes nothing off the default palette.
+	 * A user-added color viewed from another palette still takes its value from the default palette,
+	 * so it names that source like any other swatch.
 	 *
 	 * @return void
 	 */
-	it('treats a user-added color on another palette like any other swatch', () => {
+	it('marks an un-overridden user-added color on another palette as inherited', () => {
 		expect(swatchPillVariant({ isDefault: false, isCustom: true, overridden: false })).toBe('inherited');
-		expect(swatchPillVariant({ isDefault: false, isCustom: true, overridden: true })).toBe('reset');
+	});
+
+	/**
+	 * Override that same color and the card offers no pill: a user-created color is deleted, never
+	 * reset, because nothing shipped it and there is no baseline value to go back to. Delete is its
+	 * action, in the settings panel — which is where it has always been, so the card offering Reset
+	 * put the two surfaces at odds over the same swatch.
+	 *
+	 * @return void
+	 */
+	it('offers no reset for an overridden user-added color on another palette', () => {
+		expect(swatchPillVariant({ isDefault: false, isCustom: true, overridden: true })).toBeNull();
 	});
 });
 

--- a/src/style-library/__tests__/palettes.test.js
+++ b/src/style-library/__tests__/palettes.test.js
@@ -26,6 +26,7 @@ import {
 	slugifyPaletteLabel,
 	stripEffectiveFlags,
 	swatchInitialValues,
+	swatchPillVariant,
 	validateNewGroupLabel,
 } from '../helpers/palettes';
 
@@ -847,6 +848,77 @@ describe('paletteShowsInheritance', () => {
 	 */
 	it('is false when no palette is being edited', () => {
 		expect(paletteShowsInheritance({ defaultId: 'default' }, '')).toBe(false);
+	});
+});
+
+describe('swatchPillVariant', () => {
+	/**
+	 * On the default palette a shipped swatch still carrying its shipped value states that it is
+	 * the default — there is no other palette to name, and nothing to undo.
+	 *
+	 * @return void
+	 */
+	it('marks an untouched shipped swatch on the default palette as the default', () => {
+		expect(swatchPillVariant({ isDefault: true, isCustom: false, overridden: false })).toBe('default');
+	});
+
+	/**
+	 * Changed away from its shipped value, the same swatch offers the way back.
+	 *
+	 * @return void
+	 */
+	it('offers reset for a changed shipped swatch on the default palette', () => {
+		expect(swatchPillVariant({ isDefault: true, isCustom: false, overridden: true })).toBe('reset');
+	});
+
+	/**
+	 * A color someone added has no shipped value behind it, so it can claim neither the default
+	 * pill nor a reset. Its card carries no pill at all — Delete is its affordance, in the
+	 * settings panel.
+	 *
+	 * @return void
+	 */
+	it('gives a user-added color on the default palette no pill', () => {
+		expect(swatchPillVariant({ isDefault: true, isCustom: true, overridden: false })).toBeNull();
+	});
+
+	/**
+	 * A user-added color is never marked overridden on the default palette, but the rule holds
+	 * even if a stale view says otherwise: with no shipped value there is nothing to reset to.
+	 *
+	 * @return void
+	 */
+	it('gives a user-added color no pill even when the view calls it overridden', () => {
+		expect(swatchPillVariant({ isDefault: true, isCustom: true, overridden: true })).toBeNull();
+	});
+
+	/**
+	 * On any other palette an un-overridden swatch names the palette it follows, exactly as before.
+	 *
+	 * @return void
+	 */
+	it('marks an un-overridden swatch on another palette as inherited', () => {
+		expect(swatchPillVariant({ isDefault: false, isCustom: false, overridden: false })).toBe('inherited');
+	});
+
+	/**
+	 * And an overridden one offers the way back to that palette.
+	 *
+	 * @return void
+	 */
+	it('offers reset for an overridden swatch on another palette', () => {
+		expect(swatchPillVariant({ isDefault: false, isCustom: false, overridden: true })).toBe('reset');
+	});
+
+	/**
+	 * A user-added color still inherits its value from the default palette when viewed anywhere
+	 * else, so the custom flag changes nothing off the default palette.
+	 *
+	 * @return void
+	 */
+	it('treats a user-added color on another palette like any other swatch', () => {
+		expect(swatchPillVariant({ isDefault: false, isCustom: true, overridden: false })).toBe('inherited');
+		expect(swatchPillVariant({ isDefault: false, isCustom: true, overridden: true })).toBe('reset');
 	});
 });
 

--- a/src/style-library/__tests__/use-palettes.test.js
+++ b/src/style-library/__tests__/use-palettes.test.js
@@ -709,17 +709,26 @@ describe('usePalettes', () => {
 		expect(notify.notifySuccess).not.toHaveBeenCalled();
 	});
 
-	it('resetSwatch rejects synchronously, without calling deleteSwatch, when editing the default palette', async () => {
+	/**
+	 * Resetting a swatch on the default palette issues the same request as anywhere else. The
+	 * server decides what "undo" means there — it restores the shipped color and keeps the row
+	 * (`Palettes_Controller::delete_swatch()`) — so the hook has no reason to refuse it.
+	 *
+	 * @return void
+	 */
+	it('resetSwatch issues the request while editing the default palette', async () => {
 		client.fetchPalettes.mockResolvedValueOnce(listingRows());
+		client.deleteSwatch.mockResolvedValueOnce(listingRows());
 
 		const probe = mountProbe();
 		await probe.render();
 
 		expect(probe.latest().editingId).toBe(DEFAULT_ID);
 
-		await expect(probe.latest().resetSwatch('primitive.color.brand.primary')).rejects.toThrow();
+		await act(async () => probe.latest().resetSwatch('primitive.color.brand.primary'));
 
-		expect(client.deleteSwatch).not.toHaveBeenCalled();
+		expect(client.deleteSwatch).toHaveBeenCalledWith(NAMESPACE, DEFAULT_ID, 'primitive.color.brand.primary', SLUG);
+		expect(notify.notifySuccess).toHaveBeenCalledWith('Swatch reset.');
 	});
 
 	it('removeGroup flags every swatch in that group pendingDelete immediately, before the write resolves', async () => {

--- a/src/style-library/components/atoms/InheritancePill.js
+++ b/src/style-library/components/atoms/InheritancePill.js
@@ -24,7 +24,9 @@ import './InheritancePill.scss';
  * Render the inheritance pill.
  *
  * @param {Object}   props               The component props.
- * @param {string}   props.variant       `'inherited'` for the static pill, `'reset'` for the button.
+ * @param {string}   props.variant       `'inherited'` for the static pill naming another palette,
+ *                                       `'default'` for the static pill on the default palette
+ *                                       itself, `'reset'` for the button.
  * @param {string}   [props.sourceLabel] The display label of the palette the value comes from.
  * @param {string}   [props.swatchName]  The color's name, used only in the reset button's
  *                                       accessible name — the visible text stays "Reset" so a row
@@ -59,6 +61,17 @@ export function InheritancePill({
 			>
 				{__('Reset', 'kadence-blocks')}
 			</button>
+		);
+	}
+
+	// On the default palette the pill is a statement, not a pointer: this color is the shipped one.
+	// A fixed word, not `sourceLabel` — the default palette can be renamed, and a pill reading
+	// "From Brand" on the palette named Brand would say it follows itself.
+	if ('default' === variant) {
+		return (
+			<span className="kadence-blocks-style-library__inheritance-pill kadence-blocks-style-library__inheritance-pill--inherited">
+				{__('Default', 'kadence-blocks')}
+			</span>
 		);
 	}
 

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -204,13 +204,21 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 			palettes
 				.resetSwatch(token)
 				.then(() => {
+					// A settings panel open on THIS swatch is now editing a value that no longer
+					// exists: its draft still holds the color the reset undid (`useSettingsPanel`
+					// seeds once per item and cannot follow an external write), so its Save would
+					// write that color straight back. A panel on any other swatch is untouched.
+					if (route.item === token) {
+						navigate({ item: '' });
+					}
+
 					card?.querySelector('.kadence-blocks-style-library__swatch-card-select')?.focus();
 				})
 				// Swallowed: a failure already surfaces as a toast from inside `resetSwatch`, and the
 				// card simply keeps showing its override.
 				.catch(() => {});
 		},
-		[palettes.isBusy, palettes.resetSwatch]
+		[palettes.isBusy, palettes.resetSwatch, route.item, navigate]
 	);
 
 	/**

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -9,7 +9,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { Button, DropdownMenu, MenuGroup, MenuItem, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical, plus } from '@wordpress/icons';
@@ -181,8 +181,15 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 	// The swatch whose settings panel is open, readable at any later moment rather than as of the
 	// render a callback closed over — see `handleResetSwatch`, which decides whether to close the
 	// panel only once its write has settled.
+	//
+	// Synced in an effect, never during render: React can start a render and throw it away, and a
+	// ref written on the way through would then hold a route the user is not actually on. Only a
+	// committed render should move it.
 	const openItemRef = useRef(route.item);
-	openItemRef.current = route.item;
+
+	useEffect(() => {
+		openItemRef.current = route.item;
+	}, [route.item]);
 
 	/**
 	 * Reset one swatch's override, then, on success, move focus to that card's own select button —

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -9,7 +9,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { Button, DropdownMenu, MenuGroup, MenuItem, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical, plus } from '@wordpress/icons';
@@ -178,6 +178,12 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 		palettes.listing.palettes.find((row) => row.id === palettes.listing.defaultId)
 	);
 
+	// The swatch whose settings panel is open, readable at any later moment rather than as of the
+	// render a callback closed over — see `handleResetSwatch`, which decides whether to close the
+	// panel only once its write has settled.
+	const openItemRef = useRef(route.item);
+	openItemRef.current = route.item;
+
 	/**
 	 * Reset one swatch's override, then, on success, move focus to that card's own select button —
 	 * the pill that was just clicked is about to unmount (the card flips back to the static "From"
@@ -208,7 +214,13 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 					// exists: its draft still holds the color the reset undid (`useSettingsPanel`
 					// seeds once per item and cannot follow an external write), so its Save would
 					// write that color straight back. A panel on any other swatch is untouched.
-					if (route.item === token) {
+					//
+					// Read through the ref, not this callback's captured `route.item`: a card's
+					// select button stays live during a write (only `isPendingDelete` disables it),
+					// so the open swatch can change before the reset comes back. The captured value
+					// would close whatever the user opened next, and leave open the panel it was
+					// supposed to close.
+					if (openItemRef.current === token) {
 						navigate({ item: '' });
 					}
 
@@ -218,7 +230,7 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 				// card simply keeps showing its override.
 				.catch(() => {});
 		},
-		[palettes.isBusy, palettes.resetSwatch, route.item, navigate]
+		[palettes.isBusy, palettes.resetSwatch, navigate]
 	);
 
 	/**

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -42,6 +42,7 @@ import {
 	paletteDisplayLabel,
 	paletteShowsInheritance,
 	paletteSuccessorOptions,
+	swatchPillVariant,
 } from '../../helpers/palettes';
 import { ColorPaletteSettings } from './ColorPaletteSettings';
 import './ColorPaletteScreen.scss';
@@ -212,6 +213,53 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 		[palettes.isBusy, palettes.resetSwatch]
 	);
 
+	/**
+	 * The pill for one mapped grid item, or null when the card carries none. The variant decision
+	 * itself lives in `swatchPillVariant`; this only turns it into the element.
+	 *
+	 * `sourceLabel` is the default palette's own label off the default palette (the pill names the
+	 * palette a value follows) and the fixed word "Default" on it (a reset there restores the
+	 * shipped color, so that is what the button's accessible name should say it resets to).
+	 *
+	 * @param {Object} item A mapped grid item from `mapPaletteToSwatchGroups()`.
+	 *
+	 * @since TBD
+	 *
+	 * @return {?JSX.Element} The pill, or null.
+	 */
+	const renderPill = useCallback(
+		(item) => {
+			const variant = swatchPillVariant({
+				isDefault: !showsInheritance,
+				isCustom: palettes.isSwatchCustom(item.id),
+				overridden: item.overridden,
+			});
+
+			// Off the default palette the pill names a palette, so a listing that cannot name one
+			// shows nothing rather than a blank source.
+			if (!variant || (showsInheritance && !defaultLabel)) {
+				return null;
+			}
+
+			const sourceLabel = showsInheritance ? defaultLabel : __('Default', 'kadence-blocks');
+
+			if ('reset' === variant) {
+				return (
+					<InheritancePill
+						variant="reset"
+						sourceLabel={sourceLabel}
+						swatchName={item.name}
+						isDisabled={palettes.isBusy || item.pendingDelete}
+						onReset={(event) => handleResetSwatch(event, item.id)}
+					/>
+				);
+			}
+
+			return <InheritancePill variant={variant} sourceLabel={sourceLabel} />;
+		},
+		[showsInheritance, defaultLabel, palettes.isBusy, palettes.isSwatchCustom, handleResetSwatch]
+	);
+
 	const options = useMemo(
 		() =>
 			palettes.listing.palettes.map((row) => ({
@@ -238,21 +286,10 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 					// delete, where reordering something about to vanish is not meaningful.
 					isDraggable: !item.pendingDelete,
 					isPendingDelete: item.pendingDelete,
-					pill:
-						!showsInheritance || !defaultLabel ? null : item.overridden ? (
-							<InheritancePill
-								variant="reset"
-								sourceLabel={defaultLabel}
-								swatchName={item.name}
-								isDisabled={palettes.isBusy || item.pendingDelete}
-								onReset={(event) => handleResetSwatch(event, item.id)}
-							/>
-						) : (
-							<InheritancePill variant="inherited" sourceLabel={defaultLabel} />
-						),
+					pill: renderPill(item),
 				})),
 			})),
-		[palettes.palette, palettes.isBusy, showsInheritance, defaultLabel, handleResetSwatch]
+		[palettes.palette, renderPill]
 	);
 
 	return (

--- a/src/style-library/components/pages/ColorPaletteScreen.js
+++ b/src/style-library/components/pages/ColorPaletteScreen.js
@@ -505,6 +505,12 @@ export function ColorPaletteScreen({ label, route, navigate, library }) {
 							.then(() => {
 								setDeleteTarget(null);
 								palettes.clearDeleteError();
+								// Whatever the settings panel had open is stale now: a reset replaced every
+								// swatch's value, and a delete took the whole palette away. Either way its
+								// draft still holds what was there before — `useSettingsPanel` seeds once
+								// per item and cannot follow an external write — so its Save would put that
+								// back. Same reasoning as a single swatch's reset, one level up.
+								navigate({ item: '' });
 							})
 							// Swallowed: a request failure already lands in `deleteError`, rendered inline —
 							// the modal stays open on it.

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -124,13 +124,16 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 	};
 
 	// A custom swatch is removed entirely (a structure edit, with a best-effort primitive cleanup
-	// after — `removeSwatch` decides that internally). A built-in swatch showing THIS palette's own
-	// override is reverted to inherited instead (`resetSwatch`) — never removed, since its
-	// definition belongs to the default palette, not to the one currently open. A built-in swatch
-	// with nothing to revert here (the default palette itself, or a non-default palette where it
-	// isn't overridden) gets neither action.
+	// after — `removeSwatch` decides that internally). A built-in swatch with something to undo is
+	// reverted instead (`resetSwatch`) — never removed, since the row itself is shipped. What the
+	// revert lands on is the server's call: the palette's inherited value, or the shipped color
+	// when the default palette is the one open. A built-in swatch with nothing to undo gets
+	// neither action.
+	//
+	// Kept in step with the card's own pill (`ColorPaletteScreen`'s `renderPill`) — a card that
+	// offers Reset and a panel that hides it would disagree about the same swatch.
 	const isCustom = palettes.isSwatchCustom(token);
-	const canReset = !isCustom && palettes.editingId !== palettes.listing.defaultId && swatch.overridden;
+	const canReset = !isCustom && swatch.overridden;
 
 	const onDelete = () => {
 		if (palettes.isBusy) {

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -75,8 +75,14 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 	// The open swatch as of right now, for `onReset` to read once its write settles — the grid's
 	// select buttons stay live during a write, so the panel can be showing a different swatch by
 	// then, and closing on the captured one would close that new selection instead.
+	//
+	// Synced in an effect, never during render: a render React starts and discards would otherwise
+	// move the ref to a swatch that was never committed.
 	const openItemRef = useRef(token);
-	openItemRef.current = token;
+
+	useEffect(() => {
+		openItemRef.current = token;
+	}, [token]);
 
 	// The skeleton below lives inside its own `role="status"` region, which only announces "Loading…"
 	// while it is actually mounted — the moment it is replaced by the real panel, that region is

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -158,6 +158,12 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 		setPendingAction('delete');
 		palettes
 			.resetSwatch(token)
+			// Closed on success, the same as `onDelete` and for the same kind of reason: the panel is
+			// editing a value that no longer exists. Its draft still holds the color the reset just
+			// undid — `useSettingsPanel` seeds once per item and deliberately ignores later external
+			// writes, so it cannot follow this one — and a panel left open would offer a Save that
+			// writes that color straight back, silently undoing the reset.
+			.then(() => panel.close())
 			// Swallowed: a failure already surfaces via `notifyError` inside `resetSwatch`, and the
 			// panel simply stays open showing the (unchanged) override.
 			.catch(() => {})

--- a/src/style-library/components/pages/ColorPaletteSettings.js
+++ b/src/style-library/components/pages/ColorPaletteSettings.js
@@ -14,7 +14,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -72,6 +72,11 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 	// the busy animation on only the button the user actually clicked — the `PresetSidebar.js` idiom,
 	// tracked locally for the same reason: only this panel's footer needs the distinction.
 	const [pendingAction, setPendingAction] = useState(null);
+	// The open swatch as of right now, for `onReset` to read once its write settles — the grid's
+	// select buttons stay live during a write, so the panel can be showing a different swatch by
+	// then, and closing on the captured one would close that new selection instead.
+	const openItemRef = useRef(token);
+	openItemRef.current = token;
 
 	// The skeleton below lives inside its own `role="status"` region, which only announces "Loading…"
 	// while it is actually mounted — the moment it is replaced by the real panel, that region is
@@ -155,6 +160,8 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 			return;
 		}
 
+		const resetting = token;
+
 		setPendingAction('delete');
 		palettes
 			.resetSwatch(token)
@@ -163,7 +170,15 @@ export function ColorPaletteSettings({ route, navigate, library }) {
 			// undid — `useSettingsPanel` seeds once per item and deliberately ignores later external
 			// writes, so it cannot follow this one — and a panel left open would offer a Save that
 			// writes that color straight back, silently undoing the reset.
-			.then(() => panel.close())
+			//
+			// Only when the panel is still showing the swatch that was reset — someone can select a
+			// different one while the write is in flight, and closing then would shut a panel that
+			// has nothing stale in it.
+			.then(() => {
+				if (openItemRef.current === resetting) {
+					panel.close();
+				}
+			})
 			// Swallowed: a failure already surfaces via `notifyError` inside `resetSwatch`, and the
 			// panel simply stays open showing the (unchanged) override.
 			.catch(() => {})

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -132,6 +132,42 @@ export function paletteShowsInheritance(listing, editingId) {
 }
 
 /**
+ * Which pill a swatch card carries, if any. Every palette states where its colors stand; what
+ * differs is what "the value it started from" means.
+ *
+ * On a non-default palette that is the default palette: a swatch either follows it, or overrides
+ * it and offers the way back. On the default palette there is no other palette to follow, so the
+ * comparison is against the SHIPPED value instead — which is exactly what its `overridden` flag
+ * already measures (`Palettes_Controller::effective_view()`), and what a reset there restores
+ * (`delete_swatch()` puts the shipped color back rather than dropping the row).
+ *
+ * A user-added color is the one case with no pill: nothing shipped it, so it can neither claim to
+ * be a default nor be reset to one. Its card offers Delete in the settings panel instead. That
+ * only applies on the default palette, which owns the structure the color was added to; seen from
+ * any other palette the color is inherited like every other swatch.
+ *
+ * @param {Object}  args
+ * @param {boolean} args.isDefault  Whether the palette being edited is the default one.
+ * @param {boolean} args.isCustom   Whether the swatch's token was created by a user rather than shipped.
+ * @param {boolean} args.overridden Whether the swatch has anything to undo.
+ *
+ * @since TBD
+ *
+ * @return {?string} `'default'`, `'reset'`, `'inherited'`, or null for no pill.
+ */
+export function swatchPillVariant({ isDefault, isCustom, overridden }) {
+	if (isDefault && isCustom) {
+		return null;
+	}
+
+	if (overridden) {
+		return 'reset';
+	}
+
+	return isDefault ? 'default' : 'inherited';
+}
+
+/**
  * How many swatches in a mapped grid still take their value from the default palette. Groups and
  * swatches that are optimistically deleted are skipped: they are on their way out of the grid, and
  * counting them would state a number the grid is about to contradict.

--- a/src/style-library/helpers/palettes.js
+++ b/src/style-library/helpers/palettes.js
@@ -141,10 +141,12 @@ export function paletteShowsInheritance(listing, editingId) {
  * already measures (`Palettes_Controller::effective_view()`), and what a reset there restores
  * (`delete_swatch()` puts the shipped color back rather than dropping the row).
  *
- * A user-added color is the one case with no pill: nothing shipped it, so it can neither claim to
- * be a default nor be reset to one. Its card offers Delete in the settings panel instead. That
- * only applies on the default palette, which owns the structure the color was added to; seen from
- * any other palette the color is inherited like every other swatch.
+ * A user-added color is never reset, on any palette: nothing shipped it, so there is no baseline
+ * value to go back to, and Delete is its action — the one the settings panel has always offered it.
+ * On the default palette, which owns the structure the color was added to, that leaves it with no
+ * pill at all. Seen from any other palette it still takes its value from the default one, so it
+ * names that source until it is overridden, and then falls silent rather than offering a reset the
+ * panel would refuse.
  *
  * @param {Object}  args
  * @param {boolean} args.isDefault  Whether the palette being edited is the default one.
@@ -156,8 +158,8 @@ export function paletteShowsInheritance(listing, editingId) {
  * @return {?string} `'default'`, `'reset'`, `'inherited'`, or null for no pill.
  */
 export function swatchPillVariant({ isDefault, isCustom, overridden }) {
-	if (isDefault && isCustom) {
-		return null;
+	if (isCustom) {
+		return isDefault || overridden ? null : 'inherited';
 	}
 
 	if (overridden) {

--- a/src/style-library/hooks/use-palettes.js
+++ b/src/style-library/hooks/use-palettes.js
@@ -512,16 +512,20 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 		[feedTokens]
 	);
 
-	// Revert a NON-default palette's own override for a token back to inherited — the counterpart
-	// to `removeSwatch`, for a swatch that is a delta on a built-in token rather than a user-created
-	// one. Not optimistic: unlike a save (where the new value is already known) or a delete (where
-	// "gone" is unambiguous), showing the reverted color instantly would mean guessing the inherited
+	// Undo a palette's own value for one built-in token — the counterpart to `removeSwatch`, which
+	// is for a user-created one. What "undo" resolves to is the server's call and differs by
+	// palette: a non-default palette drops its delta and goes back to inheriting, while the default
+	// palette has nothing to inherit from and gets its SHIPPED color restored instead, keeping the
+	// row (`Palettes_Controller::delete_swatch()`). Both are the same request from here.
+	//
+	// Not optimistic: unlike a save (where the new value is already known) or a delete (where
+	// "gone" is unambiguous), showing the reverted color instantly would mean guessing the restored
 	// value ahead of the response, so this only shows a busy state (`SettingsPanel`'s `isDeleting`,
 	// relabeled "Resetting…" by the caller) until the write confirms.
 	const resetSwatch = useCallback(
 		(token) => {
-			if (!namespace || !slug || editingId === listing.defaultId) {
-				return Promise.reject(new Error('A swatch of the default palette cannot be reverted.'));
+			if (!namespace || !slug) {
+				return Promise.reject(new Error('A swatch cannot be reverted before the library is known.'));
 			}
 
 			const busy = guardBusy();
@@ -540,7 +544,7 @@ export function usePalettes(feed, refreshFeed, route, navigate) {
 				onError: (err) => notifyError(err.message),
 			}).then(() => notifySuccess(__('Swatch reset.', 'kadence-blocks')));
 		},
-		[namespace, slug, listing.defaultId, editingId, onReceive, refreshFeed]
+		[namespace, slug, editingId, onReceive, refreshFeed]
 	);
 
 	const addColor = useCallback(


### PR DESCRIPTION
> Stacked on #1497. Review that one first — this branch is based on it.

## Summary

The Default palette's swatch cards carried no badge at all, and offered no way to undo a color change. Every other palette states where each color stands: a swatch either follows the Default palette, or overrides it and offers **Reset**. The Default palette said nothing.

It now states the same thing in its own terms. It has no other palette to follow, so the comparison is against the **shipped** value:

| Swatch on the Default palette | Badge |
| --- | --- |
| Shipped color, untouched | `Default` |
| Shipped color, changed | `Reset` |
| Color someone added | none |

A user-added color gets no badge because nothing shipped it — it can neither claim to be a default nor be reset to one. Delete, in the settings panel, is its affordance.

The badge reads `Default` rather than `From Default`: on this palette it is a statement, not a pointer. It stays `Default` even if the palette is renamed, since a pill reading "From Brand" on the palette named Brand would say it follows itself.

## Nothing needed on the server

`Palettes_Controller::delete_swatch()` already restores the shipped color for a baseline swatch on the default palette (keeping the row, rather than dropping it), and `effective_view()` already computes `overridden` there as "differs from the shipped value". Three stale client guards were hiding all of it:

* `use-palettes.js` — `resetSwatch` rejected outright with *"A swatch of the default palette cannot be reverted."*
* `ColorPaletteSettings.js` — `canReset` excluded the default palette, so the settings panel hid Reset too.
* `ColorPaletteScreen.js` — the pill rendered only when the palette had something to inherit from.

The first is the same shape as the bug in #1497: a client-side rule that outlived the server behavior it was written for.

## What changed

* New `swatchPillVariant()` in `helpers/palettes.js` returns `'default' | 'reset' | 'inherited' | null` from the palette, the token, and what it overrides. The decision was a nested ternary in JSX and had run out of room for a fourth case.
* `InheritancePill` gains the `default` variant.
* `ColorPaletteScreen` renders the pill through a `renderPill` callback rather than inline, and passes the fixed word `Default` as the reset button's source so its accessible name reads "Reset Main 1 to Default".
* `ColorPaletteSettings`' `canReset` drops the default-palette exclusion, so the panel and the card never disagree about the same swatch.
* `resetSwatch` drops its default-palette rejection.

The header notice ("N colors inherit from Default") is unchanged and still appears only on other palettes — nothing is inherited on the Default palette, so the sentence has no true form there.

## Tests

* `palettes.test.js` — the full variant matrix for `swatchPillVariant`, including a user-added color staying pill-less even if a stale view calls it overridden.
* `palette-inheritance.test.js` — the Default palette now shows a `Default` pill and a `Reset` button, a user-added color shows none, and clicking Reset calls through to the hook. Replaces the case that asserted no pills there.
* `use-palettes.test.js` — `resetSwatch` on the default palette issues the DELETE and announces "Swatch reset.", replacing the case that pinned the old synchronous rejection.
* `color-palette-settings.test.js` — a changed built-in swatch on the default palette offers Reset but still no Delete.
* `palette-flows.test.js` — a revert-failure case no longer claims the backend refuses default-palette reverts, which it does not.

## Reset means "back to baseline", Delete means "custom color"

The card and the settings panel disagreed about a user-created color that a non-default palette overrides: the card offered **Reset**, the panel offered **Delete**. The panel had it right — a color nobody shipped has no baseline value to go back to — so the card now offers no pill for it, matching what the panel has always done. On any palette, a custom color is deleted and a shipped one is reset.

An un-overridden custom color seen from another palette still names the Default palette as its source, which is where its value genuinely comes from.

## Refs synced from an effect

`openItemRef` in both `ColorPaletteScreen` and `ColorPaletteSettings` was assigned during render. React can start a render and discard it, which would leave the ref naming a swatch that never committed — and the ref exists to be read later, once a write settles. Both now sync in an effect keyed on the open item, so only a committed render moves them.

## Panel sync on reset

Resetting a swatch left an open settings panel showing the value the reset had just undone: `useSettingsPanel` seeds its draft once per item and deliberately ignores later external writes, so it could not follow the reset. The panel's Save stayed enabled on that stale draft — clicking it wrote the old color straight back and silently undid the reset.

Both entry points now close the panel once a reset settles, which is what `onDelete` already does for the same reason. The card's pill only closes a panel open on that same swatch; a panel on another swatch is untouched, and a failed reset leaves it open with the error.

This was reachable before this branch, on any non-default palette. It is folded in here because this branch is what makes it reachable on the Default palette, where the panel's own Reset sits directly beside Save.

## Test plan

* [x] `npx wp-scripts test-unit-js --testPathPattern "src/style-library"` — 66 suites, 944 tests pass.
* [x] eslint and cspell clean on every changed file.
* [x] Manual, on the Default palette: every shipped color shows a `Default` badge; changing one flips its badge to `Reset`; clicking that returns the color to its shipped value with a "Swatch reset." notice; a color added with **+ Add color** shows no badge and offers Delete instead.
