### PR TITLE
[DTM] SOFT-4268 [1/3]: Extract the per-side preview cap into a shared helper

### DIFF
--- a/src/style-library/__tests__/preview.test.js
+++ b/src/style-library/__tests__/preview.test.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+/**
+ * Internal dependencies
+ */
+import { capBoxSides } from '../helpers/preview';
+
+describe('capBoxSides', () => {
+	/**
+	 * AC4: a single length is wrapped in min() against the cap.
+	 */
+	it('caps a single length', () => {
+		expect(capBoxSides('6rem', '2rem')).toBe('min(6rem, 2rem)');
+	});
+
+	/**
+	 * AC4: each side of a shorthand is capped independently.
+	 */
+	it('caps each side of a shorthand', () => {
+		expect(capBoxSides('0.4em 1em 0.4em 1em', '2rem')).toBe(
+			'min(0.4em, 2rem) min(1em, 2rem) min(0.4em, 2rem) min(1em, 2rem)'
+		);
+	});
+
+	/**
+	 * AC4: a unitless zero stays unwrapped — min(0, 2rem) mixes a number with a length,
+	 * which is invalid CSS and would drop the whole declaration.
+	 */
+	it('leaves a unitless component untouched', () => {
+		expect(capBoxSides('0 1rem 0 1rem', '2rem')).toBe('0 min(1rem, 2rem) 0 min(1rem, 2rem)');
+	});
+
+	/**
+	 * AC4: an explicitly signed length is still a number with a unit, so it is capped like any other
+	 * — an unwrapped `+100rem` would escape the very bound the cap exists to impose.
+	 */
+	it('caps an explicitly signed length', () => {
+		expect(capBoxSides('+100rem', '2rem')).toBe('min(+100rem, 2rem)');
+	});
+
+	/**
+	 * AC4/AC3: nothing to apply resolves to undefined so a JSX style prop drops the property.
+	 */
+	it('returns undefined for an empty value', () => {
+		expect(capBoxSides('', '2rem')).toBeUndefined();
+	});
+
+	/**
+	 * AC4/AC3: a whitespace-only value is as empty as '' — it must resolve to undefined too, not to
+	 * an empty string, so the style prop is dropped rather than set to nothing.
+	 */
+	it('returns undefined for a whitespace-only value', () => {
+		expect(capBoxSides('   ', '2rem')).toBeUndefined();
+	});
+});

--- a/src/style-library/helpers/preview.js
+++ b/src/style-library/helpers/preview.js
@@ -1,0 +1,43 @@
+/**
+ * Preview-only presentation helpers shared by the preset screens' row previews. Pure functions:
+ * no React, no feed access — resolution stays in `helpers/presets.js`, this is only about keeping
+ * a resolved value displayable inside a list row.
+ */
+
+/**
+ * Cap each side of a resolved box value (a padding or margin), so one extreme preset cannot make a
+ * list row enormous.
+ *
+ * Each side is wrapped separately because a per-side preset stores four, and CSS `min()` takes a
+ * single length rather than a shorthand. Only a component that is a NUMBER WITH A UNIT is wrapped,
+ * and that restriction is load-bearing rather than defensive: `min()` requires its arguments to be
+ * of one type, so `min(0, 2rem)` — mixing a number with a length — is invalid and the browser drops
+ * the whole declaration. A unitless `0` needs no capping anyway.
+ *
+ * @param {string} value The resolved value: one length, or a space-separated shorthand.
+ * @param {string} cap   The most any one side may show — a LENGTH, not a percentage, because the
+ *                       preview grows to fit the value rather than insetting into a fixed frame.
+ *
+ * @since TBD
+ *
+ * @return {?string} The capped value, or undefined when there is nothing to apply.
+ */
+export function capBoxSides(value, cap) {
+	if (!value) {
+		return undefined;
+	}
+
+	// Trimmed before the second emptiness check rather than only before splitting: a whitespace-only
+	// value has nothing to cap, and falling through would hand the caller an empty string instead of
+	// the "no value to apply" that a JSX style prop needs to drop the property.
+	const sides = String(value).trim();
+
+	if (!sides) {
+		return undefined;
+	}
+
+	return sides
+		.split(/\s+/)
+		.map((side) => (/^[+-]?\d*\.?\d+[a-z%]+$/i.test(side) ? `min(${side}, ${cap})` : side))
+		.join(' ');
+}

