### PR TITLE
fix: Call hooks unconditionally in BlockCSSComponent

### DIFF
--- a/src/extension/block-css/index.js
+++ b/src/extension/block-css/index.js
@@ -40,12 +40,11 @@ addFilter('blocks.registerBlockType', 'kadence/blockCSS', blockCSSAttribute);
 
 /**
  * Build the block css control
+ *
+ * Hooks run before the isSelected check to satisfy the Rules of Hooks.
  */
 const BlockCSSComponent = createHigherOrderComponent((BlockEdit) => {
 	return (props) => {
-		if (!props.isSelected) {
-			return <BlockEdit {...props} />;
-		}
 		const { hasBlockCSS, openTab } = useSelect((select) => {
 			const hasSupport = select(blocksStore).hasBlockSupport(props.name, 'kbcss');
 			let openTab = 'general';
@@ -67,6 +66,9 @@ const BlockCSSComponent = createHigherOrderComponent((BlockEdit) => {
 		const [isOpen, setOpen] = useState(false);
 		const openModal = () => setOpen(true);
 		const closeModal = () => setOpen(false);
+		if (!props.isSelected) {
+			return <BlockEdit {...props} />;
+		}
 		if (hasBlockCSS && openTab == 'advanced' && showSettings('show', 'kadence/customcss')) {
 			const {
 				attributes: { kadenceBlockCSS },


### PR DESCRIPTION
`BlockCSSComponent` returned early with `<BlockEdit {...props} />` before calling `useSelect` and `useState` whenever `props.isSelected` was `false`. Since the number of hooks a component calls must stay identical across renders, selecting or deselecting the block toggles this early return and changes the hook count between renders, which violates the Rules of Hooks.

React 18 catches this and logs:

```
Warning: Internal React error: Expected static flag was missing...
```

repeatedly in the block editor console.

The fix moves the `isSelected` early-return check to after the hook calls, so `useSelect` and `useState` always run regardless of selection state. Behavior is unchanged, only the order shifted.

## Testing

1. Open a page containing a Kadence block in the block editor (e.g. `wp-admin/post.php?post=<id>&action=edit`).
2. Open the browser console.
3. Click through several blocks to select/deselect them.
4. Before the fix: "Expected static flag was missing" warnings appear on selection changes. After the fix: no such warnings.

## Validation

Reproduced and verified locally against a live WordPress install (Kadence Blocks 3.7.9.1): baseline showed 38 occurrences of the warning after clicking through 46 blocks in the editor canvas; with the equivalent patch applied to the installed plugin bundle, the warning was completely eliminated across the same test.

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)

Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block editing stability by ensuring selection-related behavior remains consistent when block selection changes.
  * Updated internal hook execution order to comply with React’s Rules of Hooks, with no intended user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->