### PR TITLE
[DTM] SOFT-4321 [3/5]: Open the shared color popover from the shadow control's Custom tab

### DIFF
--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -68,7 +68,7 @@ import {
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorShadowControl } from '../../extension/design-tokens/components/EditorShadowControl';
 import { imageBoxShadowCss } from './box-shadow';
-import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
+import { ShadowColorField } from '../../extension/design-tokens/components/shadow-color';
 import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
 import { resolveColorLiteral } from '../../extension/design-tokens/color-literal';
 import { tokenDimension } from '../../extension/design-tokens/token-dimension';
@@ -239,6 +239,10 @@ export default function Image({
 		);
 	// One fetch of the block's effective palette groups, shared by every `ColorControl` on this block.
 	const colorGroups = useColorGroups(clientId);
+
+	// `BoxShadowControl` calls `renderColor` from inside its popover's Custom tab; defined once per
+	// render so the field closes over the shared palette groups rather than fetching its own.
+	const renderShadowColor = useCallback((slot) => <ShadowColorField {...slot} groups={colorGroups} />, [colorGroups]);
 
 	// Empty when the token registry is inactive, which is what keeps the plain controls below as the
 	// fallback rather than leaving the image with no radius/padding control at all.

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -96,7 +96,7 @@ import {
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
 import { EditorShadowControl } from '../../extension/design-tokens/components/EditorShadowControl';
-import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
+import { ShadowColorField } from '../../extension/design-tokens/components/shadow-color';
 import { BorderColorField } from '../../extension/design-tokens/components/border-color';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
 import { EditorColorControl } from '../../extension/design-tokens/components/EditorColorControl';
@@ -305,6 +305,9 @@ export default function KadenceButtonEdit(props) {
 	// `BorderControl` forwards `renderColor` down through `SlotGrid`'s `renderSlot`, so this is
 	// defined once per render rather than inline at each of the border panels below.
 	const renderBorderColor = useCallback((row) => <BorderColorField {...row} groups={colorGroups} />, [colorGroups]);
+	// Same shape as `renderBorderColor`: `BoxShadowControl` calls `renderColor` from inside its
+	// popover's Custom tab, so this closes over the shared palette groups once per render.
+	const renderShadowColor = useCallback((slot) => <ShadowColorField {...slot} groups={colorGroups} />, [colorGroups]);
 
 	const borderRadiusPresetValue = presetValueForDevice(
 		tokenBinding.borderRadius?.presetValue,

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -13,14 +13,12 @@
  *   unitless numbers become the composite's `"Npx"` strings, matching `ShadowField`'s own convention.
  * - **no `opacity` field in the composite** — the Shadow screen's `ColorPicker` carries alpha inside
  *   the color itself. Folding native's separate `opacity` into the composite's `color` (as an
- *   `rgba(...)` string when opacity is less than fully opaque, a plain hex otherwise) is what lets a
- *   caller's `renderColor` edit both through one `PopColorControl`, unchanged, via its existing
- *   `opacityValue`/`onArrayChange` props — the same two-channel mechanism the native
- *   `@kadence/components` `BoxShadowControl` already wires it through
- *   (`node_modules/@kadence/components/src/box-shadow-control/index.js`). `combineColorOpacity`/
- *   `splitColorOpacity` below are exported so a caller's `renderColor` can do that combine/split with
- *   the exact same rules this component uses to read/write the native attribute, keeping both
- *   directions symmetric.
+ *   `rgba(...)` string when opacity is less than fully opaque, a plain hex otherwise) is what lets the
+ *   caller's `renderColor` — the block editor's `ShadowColorField`, a `ColorControl` whose Custom tab
+ *   picker carries alpha inline as `#rrggbbaa` — edit both through a single color string.
+ *   `combineColorOpacity`/`splitColorOpacity` below are exported so a caller's `renderColor` can do
+ *   that combine/split with the exact same rules this component uses to read/write the native
+ *   attribute, keeping both directions symmetric.
  * This control renders no enable toggle of its own — whether a `box-shadow` declaration is emitted is
  * decided by inspecting the shadow value's own axes (an all-zero value, including the fixed "None"
  * pick, emits nothing), both on the front end and in the editor-canvas live preview. A host that
@@ -110,10 +108,9 @@ function hexToRgba(hex, alpha) {
 
 /**
  * Fold a native hex color and a separate opacity number into the single string `BoxShadowControl`'s
- * composite color slot carries, so a caller's `renderColor` can hand both to one `PopColorControl` via
- * its `value`/`opacityValue` props. Fully opaque (or unset) opacity stays a plain hex literal — no
- * `rgba(...)` wrapping — so the common case round-trips as the same hex string a plain `PopColorControl`
- * without opacity support would also produce.
+ * composite color slot carries, so a caller's `renderColor` can seed a single color picker with both.
+ * Fully opaque (or unset) opacity stays a plain hex literal — no `rgba(...)` wrapping — so the common
+ * case round-trips as the same hex string the picker emits for an opaque pick.
  *
  * @param {string}  color   The native hex color, an `rgb(...)`/`rgba(...)` literal, or any other CSS
  *                          color literal.
@@ -127,7 +124,7 @@ function hexToRgba(hex, alpha) {
  * `transparent`, `currentColor` — passes through unchanged rather than being corrupted into black;
  * the separate opacity is lost in that one case, a known, accepted limitation (there is no lossless
  * single-string encoding for "an opaque reference plus a multiplier" without `color-mix()`, which
- * `PopColorControl`/`splitColorOpacity` do not parse) — see `splitColorOpacity`'s matching fallback.
+ * `splitColorOpacity` does not parse) — see `splitColorOpacity`'s matching fallback.
  */
 export function combineColorOpacity(color, opacity) {
 	if (!color) {
@@ -182,7 +179,7 @@ export function splitColorOpacity(combined) {
 	}
 
 	// An 8-digit hex (`#RRGGBBAA`) carries its own alpha in the trailing pair — decode it rather than
-	// reading the whole 8-digit string as an opaque color, which `PopColorControl` cannot render.
+	// reading the whole 8-digit string as an opaque color, which would read as fully opaque.
 	const hexAlphaMatch = combined.match(/^#?([0-9a-f]{6})([0-9a-f]{2})$/i);
 
 	if (hexAlphaMatch) {

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -357,6 +357,27 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 			inset: false,
 		});
 	});
+
+	/**
+	 * A token alias picked as the shadow's color passes through the split untouched as the native
+	 * `color`, with full opacity — the alias-aware color output resolves it on render.
+	 *
+	 * @return {void}
+	 */
+	it('keeps a token alias as the native color with full opacity', () => {
+		const native = toNativeShadow({
+			color: '{semantic.color.accent.main}',
+			offsetX: '2px',
+			offsetY: '3px',
+			blur: '4px',
+			spread: '5px',
+			inset: false,
+		});
+
+		expect(native[0].color).toBe('{semantic.color.accent.main}');
+		expect(native[0].opacity).toBe(1);
+		expect(native[0]).not.toHaveProperty(SHADOW_TOKEN_KEY);
+	});
 });
 
 describe('EditorShadowControl always renders, with no enable toggle', () => {

--- a/src/extension/design-tokens/components/__tests__/shadow-color.test.js
+++ b/src/extension/design-tokens/components/__tests__/shadow-color.test.js
@@ -1,0 +1,225 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import { ShadowColorField } from '../shadow-color';
+
+// Mirrors `border-color.test.js`'s stand-in: `@wordpress/components` resolves its own nested `react`
+// copy, a different module instance than the top-level `react-dom/client` this test renders with,
+// which trips React's "Invalid hook call" guard. `Dropdown` renders both its toggle and its content
+// at once so a test can reach the popover's rows without simulating a real open click.
+jest.mock('@wordpress/components', () => ({
+	Button: ({ children, isPressed, showTooltip, ...props }) => <button {...props}>{children}</button>,
+	Dropdown: ({ renderToggle, renderContent }) => (
+		<>
+			{renderToggle({ isOpen: false, onToggle: () => {} })}
+			{renderContent({ onClose: () => {} })}
+		</>
+	),
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+	RangeControl: ({ label }) => <div>{label}</div>,
+	SelectControl: ({ label }) => <div>{label}</div>,
+	TabPanel: ({ children, tabs }) => (
+		<div>
+			{tabs.map((tab) => (
+				<div key={tab.name} data-tab={tab.name}>
+					{children(tab)}
+				</div>
+			))}
+		</div>
+	),
+	Tooltip: ({ children }) => children,
+	__experimentalNumberControl: ({ label }) => <div>{label}</div>,
+}));
+
+jest.mock('@wordpress/icons', () => ({
+	check: 'check',
+	globe: 'globe',
+	settings: 'settings',
+	undo: 'undo',
+	Icon: ({ icon, ...props }) => <span {...props}>{icon}</span>,
+}));
+
+jest.mock('@wordpress/i18n', () => ({
+	__: (text) => text,
+	sprintf: (format, ...args) => {
+		let next = 0;
+		return format.replace(/%(?:(\d+)\$)?s/g, (match, position) =>
+			position ? args[Number(position) - 1] : args[next++]
+		);
+	},
+}));
+
+// Exposes the `color` the Custom tab was seeded with, and emits a translucent `#rrggbbaa` on click —
+// the shape the real picker produces once its alpha slider leaves fully opaque.
+jest.mock('../../../../token-controls/molecules/ColorPicker', () => ({
+	ColorPicker: ({ color, onChange }) => (
+		<button
+			type="button"
+			data-testid="color-picker"
+			data-color={color ?? ''}
+			onClick={() => onChange('#abcdef80')}
+		/>
+	),
+}));
+
+jest.mock('../../../../token-controls/styles/token-controls.scss', () => ({}), { virtual: true });
+
+const GROUPS = [
+	{
+		id: 'accent',
+		label: 'Accent',
+		swatches: [
+			{
+				id: 'semantic.color.accent.main',
+				label: 'Main',
+				value: '#3182ce',
+				alias: '{semantic.color.accent.main}',
+			},
+		],
+	},
+];
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Mount the field with the given prop overrides.
+ *
+ * @param {Object} props Prop overrides merged over the defaults.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function render(props = {}) {
+	act(() => {
+		root.render(
+			createElement(ShadowColorField, {
+				value: '',
+				onChange: jest.fn(),
+				groups: GROUPS,
+				...props,
+			})
+		);
+	});
+}
+
+describe('ShadowColorField', () => {
+	/**
+	 * The trigger is the full `ColorControl` row with a visible "Color" label, not the bare swatch the
+	 * border field renders — the shadow popover has a whole row to give it.
+	 *
+	 * @return {void}
+	 */
+	it('renders a visible "Color" label on the trigger row', () => {
+		render();
+
+		expect(container.querySelector('.kb-color-control__label').textContent).toBe('Color');
+		expect(container.querySelector('.kb-color-swatch-control')).toBeNull();
+	});
+
+	/**
+	 * A token pick reaches `onChange` as the entry's bracket alias — the shape the shadow item's
+	 * `color` stores, and the one the alias-aware renderers resolve.
+	 *
+	 * @return {void}
+	 */
+	it('writes a picked token as its bracket alias', () => {
+		const onChange = jest.fn();
+		render({ onChange });
+
+		act(() => {
+			container.querySelector('.kb-color-control__item').click();
+		});
+
+		expect(onChange).toHaveBeenCalledWith('{semantic.color.accent.main}');
+	});
+
+	/**
+	 * A bound alias names itself on the trigger, so the row reads as the token rather than as an
+	 * anonymous swatch.
+	 *
+	 * @return {void}
+	 */
+	it("shows the picked token's label on the trigger", () => {
+		render({ value: '{semantic.color.accent.main}' });
+
+		expect(container.querySelector('.kb-color-control__value').textContent).toBe('Main');
+	});
+
+	/**
+	 * A Custom-tab pick reaches `onChange` as the picker's own `#rrggbbaa` literal, alpha included —
+	 * there is no separate opacity channel to write any more.
+	 *
+	 * @return {void}
+	 */
+	it('writes a custom color as the raw literal, alpha included', () => {
+		const onChange = jest.fn();
+		render({ onChange });
+
+		act(() => {
+			container.querySelector('[data-testid="color-picker"]').click();
+		});
+
+		expect(onChange).toHaveBeenCalledWith('#abcdef80');
+	});
+
+	/**
+	 * A shadow saved by the previous control arrives as the `rgba(...)` string `fromNativeShadow()`
+	 * folds its color and opacity into; the Custom tab must seed from that literal, and the trigger
+	 * swatch must paint it, rather than either treating it as unset.
+	 *
+	 * @return {void}
+	 */
+	it('seeds the Custom tab and the swatch from an existing rgba(...) value', () => {
+		render({ value: 'rgba(17, 17, 17, 0.4)' });
+
+		expect(container.querySelector('[data-testid="color-picker"]').dataset.color).toBe('rgba(17, 17, 17, 0.4)');
+		expect(container.querySelector('.kb-color-control__trigger .kb-color-swatch').style.background).toContain(
+			'17, 17, 17'
+		);
+	});
+
+	/**
+	 * A shadow always has a color, so the popover offers no Clear row — clearing would leave geometry
+	 * with no color, which renders as an opaque black shadow rather than none.
+	 *
+	 * @return {void}
+	 */
+	it('offers no Clear row', () => {
+		render({ value: '#171717' });
+
+		expect(container.querySelector('.kb-color-control__clear')).toBeNull();
+	});
+
+	/**
+	 * `BoxShadowControl` passes its own `disabled` through the render prop; the trigger honors it.
+	 *
+	 * @return {void}
+	 */
+	it('disables the trigger when the shadow control is read-only', () => {
+		render({ disabled: true });
+
+		expect(container.querySelector('.kb-color-control__trigger-button').disabled).toBe(true);
+	});
+});

--- a/src/extension/design-tokens/components/__tests__/shadow-color.test.js
+++ b/src/extension/design-tokens/components/__tests__/shadow-color.test.js
@@ -201,6 +201,19 @@ describe('ShadowColorField', () => {
 	});
 
 	/**
+	 * `transparent` is the composite's "no color yet" default. It must reach the picker as '' rather
+	 * than as a value: read as a color it is alpha 0, which pins the alpha slider at zero and makes
+	 * every hue the user picks come back fully see-through.
+	 *
+	 * @return {void}
+	 */
+	it('opens the picker unset rather than seeding it from transparent', () => {
+		render({ value: 'transparent' });
+
+		expect(container.querySelector('[data-testid="color-picker"]').dataset.color).toBe('');
+	});
+
+	/**
 	 * A shadow always has a color, so the popover offers no Clear row — clearing would leave geometry
 	 * with no color, which renders as an opaque black shadow rather than none.
 	 *

--- a/src/extension/design-tokens/components/shadow-color.js
+++ b/src/extension/design-tokens/components/shadow-color.js
@@ -1,56 +1,62 @@
 /**
- * The default `renderColor` for `EditorShadowControl`.
+ * The block editor's color field for `EditorShadowControl`'s Custom tab.
  *
- * Kept out of `EditorShadowControl.js` itself, even though it exists only to be passed to it: this is
- * the one piece that reaches for `@kadence/components`, and that package ships a `dist/cjs` build with
- * bare `import` statements that Jest cannot parse. Every other module under `components/` stays clear
- * of it — `EditorBorderControl` takes its color field as a prop for the same reason — so importing it
- * there would make `EditorShadowControl` untestable in isolation. A separate module keeps the cost on
- * the blocks that render a color field, which are already in that position.
+ * Sits beside `border-color.js`, `color-literal.js` and `use-color-groups.js` because it is the
+ * editor's own adapter rather than part of the host-agnostic control library: it knows how a token
+ * resolves against this document, and it is handed the block's effective palette groups. A block
+ * wires it exactly the way it wires `BorderColorField` — once per render through `useCallback`,
+ * closing over `useColorGroups(clientId)` — and passes the result as `renderColor`.
+ *
+ * Kept out of `EditorShadowControl.js` so that module stays free of `ColorControl`'s `Dropdown` and
+ * `react-color` imports; its own suite calls it as a plain function with no `@wordpress/components`
+ * stand-in, and pulling the popover in there would force one for no gain.
  */
 
 /**
  * WordPress dependencies
  */
-import { PopColorControl } from '@kadence/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { combineColorOpacity, splitColorOpacity } from './EditorShadowControl';
+import { ColorControl } from '../../../token-controls';
+import { resolveColorLiteral } from '../color-literal';
 
 /**
- * Render the shared color field for a shadow composite's single `color` slot.
+ * Render the color field for a shadow composite's single `color` slot.
  *
- * Every block wires this identically, because the shape it bridges belongs to the control rather than
- * to any block: the composite carries alpha inside `color` while the native attribute keeps a separate
- * `opacity`, and `PopColorControl` edits both through its own two channels. A block only needs its own
- * `renderColor` if it wants a different color field here; otherwise it passes this.
+ * The composite carries alpha inside the color string itself — an `rgba(...)` literal folded by
+ * `fromNativeShadow()`, or the `#rrggbbaa` the shared picker emits — so the value goes to
+ * `ColorControl` untouched and every pick comes back through one `onChange`. `toNativeShadow()`
+ * splits it back into the native `(color, opacity)` pair; a token alias passes through that split
+ * unchanged and renders through the alias-aware color output on both the canvas and the front end.
  *
- * `hideClear` because the composite always has a color — clearing it to nothing would leave a shadow
- * with geometry and no color, which renders as an opaque black one rather than as no shadow. Removing
- * a shadow is what zeroing its axes is for.
+ * No `onClear`: the composite always has a color. Clearing it to nothing would leave a shadow with
+ * geometry and no color, which renders as an opaque black one rather than as no shadow. Removing a
+ * shadow is what zeroing its axes, or the Style Library's None pick, is for.
  *
- * @param {Object}   props          The render-prop's argument.
- * @param {string}   props.value    The composite's current `color` slot, alpha included.
- * @param {Function} props.onChange Called with the next `color` slot.
+ * @param {Object}   props            The component props.
+ * @param {*}        props.value      The composite's current `color` slot: a bracket alias or a raw
+ *                                    literal, alpha included.
+ * @param {Function} props.onChange   Called with the next `color` slot.
+ * @param {boolean}  [props.disabled] Whether the field is read-only.
+ * @param {Array}    props.groups     The block's effective palette groups, from `useColorGroups()`.
  *
  * @since TBD
  *
  * @return {JSX.Element} The rendered color field.
  */
-export function renderShadowColor({ value, onChange }) {
-	const { color, opacity } = splitColorOpacity(value);
-
+export function ShadowColorField({ value, onChange, disabled = false, groups }) {
 	return (
-		<PopColorControl
-			value={color || ''}
-			default={'#000000'}
-			hideClear={true}
-			opacityValue={opacity}
-			onChange={(next) => onChange(combineColorOpacity(next, opacity))}
-			onOpacityChange={(next) => onChange(combineColorOpacity(color, next))}
-			onArrayChange={(next, nextOpacity) => onChange(combineColorOpacity(next, nextOpacity))}
+		<ColorControl
+			label={__('Color', 'kadence-blocks')}
+			value={value || ''}
+			groups={groups}
+			onPick={onChange}
+			onCustom={onChange}
+			resolveLiteral={resolveColorLiteral}
+			disabled={disabled}
 		/>
 	);
 }

--- a/src/extension/design-tokens/components/shadow-color.js
+++ b/src/extension/design-tokens/components/shadow-color.js
@@ -51,7 +51,11 @@ export function ShadowColorField({ value, onChange, disabled = false, groups }) 
 	return (
 		<ColorControl
 			label={__('Color', 'kadence-blocks')}
-			value={value || ''}
+			// `transparent` is the composite's "no color yet" default, and it must not reach the picker as
+			// a value: `react-color` reads it as alpha 0, which pins the alpha slider at zero, so every
+			// hue the user then picks is emitted fully see-through and reads straight back as no color.
+			// Passing '' instead opens the picker unset, and the first pick lands at full alpha.
+			value={value && value !== 'transparent' ? value : ''}
 			groups={groups}
 			onPick={onChange}
 			onCustom={onChange}

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -362,6 +362,10 @@ export function BoxShadowControl({
 					<Dropdown
 						className="kadence-token-field__dropdown"
 						contentClassName="kadence-token-field__popover"
+						// Beside the trigger, not above it — the same placement every other control in this
+						// library uses. The inspector column is narrow enough that a popover opening upward
+						// covers the controls the user was just reading.
+						popoverProps={{ placement: 'left-start' }}
 						renderToggle={({ isOpen, onToggle }) => (
 							<Button
 								className="kadence-token-field__trigger kb-box-shadow-control__trigger"

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -14,7 +14,7 @@
  *
  * Color is out of scope here (see `renderColor`) exactly as in `BorderControl` — this control does
  * not import or build a color picker. The Custom tab's color row wraps whatever `renderColor`
- * renders (the Style Library's swatch-plus-label toggle, the block editor's `PopColorControl`) in
+ * renders (the Style Library's swatch-plus-label toggle, the block editor's `ShadowColorField`) in
  * plain layout chrome; it does not touch what that render prop returns.
  *
  * The token rows also hide their resolved value (`TokenPopover`'s `showValue={false}`) — a shadow's
@@ -248,7 +248,7 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
 			{renderColor && (
 				// A plain wrapper, not a rebuilt picker: whatever the caller's `renderColor` already renders
 				// (the Style Library's `TokenColorSelectField` swatch-plus-"Color"-label toggle, the block
-				// editor's `PopColorControl`) keeps its own click-to-open mechanism and chrome untouched;
+				// editor's `ShadowColorField`) keeps its own click-to-open mechanism and chrome untouched;
 				// this only gives it its own row above the axes instead of sitting inline with them.
 				<div className="kb-box-shadow-control__color-row">
 					{renderColor({ value: shadow.color, onChange: (next) => setPart('color', next), disabled })}

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -301,7 +301,7 @@
 /*
  * The color row: a plain full-width wrapper around whatever `renderColor` renders (see the render
  * function's own comment on why this does not rebuild that markup). Margin only, no border/padding
- * of its own — the Style Library's `TokenColorSelectField` and the block editor's `PopColorControl`
+ * of its own — the Style Library's `TokenColorSelectField` and the block editor's `ShadowColorField`
  * already draw their own bordered, clickable swatch-plus-label toggle, and adding a second border
  * around it would double up the chrome the reference `ShadowField` only draws once.
  */


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/b1a4c066dd6348b9a9d4f64ffe317497)

Based on #1515.

## Summary

The Shadow control's Custom tab was the last color field in the design-tokens UI still drawing the
legacy `PopColorControl`: a bare chip with its own picker, a separate opacity slider, and no way to
bind a palette token. It now opens the shared `ColorControl` — the same popover the Border color row
uses — under a visible "Color" label.

`ShadowColorField` is the editor's adapter, sitting beside `BorderColorField`. Seven call sites (six
Button states plus the Image block) build it with `useCallback` over the block's palette groups.
`BoxShadowControl` needed no change; it only calls `renderColor`.

## The picker must not open at `transparent`

The composite's "no color yet" default is the literal `transparent`, which `react-color` reads as
**alpha 0**. That pinned the alpha slider at zero, so every hue picked came back fully see-through
and read straight back as no color — the field looked broken. `transparent` is now translated to
`''` before it reaches the control, so the picker opens unset and the first pick lands opaque.

## Alpha and tokens

Alpha rides inside the color string — an `rgba(...)` folded by `fromNativeShadow()`, or the
`#rrggbbaa` the shared picker emits — and `toNativeShadow()` splits it back into the native
`(color, opacity)` pair, so the stored attribute shape is unchanged and the separate opacity channel
is no longer needed in the UI. A token alias passes through that split untouched and resolves on both
render paths, so picking a Style Library color binds the alias rather than freezing a literal.

There is no Clear row: a shadow always has a color, and clearing it would leave geometry with no
color, which paints opaque black rather than nothing. Zeroing the axes, or the "None" pick, is how a
shadow is removed.

## Popover placement

The Shadow popover was the only control in the library opening with no `popoverProps`, so it appeared
above its input and covered the controls above it. It now uses `placement: 'left-start'` like every
sibling control, opening beside the input.

## Test plan

- `shadow-color.test.js`: the visible "Color" label, an alias pick writing the bracket alias, the
  token's label on the trigger, a custom pick writing `#abcdef80`, an existing `rgba(...)` seeding
  both picker and swatch, `transparent` opening the picker unset, no Clear row, `disabled` passthrough.
- An alias survives `toNativeShadow()` as the native color at full opacity.
- Full JS suite green on this branch alone: 1915 tests.
- CodeRabbit CLI against #1515's branch: 0 findings.
- Verified in wp-admin on a dedicated site: picking a color sticks and survives deselect/reselect,
  nothing paints until an axis moves, Blur 14 / Y 8 paints in that color in the editor and on the
  front end (`rgb(196, 38, 38) 0px 8px 14px 0px`), and the color popover opens over the Shadow
  popover without closing it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved box-shadow color controls with shared palette options, custom RGBA values, transparency, and token aliases.
  - Added clearer labels and disabled-state support for shadow color fields.
  - Updated shadow color menus for more consistent positioning.

- **Bug Fixes**
  - Preserved shadow color token aliases and full-opacity values when editing design tokens.

- **Tests**
  - Added coverage for token selection, custom colors, transparency, disabled controls, and alias handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->