### PR TITLE
[DTM] SOFT-4268 [2/3]: Preview every Button preset style control on its row chip

### DIFF
--- a/src/style-library/__tests__/button-preset.test.js
+++ b/src/style-library/__tests__/button-preset.test.js
@@ -178,12 +178,14 @@ describe('BUTTON_PRESET.renderPreview', () => {
 		// receives, so the assertions below prove both that `capBoxSides` gets the row's raw
 		// padding/margin plus the chip's cap AND that each return value lands on the matching style
 		// property (not swapped) — `capBoxSides`'s own capping math is covered by `preview.test.js`.
+		const isAxisCap = (cap) => Boolean(cap) && cap.vertical === '50vh' && cap.horizontal === '50vw';
+
 		capBoxSides.mockImplementation((value, cap) => {
-			if (value === preview.padding && cap === '2rem') {
+			if (value === preview.padding && isAxisCap(cap)) {
 				return '11px';
 			}
 
-			if (value === preview.margin && cap === '2rem') {
+			if (value === preview.margin && isAxisCap(cap)) {
 				return '22px';
 			}
 

--- a/src/style-library/__tests__/button-preset.test.js
+++ b/src/style-library/__tests__/button-preset.test.js
@@ -20,6 +20,8 @@ jest.mock('../helpers/preview', () => ({
 	capBoxSides: jest.fn(jest.requireActual('../helpers/preview').capBoxSides),
 }));
 
+const actualCapBoxSides = jest.requireActual('../helpers/preview').capBoxSides;
+
 describe('BUTTON_PRESET.preview', () => {
 	/**
 	 * AC2: every resting-state property the preview can show resolves through the feed's value map,
@@ -133,6 +135,10 @@ describe('BUTTON_PRESET.renderPreview', () => {
 	afterEach(() => {
 		act(() => root.unmount());
 		container.remove();
+		// The padding/margin test overrides `capBoxSides`'s implementation to return sentinels;
+		// restore the wrapped-real-implementation default so no other test's outcome depends on
+		// whichever test ran before it.
+		capBoxSides.mockImplementation(actualCapBoxSides);
 	});
 
 	const preview = {
@@ -161,18 +167,32 @@ describe('BUTTON_PRESET.renderPreview', () => {
 	 * side so one extreme preset cannot blow up its list row.
 	 */
 	it('applies border, shadow, and capped padding/margin to the chip', () => {
+		// jsdom's bundled cssstyle does not implement the CSS `min()` function: any declaration using
+		// it is rejected outright (not normalized, the way jsdom rewrites hex colors to `rgb()`), so
+		// `chip.style.padding`/`.margin` cannot hold the real capped value here even though a real
+		// browser renders it. Stand in `min()`-free sentinels keyed to which argument each call
+		// receives, so the assertions below prove both that `capBoxSides` gets the row's raw
+		// padding/margin plus the chip's cap AND that each return value lands on the matching style
+		// property (not swapped) — `capBoxSides`'s own capping math is covered by `preview.test.js`.
+		capBoxSides.mockImplementation((value, cap) => {
+			if (value === preview.padding && cap === '2rem') {
+				return '11px';
+			}
+
+			if (value === preview.margin && cap === '2rem') {
+				return '22px';
+			}
+
+			return actualCapBoxSides(value, cap);
+		});
+
 		const chip = mountChip({ id: 'primary', label: 'Primary', preview });
 
 		expect(chip.style.borderWidth).toBe('2px');
 		expect(chip.style.borderStyle).toBe('dashed');
 		expect(chip.style.boxShadow).toBe('0px 2px 4px 0px rgba(0, 0, 0, 0.2)');
-		// jsdom's bundled cssstyle does not implement the CSS `min()` function: any declaration using
-		// it is rejected outright (not normalized, the way jsdom rewrites hex colors to `rgb()`), so
-		// `chip.style.padding`/`.margin` read back empty here even though a real browser renders the
-		// capped value. Assert on the wiring instead — `capBoxSides` gets the row's raw padding/margin
-		// and the chip's cap — while `capBoxSides`'s own capping math is covered by `preview.test.js`.
-		expect(capBoxSides).toHaveBeenCalledWith(preview.padding, '2rem');
-		expect(capBoxSides).toHaveBeenCalledWith(preview.margin, '2rem');
+		expect(chip.style.padding).toBe('11px');
+		expect(chip.style.margin).toBe('22px');
 	});
 
 	/**

--- a/src/style-library/__tests__/button-preset.test.js
+++ b/src/style-library/__tests__/button-preset.test.js
@@ -1,8 +1,24 @@
 /* eslint-env jest */
 /**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
  * Internal dependencies
  */
+import { capBoxSides } from '../helpers/preview';
 import { BUTTON_PRESET } from '../presets/button-preset';
+
+// Wraps the real `capBoxSides` so its capping math still runs (`preview.test.js` already covers
+// that math directly) while letting the chip test below assert it was called with the row's raw
+// padding/margin and the chip's cap — the DOM assertion `chip.style.padding` cannot make the same
+// point, see the comment at that assertion.
+jest.mock('../helpers/preview', () => ({
+	...jest.requireActual('../helpers/preview'),
+	capBoxSides: jest.fn(jest.requireActual('../helpers/preview').capBoxSides),
+}));
 
 describe('BUTTON_PRESET.preview', () => {
 	/**
@@ -86,5 +102,137 @@ describe('BUTTON_PRESET.preview', () => {
 			borderColor: '',
 			shadow: '',
 		});
+	});
+});
+
+describe('BUTTON_PRESET.renderPreview', () => {
+	let container;
+	let root;
+
+	/**
+	 * Mounts a chip for one row and returns the rendered span.
+	 *
+	 * @param {Object} row The row descriptor to render.
+	 *
+	 * @return {HTMLElement} The chip element.
+	 */
+	const mountChip = (row) => {
+		act(() => root.render(BUTTON_PRESET.renderPreview(row)));
+
+		return container.querySelector('.kadence-blocks-style-library__button-preset-preview');
+	};
+
+	beforeEach(() => {
+		// Same as `preset-screen.test.js`: mounted tests must declare the act() environment or
+		// React warns on every state update.
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+		container = document.body.appendChild(document.createElement('div'));
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+	});
+
+	const preview = {
+		background: '#3633e1',
+		color: '#ffffff',
+		borderRadius: '0.5rem',
+		borderWidth: '2px',
+		borderStyle: 'dashed',
+		borderColor: '#d0d5dd',
+		shadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.2)',
+		padding: '0.4em 6rem 0.4em 6rem',
+		margin: '0 0 0.5rem 0',
+		hover: {
+			background: '#ffffff',
+			color: '#3633e1',
+			borderRadius: '',
+			borderWidth: '',
+			borderStyle: '',
+			borderColor: '',
+			shadow: '',
+		},
+	};
+
+	/**
+	 * AC1/AC4: the chip applies every resolved resting style, with padding and margin capped per
+	 * side so one extreme preset cannot blow up its list row.
+	 */
+	it('applies border, shadow, and capped padding/margin to the chip', () => {
+		const chip = mountChip({ id: 'primary', label: 'Primary', preview });
+
+		expect(chip.style.borderWidth).toBe('2px');
+		expect(chip.style.borderStyle).toBe('dashed');
+		expect(chip.style.boxShadow).toBe('0px 2px 4px 0px rgba(0, 0, 0, 0.2)');
+		// jsdom's bundled cssstyle does not implement the CSS `min()` function: any declaration using
+		// it is rejected outright (not normalized, the way jsdom rewrites hex colors to `rgb()`), so
+		// `chip.style.padding`/`.margin` read back empty here even though a real browser renders the
+		// capped value. Assert on the wiring instead — `capBoxSides` gets the row's raw padding/margin
+		// and the chip's cap — while `capBoxSides`'s own capping math is covered by `preview.test.js`.
+		expect(capBoxSides).toHaveBeenCalledWith(preview.padding, '2rem');
+		expect(capBoxSides).toHaveBeenCalledWith(preview.margin, '2rem');
+	});
+
+	/**
+	 * AC5a: while the pointer is over the chip it swaps to the resolved hover styles, and a hover
+	 * property the preset leaves unset keeps its resting value; leaving restores the resting state.
+	 */
+	it('swaps to hover styles under the pointer and back off it', () => {
+		const chip = mountChip({ id: 'primary', label: 'Primary', preview });
+
+		act(() => {
+			chip.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+		});
+
+		expect(chip.style.background).toBe('rgb(255, 255, 255)');
+		expect(chip.style.color).toBe('rgb(54, 51, 225)');
+		// Unset hover values keep the resting style.
+		expect(chip.style.borderStyle).toBe('dashed');
+		expect(chip.style.borderRadius).toBe('0.5rem');
+
+		act(() => {
+			chip.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+		});
+
+		expect(chip.style.background).toBe('rgb(54, 51, 225)');
+		expect(chip.style.color).toBe('rgb(255, 255, 255)');
+	});
+
+	/**
+	 * AC5b: `showHoverState` holds the hover styles with no pointer involved — the screen sets it
+	 * for the row whose panel is on the Hover tab.
+	 */
+	it('holds the hover state when the row carries showHoverState', () => {
+		const chip = mountChip({ id: 'primary', label: 'Primary', preview, showHoverState: true });
+
+		expect(chip.style.background).toBe('rgb(255, 255, 255)');
+		expect(chip.style.color).toBe('rgb(54, 51, 225)');
+	});
+
+	/**
+	 * AC3: an unresolved value renders the property absent rather than an invented fallback, so
+	 * the stylesheet's own chip defaults stay in charge.
+	 */
+	it('drops every unresolved style', () => {
+		const chip = mountChip({
+			id: 'primary',
+			label: 'Primary',
+			preview: {
+				background: '',
+				color: '',
+				borderRadius: '',
+				borderWidth: '',
+				borderStyle: '',
+				borderColor: '',
+				shadow: '',
+				padding: '',
+				margin: '',
+				hover: preview.hover,
+			},
+		});
+
+		expect(chip.getAttribute('style')).toBeFalsy();
 	});
 });

--- a/src/style-library/__tests__/button-preset.test.js
+++ b/src/style-library/__tests__/button-preset.test.js
@@ -1,0 +1,90 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import { BUTTON_PRESET } from '../presets/button-preset';
+
+describe('BUTTON_PRESET.preview', () => {
+	/**
+	 * AC2: every resting-state property the preview can show resolves through the feed's value map,
+	 * aliases included — border as its three sibling keys, shadow as a composite,
+	 * padding/margin as per-side slot lists.
+	 *
+	 * @return {void}
+	 */
+	it('resolves border, shadow, padding and margin alongside the color trio', () => {
+		const values = {
+			'semantic.color.action-primary': '#3633e1',
+			'semantic.color.on-primary': '#ffffff',
+			'semantic.border-width.default': '1px',
+			'semantic.color.border': '#d0d5dd',
+			'primitive.spacing.sm': '0.5rem',
+		};
+		const tokens = {
+			'button-bg': '{semantic.color.action-primary}',
+			'button-text': '{semantic.color.on-primary}',
+			'button-radius': '0.5rem',
+			'button-border-width': '{semantic.border-width.default}',
+			'button-border-style': 'solid',
+			'button-border-color': '{semantic.color.border}',
+			'button-shadow': {
+				color: 'rgba(0, 0, 0, 0.2)',
+				offsetX: '0px',
+				offsetY: '2px',
+				blur: '4px',
+				spread: '0px',
+			},
+			'button-padding': ['{primitive.spacing.sm}', '1em', '{primitive.spacing.sm}', '1em'],
+			'button-margin': ['0', '0', '0.5rem', '0'],
+			'button-bg-hover': '{semantic.color.on-primary}',
+			'button-text-hover': '{semantic.color.action-primary}',
+		};
+
+		expect(BUTTON_PRESET.preview(tokens, values)).toEqual({
+			background: '#3633e1',
+			color: '#ffffff',
+			borderRadius: '0.5rem',
+			borderWidth: '1px',
+			borderStyle: 'solid',
+			borderColor: '#d0d5dd',
+			shadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.2)',
+			padding: '0.5rem 1em 0.5rem 1em',
+			margin: '0 0 0.5rem 0',
+			hover: {
+				background: '#ffffff',
+				color: '#3633e1',
+				borderRadius: '',
+				borderWidth: '',
+				borderStyle: '',
+				borderColor: '',
+				shadow: '',
+			},
+		});
+	});
+
+	/**
+	 * AC3: a preset that stores none of the new properties previews them as empty strings, the
+	 * same absent-not-invented posture the color trio already takes — hover included.
+	 *
+	 * @return {void}
+	 */
+	it('previews unset style properties as empty', () => {
+		const preview = BUTTON_PRESET.preview({ 'button-bg': 'transparent' }, {});
+
+		expect(preview.borderWidth).toBe('');
+		expect(preview.borderStyle).toBe('');
+		expect(preview.borderColor).toBe('');
+		expect(preview.shadow).toBe('');
+		expect(preview.padding).toBe('');
+		expect(preview.margin).toBe('');
+		expect(preview.hover).toEqual({
+			background: '',
+			color: '',
+			borderRadius: '',
+			borderWidth: '',
+			borderStyle: '',
+			borderColor: '',
+			shadow: '',
+		});
+	});
+});

--- a/src/style-library/__tests__/button-preset.test.js
+++ b/src/style-library/__tests__/button-preset.test.js
@@ -116,6 +116,8 @@ describe('BUTTON_PRESET.renderPreview', () => {
 	 *
 	 * @param {Object} row The row descriptor to render.
 	 *
+	 * @since TBD
+	 *
 	 * @return {HTMLElement} The chip element.
 	 */
 	const mountChip = (row) => {
@@ -165,6 +167,8 @@ describe('BUTTON_PRESET.renderPreview', () => {
 	/**
 	 * AC1/AC4: the chip applies every resolved resting style, with padding and margin capped per
 	 * side so one extreme preset cannot blow up its list row.
+	 *
+	 * @return {void}
 	 */
 	it('applies border, shadow, and capped padding/margin to the chip', () => {
 		// jsdom's bundled cssstyle does not implement the CSS `min()` function: any declaration using
@@ -198,6 +202,8 @@ describe('BUTTON_PRESET.renderPreview', () => {
 	/**
 	 * AC5a: while the pointer is over the chip it swaps to the resolved hover styles, and a hover
 	 * property the preset leaves unset keeps its resting value; leaving restores the resting state.
+	 *
+	 * @return {void}
 	 */
 	it('swaps to hover styles under the pointer and back off it', () => {
 		const chip = mountChip({ id: 'primary', label: 'Primary', preview });
@@ -211,6 +217,8 @@ describe('BUTTON_PRESET.renderPreview', () => {
 		// Unset hover values keep the resting style.
 		expect(chip.style.borderStyle).toBe('dashed');
 		expect(chip.style.borderRadius).toBe('0.5rem');
+		expect(chip.style.borderWidth).toBe('2px');
+		expect(chip.style.borderColor).toBe('#d0d5dd');
 
 		act(() => {
 			chip.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
@@ -223,6 +231,8 @@ describe('BUTTON_PRESET.renderPreview', () => {
 	/**
 	 * AC5b: `showHoverState` holds the hover styles with no pointer involved — the screen sets it
 	 * for the row whose panel is on the Hover tab.
+	 *
+	 * @return {void}
 	 */
 	it('holds the hover state when the row carries showHoverState', () => {
 		const chip = mountChip({ id: 'primary', label: 'Primary', preview, showHoverState: true });
@@ -234,6 +244,8 @@ describe('BUTTON_PRESET.renderPreview', () => {
 	/**
 	 * AC3: an unresolved value renders the property absent rather than an invented fallback, so
 	 * the stylesheet's own chip defaults stay in charge.
+	 *
+	 * @return {void}
 	 */
 	it('drops every unresolved style', () => {
 		const chip = mountChip({

--- a/src/style-library/__tests__/preset-screen.test.js
+++ b/src/style-library/__tests__/preset-screen.test.js
@@ -232,6 +232,34 @@ describe('PresetScreen draft overlay', () => {
 		expect(container.textContent).not.toContain('Leaked');
 		expect(container.textContent).toContain('Primary');
 	});
+
+	/**
+	 * A publication whose panel sits on the Hover tab makes the open row's chip hold the hover
+	 * state — and only the open row's, so sibling chips keep resting styles.
+	 *
+	 * @return {void}
+	 */
+	it('holds the hover state on the open row while the publication is on the hover tab', () => {
+		useDraftChannel.mockReturnValue({
+			publication: {
+				itemId: 'primary',
+				draft: { tokens: { 'button-bg': '#3633e1', 'button-bg-hover': '#ffffff' } },
+				activeTab: 'hover',
+			},
+			guard: (fn) => fn(),
+		});
+
+		renderPresetScreen(
+			{ payload: {}, isLoading: false, loadError: null, rows: ROWS, initialValuesFor: () => ({}) },
+			{ item: 'primary' }
+		);
+
+		const chips = container.querySelectorAll('.kadence-blocks-style-library__button-preset-preview');
+
+		// The open row's chip renders the hover background; the sibling keeps its resting one.
+		expect(chips[0].style.background).toBe('rgb(255, 255, 255)');
+		expect(chips[1].style.background).toBe('rgb(34, 34, 34)');
+	});
 });
 
 describe('PresetScreen selection', () => {

--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -160,6 +160,16 @@ describe('presetRows', () => {
 		'semantic.color.on-primary': '#ffffff',
 	};
 
+	const emptyHover = {
+		background: '',
+		color: '',
+		borderRadius: '',
+		borderWidth: '',
+		borderStyle: '',
+		borderColor: '',
+		shadow: '',
+	};
+
 	it('maps the payload to row view models in payload order, resolving preview values', () => {
 		const payload = {
 			userCreated: [],
@@ -190,9 +200,31 @@ describe('presetRows', () => {
 			id: 'primary',
 			label: 'Primary',
 			userCreated: false,
-			preview: { background: '#3633e1', color: '#ffffff', borderRadius: '0.5rem' },
+			preview: {
+				background: '#3633e1',
+				color: '#ffffff',
+				borderRadius: '0.5rem',
+				borderWidth: '',
+				borderStyle: '',
+				borderColor: '',
+				shadow: '',
+				padding: '',
+				margin: '',
+				hover: emptyHover,
+			},
 		});
-		expect(rows[1].preview).toEqual({ background: 'transparent', color: '#3633e1', borderRadius: '0.25rem' });
+		expect(rows[1].preview).toEqual({
+			background: 'transparent',
+			color: '#3633e1',
+			borderRadius: '0.25rem',
+			borderWidth: '',
+			borderStyle: '',
+			borderColor: '',
+			shadow: '',
+			padding: '',
+			margin: '',
+			hover: emptyHover,
+		});
 	});
 
 	it('resolves a responsive preview at the breakpoint being viewed', () => {
@@ -653,18 +685,50 @@ describe('overlayPresetRows', () => {
 		'semantic.color.on-primary': '#ffffff',
 	};
 
+	const emptyHover = {
+		background: '',
+		color: '',
+		borderRadius: '',
+		borderWidth: '',
+		borderStyle: '',
+		borderColor: '',
+		shadow: '',
+	};
+
 	const rows = [
 		{
 			id: 'primary',
 			label: 'Primary',
 			userCreated: false,
-			preview: { background: '#3633e1', color: '#ffffff', borderRadius: '0.5rem' },
+			preview: {
+				background: '#3633e1',
+				color: '#ffffff',
+				borderRadius: '0.5rem',
+				borderWidth: '',
+				borderStyle: '',
+				borderColor: '',
+				shadow: '',
+				padding: '',
+				margin: '',
+				hover: emptyHover,
+			},
 		},
 		{
 			id: 'secondary',
 			label: 'Secondary',
 			userCreated: false,
-			preview: { background: 'transparent', color: '#3633e1', borderRadius: '0.25rem' },
+			preview: {
+				background: 'transparent',
+				color: '#3633e1',
+				borderRadius: '0.25rem',
+				borderWidth: '',
+				borderStyle: '',
+				borderColor: '',
+				shadow: '',
+				padding: '',
+				margin: '',
+				hover: emptyHover,
+			},
 		},
 	];
 
@@ -686,7 +750,26 @@ describe('overlayPresetRows', () => {
 			id: 'primary',
 			label: 'Primary CTA',
 			userCreated: false,
-			preview: { background: '#ffffff', color: '#3633e1', borderRadius: '1rem' },
+			preview: {
+				background: '#ffffff',
+				color: '#3633e1',
+				borderRadius: '1rem',
+				borderWidth: '',
+				borderStyle: '',
+				borderColor: '',
+				shadow: '',
+				padding: '',
+				margin: '',
+				hover: {
+					background: '#3633e1',
+					color: '#ffffff',
+					borderRadius: '',
+					borderWidth: '',
+					borderStyle: '',
+					borderColor: '',
+					shadow: '',
+				},
+			},
 		});
 		expect(next[1]).toBe(rows[1]);
 	});

--- a/src/style-library/__tests__/preview.test.js
+++ b/src/style-library/__tests__/preview.test.js
@@ -22,6 +22,19 @@ describe('capBoxSides', () => {
 	});
 
 	/**
+	 * A per-axis pair lands each cap on the shorthand's real axis: even positions are vertical
+	 * (top, and bottom in the 3-value form), odd positions horizontal.
+	 */
+	it('caps each axis with its own length when given a per-axis pair', () => {
+		const caps = { vertical: '50vh', horizontal: '50vw' };
+
+		expect(capBoxSides('3rem 10rem 3rem 10rem', caps)).toBe(
+			'min(3rem, 50vh) min(10rem, 50vw) min(3rem, 50vh) min(10rem, 50vw)'
+		);
+		expect(capBoxSides('0.4em 1em', caps)).toBe('min(0.4em, 50vh) min(1em, 50vw)');
+	});
+
+	/**
 	 * AC4: a unitless zero stays unwrapped — min(0, 2rem) mixes a number with a length,
 	 * which is invalid CSS and would drop the whole declaration.
 	 */
@@ -42,6 +55,32 @@ describe('capBoxSides', () => {
 	 */
 	it('returns undefined for an empty value', () => {
 		expect(capBoxSides('', '2rem')).toBeUndefined();
+	});
+
+	/**
+	 * AC4: a one-value shorthand covers all four sides, so a per-axis cap expands it to the
+	 * vertical/horizontal pair rather than holding left and right to the vertical bound.
+	 */
+	it('expands a one-value shorthand against a per-axis cap', () => {
+		expect(capBoxSides('6rem', { vertical: '50vh', horizontal: '50vw' })).toBe('min(6rem, 50vh) min(6rem, 50vw)');
+	});
+
+	/**
+	 * AC4: a three-value shorthand already reads top, horizontal, bottom, so alternating the per-axis
+	 * cap by index caps it correctly with no expansion.
+	 */
+	it('caps a three-value shorthand per axis', () => {
+		expect(capBoxSides('1rem 2rem 3rem', { vertical: '50vh', horizontal: '50vw' })).toBe(
+			'min(1rem, 50vh) min(2rem, 50vw) min(3rem, 50vh)'
+		);
+	});
+
+	/**
+	 * AC4: a single cap string still applies to a one-value shorthand unchanged — the expansion is
+	 * only needed when the two axes can differ.
+	 */
+	it('leaves a one-value shorthand unexpanded under a single cap', () => {
+		expect(capBoxSides('6rem', '2rem')).toBe('min(6rem, 2rem)');
 	});
 
 	/**

--- a/src/style-library/components/pages/ButtonScreen.scss
+++ b/src/style-library/components/pages/ButtonScreen.scss
@@ -33,5 +33,6 @@
 	font-weight: var(--kb-sl-font-weight-medium);
 	line-height: var(--kb-sl-line-height-s);
 	white-space: nowrap;
-	transition: background-color 300ms ease, color 300ms ease, border-radius 300ms ease;
+	transition: background-color 300ms ease, color 300ms ease, border-radius 300ms ease, border-color 300ms ease,
+		border-width 300ms ease, box-shadow 300ms ease, padding 300ms ease, margin 300ms ease;
 }

--- a/src/style-library/components/pages/PresetScreen.js
+++ b/src/style-library/components/pages/PresetScreen.js
@@ -145,10 +145,14 @@ export function PresetScreen({ label, route, navigate, library, preset }) {
 	const [breakpoint] = useBreakpoint();
 	const rows = overlayPresetRows(screen.rows, route.item, draft, library?.values, preset.preview, breakpoint);
 
+	// Only the open row, and only while its panel's Hover tab is the one being edited: the chip
+	// then holds the hover state without the pointer, so Hover-tab edits read back immediately.
+	const isHoverDraft = Boolean(draft) && channel.publication.activeTab === 'hover';
+
 	const items = rows.map((row) => ({
 		id: row.id,
 		label: row.label,
-		preview: renderPreview(row),
+		preview: renderPreview(isHoverDraft && row.id === route.item ? { ...row, showHoverState: true } : row),
 		isDraggable: true,
 	}));
 

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -87,6 +87,10 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
 
 		publish({ itemId: id, label: presetLabel, draft: panel.draft, isDirty: panel.isDirty, activeTab });
 
+		// Re-running on `activeTab` also clears then republishes on every tab switch: safe because
+		// the guard modal traps focus while it is open (so tabs are unreachable during a guard), and
+		// `clearPublication()` nulling the pending guard action/error batches into the same commit as
+		// the republish that follows it.
 		return () => clearPublication();
 	}, [publish, clearPublication, id, presetLabel, panel.draft, panel.isDirty, activeTab]);
 

--- a/src/style-library/components/pages/PresetSidebar.js
+++ b/src/style-library/components/pages/PresetSidebar.js
@@ -85,10 +85,10 @@ function PresetSidebarBody({ navigate, route, screen, initialValues, presetLabel
 			return undefined;
 		}
 
-		publish({ itemId: id, label: presetLabel, draft: panel.draft, isDirty: panel.isDirty });
+		publish({ itemId: id, label: presetLabel, draft: panel.draft, isDirty: panel.isDirty, activeTab });
 
 		return () => clearPublication();
-	}, [publish, clearPublication, id, presetLabel, panel.draft, panel.isDirty]);
+	}, [publish, clearPublication, id, presetLabel, panel.draft, panel.isDirty, activeTab]);
 
 	// `screen.saveError`/`screen.deleteError` live on the outer preset-screen binding, not on this
 	// per-preset panel, so a failed write's error otherwise survives past the preset it happened on.

--- a/src/style-library/helpers/preview.js
+++ b/src/style-library/helpers/preview.js
@@ -16,9 +16,18 @@
  * resolves to a unitless `0`, and wrapping it once produced exactly that invalid declaration, which
  * the browser silently dropped — leaving the previous padding on screen with nothing assigned.
  *
- * @param {string} value The resolved value: one length, or a space-separated shorthand.
- * @param {string} cap   The most any one side may show — a LENGTH, not a percentage, because the
- *                       preview grows to fit the value rather than insetting into a fixed frame.
+ * The cap is either one length for every side, or a per-axis pair. With a pair, each component is
+ * capped by the axis it lands on under the CSS box shorthand: even positions are vertical (top,
+ * and bottom in the 3-value form), odd positions horizontal — which maps `v h`, `v h v`, and
+ * `v h v h` correctly, and caps a single all-sides value by the vertical axis (any realistic
+ * spacing sits far below either viewport cap, so the distinction never shows there).
+ *
+ * @param {string}                                   value The resolved value: one length, or a
+ *                                                         space-separated shorthand.
+ * @param {string|{vertical: string, horizontal: string}} cap The most any one side may show — a
+ *                       LENGTH (not a percentage, because the preview grows to fit the value rather
+ *                       than insetting into a fixed frame), or a per-axis `{vertical, horizontal}`
+ *                       pair of lengths.
  *
  * @since TBD
  *
@@ -38,8 +47,16 @@ export function capBoxSides(value, cap) {
 		return undefined;
 	}
 
-	return sides
-		.split(/\s+/)
-		.map((side) => (/^[+-]?\d*\.?\d+[a-z%]+$/i.test(side) ? `min(${side}, ${cap})` : side))
+	const capFor = (index) => (typeof cap === 'string' ? cap : index % 2 === 0 ? cap.vertical : cap.horizontal);
+	const parts = sides.split(/\s+/);
+
+	// A one-value shorthand stands for all four sides, so a per-axis cap has to expand it to the
+	// vertical/horizontal pair first — capping it in place would hold the left and right sides to the
+	// vertical bound. The two-, three- and four-value forms already alternate vertical, horizontal by
+	// index, so they need no expansion.
+	const expanded = parts.length === 1 && typeof cap !== 'string' ? [parts[0], parts[0]] : parts;
+
+	return expanded
+		.map((side, index) => (/^[+-]?\d*\.?\d+[a-z%]+$/i.test(side) ? `min(${side}, ${capFor(index)})` : side))
 		.join(' ');
 }

--- a/src/style-library/helpers/preview.js
+++ b/src/style-library/helpers/preview.js
@@ -12,7 +12,9 @@
  * single length rather than a shorthand. Only a component that is a NUMBER WITH A UNIT is wrapped,
  * and that restriction is load-bearing rather than defensive: `min()` requires its arguments to be
  * of one type, so `min(0, 2rem)` — mixing a number with a length — is invalid and the browser drops
- * the whole declaration. A unitless `0` needs no capping anyway.
+ * the whole declaration. A unitless `0` needs no capping anyway: the spacing scale's `None` step
+ * resolves to a unitless `0`, and wrapping it once produced exactly that invalid declaration, which
+ * the browser silently dropped — leaving the previous padding on screen with nothing assigned.
  *
  * @param {string} value The resolved value: one length, or a space-separated shorthand.
  * @param {string} cap   The most any one side may show — a LENGTH, not a percentage, because the

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -33,13 +33,15 @@ const TABS = [
 ];
 
 /**
- * The most preview padding or margin any one side may show. Smaller than the image preview's cap
- * because the chip sits inside a list row rather than standing alone as a tile — the spacing scale
- * runs to 10rem, and an uncapped top-step preset would make its row taller than the screen.
+ * The most preview padding or margin any one side may show, per axis. Deliberately generous —
+ * half the viewport on the side's own axis — because the chip's job is to show what the button
+ * will actually render, so every step of the spacing scale (which tops out at 10rem, far below
+ * either cap) previews at true size. The cap only exists to bound a pathological custom literal,
+ * not to tame real values.
  *
  * @since TBD
  */
-const BOX_PREVIEW_CAP = '2rem';
+const BOX_PREVIEW_CAP = { vertical: '50vh', horizontal: '50vw' };
 
 /**
  * Build a row's preview from its stored tokens.

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -10,12 +10,14 @@
 /**
  * WordPress dependencies
  */
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { BUTTON_MARGIN_FALLBACK, BUTTON_PADDING_FALLBACK } from '../../token-controls/helpers/button-box-defaults';
+import { capBoxSides } from '../helpers/preview';
 import { BUTTON_BLOCK, getPresetProperties, resolveTokenValue } from '../helpers/presets';
 
 export { BUTTON_BLOCK };
@@ -29,6 +31,15 @@ const TABS = [
 	{ name: 'normal', title: __('Normal', 'kadence-blocks') },
 	{ name: 'hover', title: __('Hover', 'kadence-blocks') },
 ];
+
+/**
+ * The most preview padding or margin any one side may show. Smaller than the image preview's cap
+ * because the chip sits inside a list row rather than standing alone as a tile — the spacing scale
+ * runs to 10rem, and an uncapped top-step preset would make its row taller than the screen.
+ *
+ * @since TBD
+ */
+const BOX_PREVIEW_CAP = '2rem';
 
 /**
  * Build a row's preview from its stored tokens.
@@ -78,33 +89,70 @@ function preview(tokens, values, breakpoint) {
 }
 
 /**
- * The row's live preview chip: a non-interactive span reading "Button", styled from the row's
- * resolved background/text/radius. Hover values are never previewed here — a static chip cannot
- * honestly show `:hover`, the sidebar's Hover tab is the editing surface for that — and an
- * unresolved value renders the property absent rather than an invented fallback.
+ * The live preview chip: a span reading "Button", styled from the row's resolved styles —
+ * background, text, radius, border, shadow, padding, and margin. While the pointer is over the
+ * chip (or `row.showHoverState` is set, which the screen does for the row whose panel is on the
+ * Hover tab), each style swaps to the preset's resolved hover value, per property: an unset hover
+ * value keeps the resting style, exactly what a real button whose preset stores no hover override
+ * does. An unresolved value renders the property absent rather than an invented fallback, leaving
+ * the stylesheet's chip defaults in charge (so a preset that sets only a border color still
+ * previews it: the stylesheet's transparent `1px solid` border supplies the width and style).
+ * Padding and margin are capped per side (see `capBoxSides`) so an extreme preset cannot make its
+ * list row enormous; neither has a hover-bound counterpart, so the chip's box never changes
+ * between states.
  *
  * Styled by `components/pages/ButtonScreen.scss`, which also carries this screen's other overrides
  * and is imported there.
  *
- * @param {{id: string, label: string, preview: {background: string, color: string, borderRadius: string}}} row The row descriptor.
+ * @param {Object} props     The component props.
+ * @param {Object} props.row The row descriptor (`{id, label, preview, showHoverState?}`).
+ *
+ * @since TBD
+ *
+ * @return {JSX.Element} The chip.
+ */
+function ButtonPresetPreviewChip({ row }) {
+	const [isHovered, setIsHovered] = useState(false);
+
+	const resting = row.preview;
+	const hover = resting.hover ?? {};
+	const showHover = isHovered || row.showHoverState === true;
+	const styleFor = (base, hovered) => (showHover && hovered ? hovered : base) || undefined;
+
+	return (
+		<span
+			className="kadence-blocks-style-library__button-preset-preview"
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => setIsHovered(false)}
+			style={{
+				background: styleFor(resting.background, hover.background),
+				color: styleFor(resting.color, hover.color),
+				borderRadius: styleFor(resting.borderRadius, hover.borderRadius),
+				borderWidth: styleFor(resting.borderWidth, hover.borderWidth),
+				borderStyle: styleFor(resting.borderStyle, hover.borderStyle),
+				borderColor: styleFor(resting.borderColor, hover.borderColor),
+				boxShadow: styleFor(resting.shadow, hover.shadow),
+				padding: capBoxSides(resting.padding, BOX_PREVIEW_CAP),
+				margin: capBoxSides(resting.margin, BOX_PREVIEW_CAP),
+			}}
+		>
+			{__('Button', 'kadence-blocks')}
+		</span>
+	);
+}
+
+/**
+ * The row's preview slot: the generic row mapper calls this as a plain function, so it stays one —
+ * the hover state lives inside `ButtonPresetPreviewChip`, which needs to be a component to hold it.
+ *
+ * @param {{id: string, label: string, preview: Object, showHoverState?: boolean}} row The row descriptor.
  *
  * @since TBD
  *
  * @return {JSX.Element} The preview element.
  */
 function renderPreview(row) {
-	return (
-		<span
-			className="kadence-blocks-style-library__button-preset-preview"
-			style={{
-				background: row.preview.background || undefined,
-				color: row.preview.color || undefined,
-				borderRadius: row.preview.borderRadius || undefined,
-			}}
-		>
-			{__('Button', 'kadence-blocks')}
-		</span>
-	);
+	return <ButtonPresetPreviewChip row={row} />;
 }
 
 /**

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -17,8 +17,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BUTTON_MARGIN_FALLBACK, BUTTON_PADDING_FALLBACK } from '../../token-controls/helpers/button-box-defaults';
-import { capBoxSides } from '../helpers/preview';
 import { BUTTON_BLOCK, getPresetProperties, resolveTokenValue } from '../helpers/presets';
+import { capBoxSides } from '../helpers/preview';
 
 export { BUTTON_BLOCK };
 
@@ -157,9 +157,12 @@ function renderPreview(row) {
 
 /**
  * The per-tab settings schema: the Normal tab adds a Border and Shadow section and the Hover tab
- * never does — `button-radius`/`button-border`/`button-shadow` have no hover counterpart, so
- * rendering them there would write a property `guard_surface` rejects. The preset name is not here;
- * it is tab-independent and comes from `presetNameSchema()`.
+ * never does. The block does bind hover counterparts for radius, border, and shadow — `preview()`
+ * above resolves `button-radius-hover`, the hover border trio, and `button-shadow-hover`, and the
+ * chip already previews them — but the Hover tab only offers the color pair today; that is a
+ * scope decision, not a `guard_surface` restriction, and offering the other fields is a separate
+ * schema decision. The preset name is not here; it is tab-independent and comes from
+ * `presetNameSchema()`.
  *
  * @param {string} tab The active tab name (`'normal'` or `'hover'`).
  *

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -231,7 +231,7 @@ function schemaFor(tab) {
 		],
 	};
 
-	// Normal only, like the radius panel: neither property has a hover counterpart, so a field on the
+	// Normal only: the block binds no hover counterpart for padding or margin, so a field on the
 	// Hover tab would write something `guard_surface` rejects.
 	const spacingPanel = {
 		id: 'spacing',

--- a/src/style-library/presets/button-preset.js
+++ b/src/style-library/presets/button-preset.js
@@ -33,9 +33,11 @@ const TABS = [
 /**
  * Build a row's preview from its stored tokens.
  *
- * The shape is this block's own: a button chip needs a background, a text color and a radius.
- * Another block's rows would preview something else entirely, which is why the generic row mapper
- * takes this as a function rather than reading fixed keys.
+ * The shape is this block's own: every resting-state property the chip can draw — background,
+ * text color, radius, the border trio, shadow, padding, and margin — plus a nested `hover` map
+ * of the state the chip swaps to on interaction (see `renderPreview`). Another block's rows
+ * would preview something else entirely, which is why the generic row mapper takes this as a
+ * function rather than reading fixed keys.
  *
  * @param {Record<string, *>}      tokens       The preset's stored token map.
  * @param {Record<string, string>} values       The feed's resolved value map.
@@ -47,13 +49,31 @@ const TABS = [
  *
  * @since TBD
  *
- * @return {{background: string, color: string, borderRadius: string}} The preview.
+ * @return {{background: string, color: string, borderRadius: string, borderWidth: string, borderStyle: string, borderColor: string, shadow: string, padding: string, margin: string, hover: {background: string, color: string, borderRadius: string, borderWidth: string, borderStyle: string, borderColor: string, shadow: string}}} The preview.
  */
 function preview(tokens, values, breakpoint) {
 	return {
 		background: resolveTokenValue(values, tokens['button-bg'], breakpoint),
 		color: resolveTokenValue(values, tokens['button-text'], breakpoint),
 		borderRadius: resolveTokenValue(values, tokens['button-radius'], breakpoint),
+		borderWidth: resolveTokenValue(values, tokens['button-border-width'], breakpoint),
+		borderStyle: resolveTokenValue(values, tokens['button-border-style'], breakpoint),
+		borderColor: resolveTokenValue(values, tokens['button-border-color'], breakpoint),
+		shadow: resolveTokenValue(values, tokens['button-shadow'], breakpoint),
+		padding: resolveTokenValue(values, tokens['button-padding'], breakpoint),
+		margin: resolveTokenValue(values, tokens['button-margin'], breakpoint),
+		// No hover padding/margin: the block binds no hover counterpart for either, so the chip's
+		// box never changes between states. The hover border trio's key order is the block's own —
+		// `button-border-hover-width`, not `button-border-width-hover` (see `declarations.php`).
+		hover: {
+			background: resolveTokenValue(values, tokens['button-bg-hover'], breakpoint),
+			color: resolveTokenValue(values, tokens['button-text-hover'], breakpoint),
+			borderRadius: resolveTokenValue(values, tokens['button-radius-hover'], breakpoint),
+			borderWidth: resolveTokenValue(values, tokens['button-border-hover-width'], breakpoint),
+			borderStyle: resolveTokenValue(values, tokens['button-border-hover-style'], breakpoint),
+			borderColor: resolveTokenValue(values, tokens['button-border-hover-color'], breakpoint),
+			shadow: resolveTokenValue(values, tokens['button-shadow-hover'], breakpoint),
+		},
 	};
 }
 

--- a/src/style-library/presets/single-icon-preset.js
+++ b/src/style-library/presets/single-icon-preset.js
@@ -42,8 +42,8 @@ const ICON_SIZE_FALLBACK = '1.5rem';
 /**
  * Build a row's preview from its stored tokens.
  *
- * An icon's whole bound surface is its color and its size, so both are previewed — unlike the
- * Button, whose preview shows three of eleven properties. Size is previewed as a real length rather
+ * An icon's whole bound surface is its color and its size, so both are previewed — with no hover
+ * state to swap to, unlike the Button's chip. Size is previewed as a real length rather
  * than a scaled-down swatch, because an icon-size scale is only legible at true size.
  *
  * @param {Record<string, *>}      tokens       The preset's stored token map.


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/5d2e88ee3bee41e4a845dcccf314cf9a)

Second of three. Based on #1504, which provides the `capBoxSides` helper this uses.

## What

The Style Library's Button preset row chip previewed only background, text color and radius, so a
preset carrying padding, a border or a shadow previewed as something the button never renders. The
chip now reflects every resting-state style control — border (width, style, color), shadow, padding
and margin — and previews the hover state too.

Saved rows and the live draft overlay run the same preview builder, so an edit shows on the chip
immediately and matches what Save writes.

## Spacing previews at true size

Every step of the spacing scale renders exactly what the button will get. The per-axis bound
(`min(side, 50vh)` vertical, `min(side, 50vw)` horizontal) exists only to contain a pathological
custom literal, never to tame a real value.

A one-value shorthand is expanded to the vertical/horizontal pair before capping — capping it in
place would hold the left and right sides to the vertical bound. The two-, three- and four-value
forms already alternate by index and need no expansion.

## Hover

The chip swaps to the preset's resolved hover styles while the pointer is over it, and holds that
state on the edited row while the settings panel's Hover tab is open (the draft publication carries
the active tab). Per property, an unset hover value keeps the resting style — the same
absent-not-invented posture the resting styles take.

Stale docblocks corrected along the way: the Hover-tab schema comments claimed radius, border and
shadow have no hover-bound counterparts, which the declarations disprove.

## Testing

- New coverage for the preview builder (aliases, per-side slot lists, composite shadows, the hover
  map), the chip (pointer hover swap and revert, held hover state, per-side capping wired to the
  correct style properties), and the Hover-tab publication path on the screen.
- Full JS suite green on this branch alone: 129 suites / 1901 tests.
- CodeRabbit CLI against #1504's branch: 0 findings.
- Verified in wp-admin: picking a padding step or border width updates the chip instantly; a hover
  background set on the Hover tab holds while that tab is open, reverts on Normal, and swaps under
  real pointer hover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Button preset previews now show border, shadow, padding, and margin styles.
  - Previews support hover states through pointer interaction and the active Hover tab.
  - Preset rows now reflect the active hover preview for open drafts.
  - Button style transitions now animate spacing, borders, and shadows.

- **Bug Fixes**
  - Improved spacing previews with accurate per-side value capping.
  - Preserved correct handling of unset and unitless values.

- **Documentation**
  - Clarified single-icon preview behavior and button spacing properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