--- a/src/style-library/presets/image-preset.js
+++ b/src/style-library/presets/image-preset.js
@@ -15,6 +15,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getPresetProperties, resolveTokenValue } from '../helpers/presets';
+import { capBoxSides } from '../helpers/preview';
 
 /**
  * The block name this screen edits — the single JS spelling, shared by the screen registration and
@@ -49,42 +50,6 @@ const IMAGE_PADDING_FALLBACK = ['0', '0', '0', '0'];
 const PADDING_PREVIEW_CAP = '4rem';
 
 /**
- * Cap each side of a resolved padding value, so one extreme preset cannot make a list row enormous.
- *
- * The tile GROWS to fit its padding rather than insetting into a fixed frame (see `ImageScreen.scss`),
- * which is what keeps each step of the scale visibly different and always leaves a photo to see. That
- * alone is unbounded, though, and the spacing scale runs to 10rem — a preset using the top step would
- * produce a tile over 20rem on a side and a row taller than the screen. The cap bounds that end while
- * leaving every step up to `XL` exact, so the values a preset realistically uses are shown true to
- * size.
- *
- * Each side is wrapped separately because a per-corner preset stores four, and CSS `min()` takes a
- * single length rather than a shorthand. Only a component that is a NUMBER WITH A UNIT is wrapped,
- * and that restriction is load-bearing rather than defensive: `min()` requires its arguments to be of
- * one type, so `min(0, 4rem)` — mixing a number with a length — is invalid and the browser drops the
- * whole declaration. The `None` step resolves to a unitless `0` (kept unitless on purpose, so a stored
- * zero still equals the token), which made picking it silently leave the previous padding on screen,
- * the property having never been assigned. Nothing without a unit needs capping anyway.
- *
- * @param {string} padding The resolved padding: one length, or a space-separated shorthand.
- *
- * @since TBD
- *
- * @return {?string} The capped padding, or undefined when there is nothing to apply.
- */
-function cappedPadding(padding) {
-	if (!padding) {
-		return undefined;
-	}
-
-	return String(padding)
-		.trim()
-		.split(/\s+/)
-		.map((side) => (/^-?\d*\.?\d+[a-z%]+$/i.test(side) ? `min(${side}, ${PADDING_PREVIEW_CAP})` : side))
-		.join(' ');
-}
-
-/**
  * Build a row's preview from its stored tokens.
  *
  * Four of the image's six bound properties, which is its whole editable surface here — border color
@@ -116,7 +81,7 @@ function preview(tokens, values, breakpoint) {
  *
  * Three nested elements, each earning its place. The outer carries the radius and the shadow, which
  * has to be cast from outside anything that clips. The middle carries the background AND the padding
- * (capped only at the very top of the scale — see `cappedPadding`), so padding renders as what it
+ * (capped only at the very top of the scale — see `capBoxSides`), so padding renders as what it
  * actually is: space between the frame and the image, at true size, with the tile growing to fit it. The inner is the stand-in photo, a neutral block carrying a generic picture glyph
  * rather than a real image, because a preset skins whatever image a block happens to hold and
  * previewing a specific picture would imply it selects one. The glyph is what makes the padding
@@ -146,7 +111,7 @@ function renderPreview(row) {
 				style={{
 					background: row.preview.background || undefined,
 					borderRadius: radius,
-					padding: cappedPadding(row.preview.padding),
+					padding: capBoxSides(row.preview.padding, PADDING_PREVIEW_CAP),
 				}}
 			>
 				<span className="kadence-blocks-style-library__image-preset-preview-photo">


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/5d2e88ee3bee41e4a845dcccf314cf9a)

First of three. A pure refactor, reviewable on its own: no behavior changes anywhere.

## What

`capBoxSides` moves out of `presets/image-preset.js` into `helpers/preview.js`, so more than one
preset screen can cap a preview's box sides. Nothing new is wired up here — the Advanced Image
preset keeps its own 4rem cap and behaves exactly as before. The Button chip that needs the helper
arrives in the next PR.

## The helper

Each side of a resolved padding/margin is wrapped separately in `min(side, cap)`. Per-side wrapping
is load-bearing rather than defensive: CSS `min()` needs its arguments to be one type, so
`min(0, 2rem)` is invalid and the browser drops the whole declaration. Only a number-with-a-unit is
wrapped; a unitless `0` needs no cap anyway.

A whitespace-only value resolves to `undefined` like an empty one, so a JSX style prop drops the
property instead of setting it to an empty string.

## Testing

- `src/style-library/__tests__/preview.test.js` — a single length, each side of a shorthand, a
  unitless component left alone, and empty/whitespace-only resolving to `undefined`.
- Full JS suite green on this branch alone: 128 suites / 1890 tests.
- CodeRabbit CLI against `feature/design-tokens-module`: 0 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image preset previews so padding values are capped consistently across all sides.
  - Preserved unitless zero values, signed lengths, and non-length padding components.
  - Empty or whitespace-only padding values are now handled without displaying invalid preview output.

- **Tests**
  - Added coverage for single-value and four-side shorthand padding, zero values, signed lengths, and empty or whitespace-only input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
