### PR TITLE
[DTM] SOFT-4268 [3/3]: Keep a preset's row chip filled while its panel is open

### DIFF
--- a/src/style-library/__tests__/presets.test.js
+++ b/src/style-library/__tests__/presets.test.js
@@ -200,6 +200,11 @@ describe('presetRows', () => {
 			id: 'primary',
 			label: 'Primary',
 			userCreated: false,
+			tokens: {
+				'button-bg': '{semantic.color.action-primary}',
+				'button-text': '{semantic.color.on-primary}',
+				'button-radius': '0.5rem',
+			},
 			preview: {
 				background: '#3633e1',
 				color: '#ffffff',
@@ -772,6 +777,68 @@ describe('overlayPresetRows', () => {
 			},
 		});
 		expect(next[1]).toBe(rows[1]);
+	});
+
+	it('keeps stored values for properties the draft leaves unset', () => {
+		// A fresh panel seeds every non-overridden property empty (`presetInitialValues`), so a
+		// draft-only preview blanks the chip the moment the panel opens. The overlay must merge the
+		// draft's SET properties over the row's stored (baseline-merged) map instead — opening the
+		// panel changes nothing, and each edit then previews against the preset's real look.
+		const storedRows = [
+			{
+				id: 'primary',
+				label: 'Primary',
+				userCreated: false,
+				tokens: {
+					'button-bg': '{semantic.color.action-primary}',
+					'button-radius': '0.5rem',
+					'button-bg-hover': '{semantic.color.on-primary}',
+				},
+				preview: BUTTON_PRESET.preview(
+					{
+						'button-bg': '{semantic.color.action-primary}',
+						'button-radius': '0.5rem',
+						'button-bg-hover': '{semantic.color.on-primary}',
+					},
+					values
+				),
+			},
+		];
+		// The fresh-open draft shape: only Text set, everything else seeded empty.
+		const draft = {
+			tokens: {
+				'button-bg': '',
+				'button-text': 'semantic.color.on-primary',
+				'button-radius': '',
+				'button-bg-hover': '',
+				'button-padding': ['', '', '', ''],
+			},
+		};
+
+		const next = overlayPresetRows(storedRows, 'primary', draft, values, BUTTON_PRESET.preview);
+
+		expect(next[0].preview.background).toBe('#3633e1');
+		expect(next[0].preview.borderRadius).toBe('0.5rem');
+		expect(next[0].preview.hover.background).toBe('#ffffff');
+		expect(next[0].preview.color).toBe('#ffffff');
+		expect(next[0].preview.padding).toBe('');
+	});
+
+	it('previews a draft value over the stored one for the same property', () => {
+		const storedRows = [
+			{
+				id: 'primary',
+				label: 'Primary',
+				userCreated: false,
+				tokens: { 'button-bg': '{semantic.color.action-primary}' },
+				preview: BUTTON_PRESET.preview({ 'button-bg': '{semantic.color.action-primary}' }, values),
+			},
+		];
+		const draft = { tokens: { 'button-bg': 'semantic.color.on-primary' } };
+
+		const next = overlayPresetRows(storedRows, 'primary', draft, values, BUTTON_PRESET.preview);
+
+		expect(next[0].preview.background).toBe('#ffffff');
 	});
 
 	it('returns the same array reference for a null draft', () => {

--- a/src/style-library/helpers/presets.js
+++ b/src/style-library/helpers/presets.js
@@ -270,7 +270,7 @@ export function resolveTokenValue(values, value, breakpoint = PRESET_BREAKPOINTS
  *
  * @since TBD
  *
- * @return {Array<{id: string, label: string, userCreated: boolean, preview: Object}>} The preset rows.
+ * @return {Array<{id: string, label: string, userCreated: boolean, tokens: Record<string, *>, preview: Object}>} The preset rows.
  */
 export function presetRows(payload, values, preview, breakpoint = PRESET_BREAKPOINTS[0]) {
 	const presets = payload?.presets ?? {};
@@ -283,6 +283,9 @@ export function presetRows(payload, values, preview, breakpoint = PRESET_BREAKPO
 			id: slug,
 			label: preset?.label ?? slug,
 			userCreated: userCreated.includes(slug),
+			// Carried on the row (not just consumed here) so `overlayPresetRows` can merge a live
+			// draft over the preset's effective values instead of previewing the draft in isolation.
+			tokens,
 			preview: preview(tokens, values, breakpoint),
 		};
 	});
@@ -513,13 +516,22 @@ export function nextPresetSlug(existingSlugs, base) {
 }
 
 /**
- * Overlay a live settings-panel draft onto the row it edits: the label and a preview re-resolved
- * from the draft's token map (bare ids), so the row chip always shows what Save would write instead
- * of waiting for it — the preset analog of `overlayDraft` (`helpers/scale.js`), same
- * reference-identity contract. Returns the exact same array reference for a `null`/absent draft or
- * an `itemId` matching no row; every non-matching row keeps its exact object identity either way.
+ * Overlay a live settings-panel draft onto the row it edits: the label, and a preview re-resolved
+ * from the draft's SET properties merged over the row's stored token map — the preset analog of
+ * `overlayDraft` (`helpers/scale.js`), same reference-identity contract. Returns the exact same
+ * array reference for a `null`/absent draft or an `itemId` matching no row; every non-matching row
+ * keeps its exact object identity either way.
  *
- * @param {Array<{id: string, label: string, preview: Object}>} rows    The rows in payload order.
+ * Merged, not replaced, because the draft deliberately seeds every non-overridden property empty
+ * (see `presetInitialValues`) while the row's stored map is baseline-merged: previewing the draft
+ * alone blanks the chip the moment the panel opens, showing a button the preset never renders.
+ * A property the draft leaves unset keeps previewing the stored value — which is also what a save
+ * produces, since `presetSaveTokens` omits unset properties and the reloaded payload re-merges the
+ * baseline. The one imprecision is clearing a previously-overridden property: until save, the chip
+ * keeps showing the old override, because the baseline value it will fall back to is a server-side
+ * merge this client cannot reproduce.
+ *
+ * @param {Array<{id: string, label: string, tokens: Record<string, *>, preview: Object}>} rows The rows in payload order.
  * @param {string}                                              itemId  The open route item id.
  * @param {?{label?: string, tokens?: Record<string, string>}}  draft   The open panel's live draft, or null.
  * @param {Record<string, string>}                              values  The feed's resolved value map.
@@ -553,10 +565,15 @@ export function overlayPresetRows(rows, itemId, draft, values, preview, breakpoi
 		// The draft holds bare ids (what the picker writes); the block's preview builder expects the
 		// stored alias shape, same as a fetched payload. Re-wrapping here means both paths run the
 		// identical builder, so a live overlay can never resolve differently from what lands on save.
-		const asStored = Object.entries(draft.tokens).reduce((acc, [property, value]) => {
-			acc[property] = aliasDeep(value ?? '');
-			return acc;
-		}, {});
+		const asStored = Object.entries(draft.tokens).reduce(
+			(acc, [property, value]) => {
+				if (!isUnsetPresetValue(value)) {
+					acc[property] = aliasDeep(value);
+				}
+				return acc;
+			},
+			{ ...(overlaid.tokens ?? {}) }
+		);
 
 		overlaid.preview = preview(asStored, values, breakpoint);
 	}


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/5d2e88ee3bee41e4a845dcccf314cf9a)

Third of three. Based on #1502.

## What

Opening a preset's settings panel blanked its row chip. The draft seeds every non-overridden
property empty (see `presetInitialValues`), and the overlay previewed that draft alone — so the
moment the panel opened, the chip showed a button the preset never renders.

The overlay now merges the draft's *set* properties over the row's stored, baseline-merged token
map. A property the draft leaves unset keeps previewing the stored value, which is also what a save
produces: `presetSaveTokens` omits unset properties and the reloaded payload re-merges the baseline.

`presetRows` now carries `tokens` on each row so the overlay has that stored map to merge onto.

This applies to every preset screen sharing the overlay helper, not only the Button.

## Known limitation

Clearing a property that was previously overridden keeps previewing the old override until save. The
value it will fall back to is a server-side baseline merge this client cannot reproduce, so the
choice is between a stale preview and a blank one — stale is the smaller lie, and it corrects itself
on save. Documented on `overlayPresetRows`.

## Testing

- `src/style-library/__tests__/presets.test.js` — the merge over stored tokens, unset properties
  falling through to the stored value, and the reference-identity contract (same array reference for
  a null draft or an unmatched item id; non-matching rows keep object identity).
- Full JS suite green on this branch alone: 129 suites / 1903 tests.
- CodeRabbit CLI against #1502's branch: one finding, which is the limitation documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preset previews now preserve stored values when draft properties are unset.
  - Explicitly edited properties correctly override stored preset values.
  - Preview rendering now accurately reflects background, border radius, hover background, text color, and spacing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
