### PR TITLE
[DTM] SOFT-4320 [3/8]: answer the theme's palette reads with token colors

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
@@ -66,7 +66,8 @@ final class Palette_Filter {
 	private Palette_Builder $builder;
 
 	/**
-	 * Per-request memo of slug => { color, name }. Null until first built; cleared on a token write.
+	 * Per-request memo of slug => { color, name }. Null until first built; cleared when a token is written
+	 * or the active library changes, the two inputs it is built from.
 	 *
 	 * @since TBD
 	 *
@@ -116,8 +117,9 @@ final class Palette_Filter {
 	}
 
 	/**
-	 * Drop the per-request memo so a token written in this request is visible to later palette reads
-	 * in the same request. Bound to the store's changed action.
+	 * Drop the per-request memo so a change made in this request is visible to later palette reads in the
+	 * same request. Bound to both inputs the memo is built from: the store's changed action and the
+	 * active-library pointer's.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
@@ -20,7 +20,12 @@ use RuntimeException;
  * because the filter runs after the theme picked the set.
  *
  * A literal color is returned rather than a var(--kb-token--…) reference: the theme passes this value
- * through hex2rgb() in places and the Customizer live preview writes it straight into CSS.
+ * through hex2rgb() in places, and a var() reference cannot be converted that way.
+ *
+ * Known limit: the Customizer live preview never reaches this filter. The theme registers the palette
+ * setting with postMessage transport and its preview script writes the control value straight onto
+ * --global-paletteN, so while a palette color is being edited the preview shows the theme's own color
+ * even for a slot a token overrides. The token color is back on the next full page load.
  *
  * Fail-open: a corrupt stored document (alias cycle / dangling alias) leaves every read untouched.
  * Gated on Token_Registry::is_active() so the fail-closed guard is honored.

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
@@ -1,0 +1,164 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette subkey .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use RuntimeException;
+
+/**
+ * Answers the Kadence theme's palette reads with resolved token colors.
+ *
+ * The theme emits --global-palette1…15 (and every other palette read) through
+ * kadence()->palette_option(), which ends in the kadence_palette_option filter. Hooking that filter
+ * makes tokens win wherever the theme renders a palette color while the stored kadence_global_palette
+ * option — the user's Style Guide — is never written. That keeps the Style Guide intact as the source
+ * the token baseline reads from, so resetting a token gives the user their own color back, and it
+ * works for whichever palette set (palette / second-palette / third-palette) the theme has active,
+ * because the filter runs after the theme picked the set.
+ *
+ * A literal color is returned rather than a var(--kb-token--…) reference: the theme passes this value
+ * through hex2rgb() in places and the Customizer live preview writes it straight into CSS.
+ *
+ * Fail-open: a corrupt stored document (alias cycle / dangling alias) leaves every read untouched.
+ * Gated on Token_Registry::is_active() so the fail-closed guard is honored.
+ *
+ * @since TBD
+ */
+final class Palette_Filter {
+
+	/**
+	 * The token registry.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * The token resolver.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Resolver
+	 */
+	private Token_Resolver $resolver;
+
+	/**
+	 * Owns the active-library pointer, read at filter time so the projected colors follow the active library.
+	 *
+	 * @since TBD
+	 *
+	 * @var Active_Token_Library_Store
+	 */
+	private Active_Token_Library_Store $active;
+
+	/**
+	 * Builds the slug => { color, name } map from the resolved tokens.
+	 *
+	 * @since TBD
+	 *
+	 * @var Palette_Builder
+	 */
+	private Palette_Builder $builder;
+
+	/**
+	 * Per-request memo of slug => { color, name }. Null until first built; cleared on a token write.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, array{color: string, name: string}>|null
+	 */
+	private ?array $entries = null;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry             $registry The token registry.
+	 * @param Token_Resolver             $resolver The token resolver.
+	 * @param Active_Token_Library_Store $active   The active-library pointer.
+	 * @param Palette_Builder            $builder  The palette entries builder.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Token_Resolver $resolver,
+		Active_Token_Library_Store $active,
+		Palette_Builder $builder
+	) {
+		$this->registry = $registry;
+		$this->resolver = $resolver;
+		$this->active   = $active;
+		$this->builder  = $builder;
+	}
+
+	/**
+	 * Return the resolved token color for a palette slot a token claims, or the theme's own value.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value  The value the theme resolved for this slot.
+	 * @param mixed $subkey The slot being read, e.g. "palette1". Not type-hinted because the theme
+	 *                      applies the filter with whatever it was called with.
+	 *
+	 * @return mixed The token color for a claimed slot, otherwise the theme's value untouched.
+	 */
+	public function filter( $value, $subkey ) {
+		if ( ! is_string( $subkey ) || ! $this->registry->is_active() ) {
+			return $value;
+		}
+
+		$entries = $this->entries();
+
+		return isset( $entries[ $subkey ] ) ? $entries[ $subkey ]['color'] : $value;
+	}
+
+	/**
+	 * Drop the per-request memo so a token written in this request is visible to later palette reads
+	 * in the same request. Bound to the store's changed action.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function on_tokens_changed(): void {
+		$this->entries = null;
+	}
+
+	/**
+	 * The slug => { color, name } map for the active library, built once per request.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, array{color: string, name: string}>
+	 */
+	private function entries(): array {
+		if ( $this->entries !== null ) {
+			return $this->entries;
+		}
+
+		// Not memoized: declarations register on init:0, and the theme reads the palette earlier than that
+		// (the Customizer and the theme's own CSS both call palette_option()). Caching the empty map here
+		// would answer every later read in the request with the theme's value, so a token override would
+		// silently do nothing.
+		if ( ! $this->builder->has_palette_tokens() ) {
+			return [];
+		}
+
+		try {
+			$resolved = $this->resolver->resolve( $this->active->get() );
+		} catch ( RuntimeException $e ) {
+			// A corrupt stored document must not break the theme's CSS. Memoize the empty result so the
+			// fifteen palette reads on a page do not each re-attempt the failing resolve.
+			$this->entries = [];
+
+			return $this->entries;
+		}
+
+		$this->entries = $this->builder->entries( $resolved );
+
+		return $this->entries;
+	}
+}

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
@@ -150,6 +150,13 @@ final class Palette_Filter {
 		// (the Customizer and the theme's own CSS both call palette_option()). Caching the empty map here
 		// would answer every later read in the request with the theme's value, so a token override would
 		// silently do nothing.
+		//
+		// Reads that early still get the theme's own color, not the token's. The theme fills its
+		// editor-color-palette theme support from palette_option() on after_setup_theme, so those entries
+		// carry the raw Style Guide colors, and the plugin's load_color_palette() (after_setup_theme:999)
+		// merges them into its own palette as-is. The block editor does not show them: the theme's
+		// theme.json defines the same slugs as var(--global-paletteN), which this filter feeds once the
+		// declarations are in, and theme.json wins over the theme support by slug.
 		if ( ! $this->builder->has_palette_tokens() ) {
 			return [];
 		}

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
@@ -2,6 +2,7 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
 
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
@@ -45,6 +46,15 @@ final class Provider extends Provider_Contract {
 		// answered from a memo built before the write.
 		add_action(
 			Token_Store::changed_action(),
+			$this->container->callback( Palette_Filter::class, 'on_tokens_changed' ),
+			5
+		);
+
+		// The memo is built from the active library's resolved tokens, so moving the pointer invalidates it
+		// for the same reason a write does. Both inputs have to clear it or a read after the switch answers
+		// with the previous library's colors.
+		add_action(
+			Active_Token_Library_Store::changed_action(),
 			$this->container->callback( Palette_Filter::class, 'on_tokens_changed' ),
 			5
 		);

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
@@ -6,8 +6,9 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
- * Registers the Kadence option-sync projector: binds the builder and projector as singletons, then
- * wires the reconcile to a once-per-request boot pass and to the token-changed action.
+ * Registers the Kadence option projection: binds the builder, projector and palette filter as
+ * singletons, wires the reconcile to a once-per-request boot pass and to the token-changed action,
+ * and hooks the theme's palette reads.
  *
  * @since TBD
  */
@@ -21,10 +22,11 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Palette_Builder::class );
 		$this->container->singleton( Projector::class );
+		$this->container->singleton( Palette_Filter::class );
 
 		// Boot pass: run late on init (after the registry's declarations are registered on init, and
 		// after the baseline/guard is in place) so the option reflects the current store on every load.
-		// This is the "always" sync and the seam that catches a theme switch on the next request.
+		// This is the always-on sync.
 		add_action( 'init', $this->container->callback( Projector::class, 'reconcile' ), 20 );
 
 		// Immediate re-sync on a token write, so the new values land within the same request.
@@ -32,6 +34,19 @@ final class Provider extends Provider_Contract {
 			Token_Store::changed_action(),
 			$this->container->callback( Projector::class, 'on_tokens_changed' ),
 			10
+		);
+
+		// The Kadence theme's palette is projected at read time, never written: every palette_option()
+		// read passes through this filter. Registered unconditionally — the theme applies the filter
+		// only when it is active, so on other themes the callback never runs.
+		add_filter( 'kadence_palette_option', $this->container->callback( Palette_Filter::class, 'filter' ), 10, 2 );
+
+		// Ahead of the projector's own listener, so a palette read later in the write request cannot be
+		// answered from a memo built before the write.
+		add_action(
+			Token_Store::changed_action(),
+			$this->container->callback( Palette_Filter::class, 'on_tokens_changed' ),
+			5
 		);
 	}
 }

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
@@ -20,6 +20,11 @@ use Tests\Support\Classes\TestCase;
 
 final class Palette_FilterTest extends TestCase {
 
+	/**
+	 * Slug of the second token library the active-library switch case needs.
+	 */
+	private const OTHER_LIBRARY = 'filter-switch-target';
+
 	private Palette_Filter $filter;
 	private Token_Registry $registry;
 	private Token_Store $store;
@@ -43,6 +48,8 @@ final class Palette_FilterTest extends TestCase {
 
 	protected function tearDown(): void {
 		$this->registry->activate();
+		$this->container->get( Active_Token_Library_Store::class )->set( Token_Store::default_slug() );
+		$this->store->delete( self::OTHER_LIBRARY );
 		$this->filter->on_tokens_changed();
 		$this->store->delete( Token_Store::default_slug() );
 		$this->reset_resolver_memo();
@@ -231,6 +238,43 @@ final class Palette_FilterTest extends TestCase {
 				]
 			)
 		);
+
+		$this->assertSame( '#abcdef', $this->filter->filter( '#old', 'palette1' ) );
+	}
+
+	/**
+	 * Switching the active library clears the memo through the provider's hook, with no manual reset.
+	 *
+	 * The memo is built from the active library's resolved tokens, so the pointer moving invalidates it for
+	 * the same reason a write does. Without the hook a palette read after the switch answers with the
+	 * previous library's colors.
+	 *
+	 * @return void
+	 */
+	public function testActiveLibrarySwitchClearsTheMemoThroughTheHook(): void {
+		$this->store->save_document(
+			(string) wp_json_encode(
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									'$type'  => 'color',
+									'$value' => '#abcdef',
+								],
+							],
+						],
+					],
+				]
+			),
+			self::OTHER_LIBRARY
+		);
+
+		// Build the memo against the default library first, so the test fails if the switch does not clear it.
+		$before = $this->filter->filter( '#old', 'palette1' );
+		$this->assertNotSame( '#abcdef', $before );
+
+		$this->container->get( Active_Token_Library_Store::class )->set( self::OTHER_LIBRARY );
 
 		$this->assertSame( '#abcdef', $this->filter->filter( '#old', 'palette1' ) );
 	}

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
@@ -1,0 +1,279 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette subkey .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Projection\Kadence_Option;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Palette_Builder;
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option\Palette_Filter;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use ReflectionProperty;
+use Tests\Support\Classes\Fake_Baseline_Document;
+use Tests\Support\Classes\TestCase;
+
+final class Palette_FilterTest extends TestCase {
+
+	private Palette_Filter $filter;
+	private Token_Registry $registry;
+	private Token_Store $store;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->filter   = $this->container->get( Palette_Filter::class );
+		$this->registry = $this->container->get( Token_Registry::class );
+		$this->store    = $this->container->get( Token_Store::class );
+
+		// The filter memoizes per request; the WP test bootstrap may already have populated it.
+		$this->filter->on_tokens_changed();
+		$this->store->delete( Token_Store::default_slug() );
+		$this->reset_resolver_memo();
+
+		// Token_Resolver also caches in the object cache keyed on the store version, so without this a
+		// resolver built inside a test is served the document an earlier test resolved.
+		wp_cache_flush();
+	}
+
+	protected function tearDown(): void {
+		$this->registry->activate();
+		$this->filter->on_tokens_changed();
+		$this->store->delete( Token_Store::default_slug() );
+		$this->reset_resolver_memo();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A slot a token claims is answered with the resolved token color, replacing the theme's value.
+	 *
+	 * @return void
+	 */
+	public function testClaimedSlotReturnsResolvedTokenColor(): void {
+		$resolved = $this->container->get( Token_Resolver::class )->resolve();
+
+		$this->assertSame(
+			$resolved->value( 'primitive.color.brand.primary' ),
+			$this->filter->filter( '#old', 'palette1' )
+		);
+	}
+
+	/**
+	 * Slots no token claims, and non-string slot keys, pass through untouched.
+	 *
+	 * @dataProvider passthroughProvider
+	 *
+	 * @param mixed $value  The theme's value.
+	 * @param mixed $subkey The slot key the theme asked for.
+	 *
+	 * @return void
+	 */
+	public function testUnclaimedSlotPassesThrough( $value, $subkey ): void {
+		$this->assertSame( $value, $this->filter->filter( $value, $subkey ) );
+	}
+
+	/**
+	 * Slot keys the token vocabulary does not claim, and malformed keys.
+	 *
+	 * @return Generator
+	 */
+	public function passthroughProvider(): Generator {
+		yield 'complement slot' => [
+			'value'  => '#FfFfFf',
+			'subkey' => 'palette10',
+		];
+		yield 'rating slot' => [
+			'value'  => '#f5a524',
+			'subkey' => 'palette15',
+		];
+		yield 'non-string subkey' => [
+			'value'  => '#abcdef',
+			'subkey' => 3,
+		];
+	}
+
+	/**
+	 * A deactivated registry (fail-closed guard) leaves every read untouched.
+	 *
+	 * @return void
+	 */
+	public function testDeactivatedRegistryPassesThrough(): void {
+		$this->registry->deactivate();
+
+		$this->assertSame( '#old', $this->filter->filter( '#old', 'palette1' ) );
+	}
+
+	/**
+	 * A token override written to the store wins over the theme value on the next read.
+	 *
+	 * @return void
+	 */
+	public function testTokenOverrideWinsAfterWrite(): void {
+		$this->store->save_document(
+			(string) wp_json_encode(
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									'$type'  => 'color',
+									'$value' => '#123456',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->filter->on_tokens_changed();
+		$this->reset_resolver_memo();
+
+		$this->assertSame( '#123456', $this->filter->filter( '#old', 'palette1' ) );
+	}
+
+	/**
+	 * The filter answers a slot the same way whichever palette set the theme has active.
+	 *
+	 * The removed option write only ever touched the "palette" set, so a site on second-palette saw
+	 * nothing. The filter runs after the theme picks the set, so the set never reaches this code.
+	 *
+	 * @return void
+	 */
+	public function testResultDoesNotDependOnTheThemesActivePaletteSet(): void {
+		$resolved = $this->container->get( Token_Resolver::class )->resolve();
+		$expected = $resolved->value( 'primitive.color.brand.primary' );
+
+		$this->assertSame( $expected, $this->filter->filter( '#from-palette', 'palette1' ) );
+		$this->assertSame( $expected, $this->filter->filter( '#from-second-palette', 'palette1' ) );
+		$this->assertSame( $expected, $this->filter->filter( '#from-third-palette', 'palette1' ) );
+	}
+
+	/**
+	 * A corrupt stored document fails open: the theme's own value is returned.
+	 *
+	 * @return void
+	 */
+	public function testCorruptDocumentPassesThrough(): void {
+		$corrupt_resolver = new Token_Resolver(
+			$this->store,
+			new Effective_Document(
+				new Fake_Baseline_Document(
+					[
+						'primitive' => [
+							'color' => [
+								'brand' => [
+									'primary' => [
+										'$type'  => 'color',
+										'$value' => '{primitive.color.missing}',
+									],
+								],
+							],
+						],
+					]
+				)
+			),
+			new Css_Renderer(),
+			$this->container->get( Effective_Palettes::class ),
+			$this->container->get( Mutator::class )
+		);
+
+		$filter = new Palette_Filter(
+			$this->registry,
+			$corrupt_resolver,
+			$this->container->get( Active_Token_Library_Store::class ),
+			$this->container->get( Palette_Builder::class )
+		);
+
+		$this->assertSame( '#old', $filter->filter( '#old', 'palette1' ) );
+	}
+
+	/**
+	 * The provider hooks the filter onto the theme's palette read.
+	 *
+	 * @return void
+	 */
+	public function testFilterIsHookedToKadencePaletteOption(): void {
+		$this->assertNotFalse( has_filter( 'kadence_palette_option' ) );
+	}
+
+	/**
+	 * A token write clears the memo through the provider's hook, with no manual reset.
+	 *
+	 * The filter memoizes per request, so without that hook a palette read later in the same request
+	 * that wrote the token would answer with the pre-write color.
+	 *
+	 * @return void
+	 */
+	public function testTokenWriteClearsTheMemoThroughTheHook(): void {
+		// Build the memo first, so the test fails if the write does not clear it.
+		$this->filter->filter( '#old', 'palette1' );
+
+		$this->store->save_document(
+			(string) wp_json_encode(
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									'$type'  => 'color',
+									'$value' => '#abcdef',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertSame( '#abcdef', $this->filter->filter( '#old', 'palette1' ) );
+	}
+
+	/**
+	 * A read taken before the declarations register does not pin an empty map for the rest of the request.
+	 *
+	 * The theme reads the palette earlier than init:0 (its own CSS and the Customizer both call
+	 * palette_option()), so memoizing "no palette tokens" would answer every later read with the theme's
+	 * value and a token override would silently do nothing. Found on a live site, not by the suite.
+	 *
+	 * @return void
+	 */
+	public function testAnEarlyReadDoesNotPinAnEmptyMap(): void {
+		$builder = new Palette_Builder( new Token_Registry() );
+		$filter  = new Palette_Filter(
+			$this->registry,
+			$this->container->get( Token_Resolver::class ),
+			$this->container->get( Active_Token_Library_Store::class ),
+			$builder
+		);
+
+		// A theme read before init:0: the registry has no palette tokens yet, so the theme's value stands.
+		$this->assertSame( '#theme', $filter->filter( '#theme', 'palette1' ) );
+
+		// Declarations register partway through the request, as they do at init:0 on a real site.
+		$registry = new ReflectionProperty( Palette_Builder::class, 'registry' );
+		$registry->setAccessible( true );
+		$registry->setValue( $builder, $this->container->get( Token_Registry::class ) );
+
+		// The same filter instance must not answer this read from the empty map it saw first.
+		$this->assertNotSame( '#theme', $filter->filter( '#theme', 'palette1' ) );
+	}
+
+	/**
+	 * Clear the resolver's per-request memo so values do not leak between tests.
+	 *
+	 * @return void
+	 */
+	private function reset_resolver_memo(): void {
+		$resolver = $this->container->get( Token_Resolver::class );
+		$memo     = new ReflectionProperty( Token_Resolver::class, 'memo' );
+		$memo->setAccessible( true );
+		$memo->setValue( $resolver, [] );
+	}
+}


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/3f7bf1ff5960448399a02dd96fd18f49)

## Summary

Puts token colors back into what the theme renders, without writing to the theme's stored palette.

The theme emits `--global-palette1…15`, and every other palette read, through
`kadence()->palette_option()`, which ends in the `kadence_palette_option` filter. Hooking that
filter makes tokens win wherever the theme renders a palette color while the stored Style Guide is
left alone — so resetting a token gives the user their own color back, and whichever palette set the
theme has active is honored, because the filter runs after the set is picked.

That last point fixes the set-2/set-3 bug for free: the removed write only ever touched
`['palette']`.

## What's in it

- `Projection/Kadence_Option/Palette_Filter.php` — returns the resolved token color for a slot a
  token claims, and the theme's own value otherwise. Gated on `Token_Registry::is_active()` and
  fails open on a corrupt stored document.
- Provider wiring: the filter at priority 10 with 2 args, plus a `Token_Store` changed-action
  listener at priority 5 — ahead of the projector's at 10, so a palette read later in the request
  that wrote a token cannot be answered from a stale memo.

A literal color is returned rather than a `var(--kb-token--…)` reference: the theme passes this
value through `hex2rgb()` in places and into the Customizer preview JS, where a `var()` would break.

## The bug this slice nearly shipped with

The first version memoized an empty map when the filter ran before the token declarations register
on `init:0` — and the theme reads the palette earlier than that. Every later read in the request
then returned the theme's value, so **a token override silently did nothing**. Found by running it
on a real site, not by the suite. The guard and its regression test are in this slice; the test
fails if the guard is removed.

## Test plan

`slic run wpunit Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest`

11 tests: claimed slots, pass-through for unclaimed and non-string keys, the deactivated-registry
guard, override-wins-after-write, independence from the active palette set, fail-open on a dangling
alias, the early-read guard, and the two hook wirings.

Verified on a live site: an override renders, deleting it falls back to the Customizer color rather
than the shipped default, and the stored option is untouched throughout.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kadence theme palette values can now reflect resolved design-token colors.
  - Token-based palette colors update automatically when design tokens change.
  - Palette values remain independent of the currently active theme palette selection.

- **Bug Fixes**
  - Unclaimed palette entries and inactive token registries continue using existing theme values.
  - Invalid token data no longer prevents palette values from being read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->