### PR TITLE
[DTM] SOFT-4320 [1/8]: let the test suites target another plugin directory

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -199,6 +199,9 @@
         "wpml",
         "wpunit",
         "writefunction",
-        "xlarge"
+        "xlarge",
+        "worktree",
+        "Chromedriver",
+        "twentytwentythree"
     ]
 }

--- a/.env.testing
+++ b/.env.testing
@@ -10,6 +10,12 @@ WP_VERSION=latest
 # This is where, in the context of the CI, we'll install and configure WordPress.
 # See `.travis.yml` for more information.
 WP_ROOT_FOLDER=/var/www/html
+# Directory name of the plugin under test inside wp-content/plugins. Defined here rather than in
+# .env.testing.slic because this file takes precedence: a value in the slic env is shadowed by this
+# one, and a mismatch between them loads the plugin twice ("Cannot declare class
+# ComposerAutoloaderInit..."). A git worktree is served from a differently named directory, so it
+# overrides this value locally (see AGENTS.md) rather than editing the suite files.
+KB_PLUGIN_DIR=kadence-blocks
 
 # The WordPress installation will be served from the Docker container.
 # See `dev/docker/ci-compose.yml` for more information.
@@ -24,7 +30,7 @@ WP_ADMIN_PASSWORD=password
 
 WP_DB_PORT=3306
 
-# The databse is served from the Docker `db` container.
+# The database is served from the Docker `db` container.
 # See `dev/docker/ci-compose.yml` for more information.
 WP_TABLE_PREFIX=wp_
 WP_DB_HOST=db
@@ -32,7 +38,7 @@ WP_DB_NAME=test
 WP_DB_USER=root
 WP_DB_PASSWORD=password
 
-# The test databse is served from the Docker `db` container.
+# The test database is served from the Docker `db` container.
 # See `dev/docker/ci-compose.yml` for more information.
 WP_TEST_DB_HOST=db
 WP_TEST_DB_NAME=test

--- a/.env.testing.slic
+++ b/.env.testing.slic
@@ -24,7 +24,7 @@ WP_ADMIN_PASSWORD=password
 
 WP_DB_PORT=3306
 
-# The databse is served from the Docker `db` container.
+# The database is served from the Docker `db` container.
 # See `dev/docker/ci-compose.yml` for more information.
 WP_TABLE_PREFIX=wp_
 WP_DB_HOST=db
@@ -32,7 +32,7 @@ WP_DB_NAME=test
 WP_DB_USER=root
 WP_DB_PASSWORD=password
 
-# The test databse is served from the Docker `db` container.
+# The test database is served from the Docker `db` container.
 # See `dev/docker/ci-compose.yml` for more information.
 WP_TEST_DB_HOST=db
 WP_TEST_DB_NAME=test

--- a/tests/snapshot.suite.yml
+++ b/tests/snapshot.suite.yml
@@ -20,6 +20,6 @@ modules:
             title: 'Kadence Blocks Snapshot Tests'
             theme: twentytwentyfour
             plugins:
-                - kadence-blocks/kadence-blocks.php
+                - %KB_PLUGIN_DIR%/kadence-blocks.php
             activatePlugins:
-                - kadence-blocks/kadence-blocks.php
+                - %KB_PLUGIN_DIR%/kadence-blocks.php

--- a/tests/wpunit.suite.yml
+++ b/tests/wpunit.suite.yml
@@ -19,6 +19,6 @@ modules:
             title: 'Kadence Blocks Tests'
             theme: twentytwentythree
             plugins:
-                - kadence-blocks/kadence-blocks.php
+                - %KB_PLUGIN_DIR%/kadence-blocks.php
             activatePlugins:
-                - kadence-blocks/kadence-blocks.php
+                - %KB_PLUGIN_DIR%/kadence-blocks.php


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/3f7bf1ff5960448399a02dd96fd18f49)

## Summary

Lets the wpunit and snapshot suites run against a plugin directory other than `kadence-blocks`.

The suites hardcoded `kadence-blocks/kadence-blocks.php` as the plugin WPLoader activates, so a
checkout served from a differently named directory — a git worktree, say — ran its own test files
against the main checkout's code. That looks like a passing suite while proving nothing.

The plugin directory now comes from `KB_PLUGIN_DIR`, which defaults to `kadence-blocks`, so nothing
changes for a normal run or for CI.

## What's in it

- `KB_PLUGIN_DIR` added to `.env.testing`, defaulting to `kadence-blocks`. It lives there rather
  than in `.env.testing.slic` because `.env.testing` takes precedence: a value in the slic env is
  shadowed by it, and a value that does not match the target loads the plugin twice.
- `tests/wpunit.suite.yml` and `tests/snapshot.suite.yml` read `%KB_PLUGIN_DIR%`.
- Fixes a `databse` typo in `.env.testing`, and adds `worktree`, `Chromedriver` and
  `twentytwentythree` to the cspell dictionary so the touched files lint clean.

## Test plan

- `slic run wpunit` — unchanged behavior with the default value.
- To verify the mechanism: point `KB_PLUGIN_DIR` at another directory and confirm a test method that
  exists only there is collected.

## Known gap

`tests/_support/Helper/Acceptance.php:30` still hardcodes `plugin activate kadence-blocks`, so the
acceptance suite cannot target another directory yet. CI is unaffected, since it targets
`kadence-blocks`. Worth a follow-up if worktree runs of that suite are wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated automated WordPress and snapshot test setups to use a configurable Kadence Blocks plugin location.
  - Added testing configuration to identify the plugin directory consistently.

- **Chores**
  - Corrected configuration comment typos.
  - Updated the spell-check dictionary to recognize project-specific terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
