### PR TITLE
[DTM] SOFT-4320 [5/8]: read the theme's Style Guide and compose the overlay

### DIFF
--- a/includes/resources/Design_Tokens/Design_Tokens_Provider.php
+++ b/includes/resources/Design_Tokens/Design_Tokens_Provider.php
@@ -18,6 +18,7 @@ final class Design_Tokens_Provider extends Provider {
 		Registry\Provider::class,
 		Database\Provider::class,
 		Schema\Provider::class,
+		Theme_Style_Guide\Provider::class,
 		Resolver\Provider::class,
 		Projection\Provider::class,
 		Foundation_Presets\Provider::class,

--- a/includes/resources/Design_Tokens/Theme_Style_Guide/Contracts/Style_Guide_Source.php
+++ b/includes/resources/Design_Tokens/Theme_Style_Guide/Contracts/Style_Guide_Source.php
@@ -1,0 +1,26 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Contracts;
+
+/**
+ * Where the active theme's Style Guide is read from.
+ *
+ * One implementation reads the Kadence theme (Style_Guide_Reader); tests hand the overlay a fake.
+ * The snapshot is raw theme data — decoding the palette JSON aside, no interpretation happens here.
+ * Picking the active palette set and turning it into token values is the mapper's job, so that
+ * logic stays unit-testable without a theme.
+ *
+ * @since TBD
+ */
+interface Style_Guide_Source {
+
+	/**
+	 * The theme's Style Guide as raw data, or null when the source is not available (the Kadence theme is
+	 * not active), so callers can tell "nothing to read" from "read, but empty".
+	 *
+	 * @since TBD
+	 *
+	 * @return array{palette: array<string, mixed>, settings: array<string, mixed>}|null
+	 */
+	public function snapshot(): ?array;
+}

--- a/includes/resources/Design_Tokens/Theme_Style_Guide/Provider.php
+++ b/includes/resources/Design_Tokens/Theme_Style_Guide/Provider.php
@@ -1,0 +1,41 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Contracts\Style_Guide_Source;
+use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+
+/**
+ * Wires the theme Style Guide layer: the Kadence reader as the source, the pure mapper, and the
+ * per-request overlay the baseline decorator and cache versioning read.
+ *
+ * @since TBD
+ */
+final class Provider extends Provider_Contract {
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function register(): void {
+		$this->container->singleton( Style_Guide_Source::class, Style_Guide_Reader::class );
+		$this->container->singleton( Style_Guide_Mapper::class );
+		$this->container->singleton( Style_Guide_Overlay::class );
+
+		// The overlay memoizes for the request, and the Kadence_Option boot pass reads it on init:20.
+		// WordPress installs the Customizer's pre_option_* preview filters later, on wp_loaded, so
+		// without this the overlay is pinned to the SAVED palette before the previewed value exists and
+		// the preview shows no change at all. Priority 0: before anything renders.
+		add_action( 'customize_preview_init', $this->container->callback( Style_Guide_Overlay::class, 'flush' ), 0 );
+
+		// A palette write inside this request must not leave it answering from values read before the
+		// write. All three hooks matter: a site that never opened the Customizer has no option at all, so
+		// its first publish is an add_option, not an update_option.
+		$flush = $this->container->callback( Style_Guide_Overlay::class, 'flush' );
+
+		foreach ( [ 'add_option_', 'update_option_', 'delete_option_' ] as $prefix ) {
+			add_action( $prefix . Style_Guide_Reader::get_palette_option_key(), $flush, 10 );
+		}
+	}
+}

--- a/includes/resources/Design_Tokens/Theme_Style_Guide/Style_Guide_Overlay.php
+++ b/includes/resources/Design_Tokens/Theme_Style_Guide/Style_Guide_Overlay.php
@@ -1,0 +1,158 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Palette_Slot;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Contracts\Style_Guide_Source;
+
+/**
+ * The theme-derived token values for this request, and a signature that changes when they do.
+ *
+ * Composes the source (WordPress I/O) and the mapper (pure) and memoizes the result, so the baseline
+ * decorator and the cache-version service read the same values. The signature is what lets a
+ * Customizer save — which bumps no store version — invalidate every resolved/projected cache.
+ *
+ * @since TBD
+ */
+final class Style_Guide_Overlay {
+
+	/**
+	 * Where the Style Guide is read from.
+	 *
+	 * @since TBD
+	 *
+	 * @var Style_Guide_Source
+	 */
+	private Style_Guide_Source $source;
+
+	/**
+	 * Snapshot => token values.
+	 *
+	 * @since TBD
+	 *
+	 * @var Style_Guide_Mapper
+	 */
+	private Style_Guide_Mapper $mapper;
+
+	/**
+	 * Supplies the slot => token map from the tokens declaring a kadence_slot.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Registry
+	 */
+	private Token_Registry $registry;
+
+	/**
+	 * Per-request memo of token id => $value. Null until a complete result was computed.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, string>|null
+	 */
+	private ?array $values = null;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Style_Guide_Source $source   The Style Guide source.
+	 * @param Style_Guide_Mapper $mapper   The pure mapper.
+	 * @param Token_Registry     $registry The token registry.
+	 */
+	public function __construct( Style_Guide_Source $source, Style_Guide_Mapper $mapper, Token_Registry $registry ) {
+		$this->source   = $source;
+		$this->mapper   = $mapper;
+		$this->registry = $registry;
+	}
+
+	/**
+	 * Token id => $value derived from the theme. Empty when the Kadence theme is not active.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, string>
+	 */
+	public function values(): array {
+		if ( $this->values !== null ) {
+			return $this->values;
+		}
+
+		$snapshot = $this->source->snapshot();
+
+		if ( $snapshot === null ) {
+			// Not memoized: before after_setup_theme the theme is not loaded yet, and a caller that early
+			// must not pin "no theme" for the rest of a request in which the theme does load.
+			return [];
+		}
+
+		$slot_tokens = $this->slot_tokens();
+		$values      = $this->mapper->map( $snapshot, $slot_tokens );
+
+		if ( $slot_tokens === [] ) {
+			// Declarations register on init:0. A caller before that would memoize a map with no palette
+			// slots for the whole request, so hand the partial result back without keeping it.
+			return $values;
+		}
+
+		$this->values = $values;
+
+		return $this->values;
+	}
+
+	/**
+	 * A short fingerprint of values(): empty when there is nothing to overlay, so a cache key that
+	 * folds it in is unchanged on non-Kadence sites.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function signature(): string {
+		$values = $this->values();
+
+		if ( $values === [] ) {
+			return '';
+		}
+
+		ksort( $values );
+
+		return md5( (string) wp_json_encode( $values ) );
+	}
+
+	/**
+	 * Drop the per-request memo. Used by tests and by any caller that changes the Style Guide and needs
+	 * the new values within the same request.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function flush(): void {
+		$this->values = null;
+	}
+
+	/**
+	 * Slot slug => token id for every token declaring a palette kadence_slot.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string, string>
+	 */
+	private function slot_tokens(): array {
+		$slots = [];
+
+		foreach ( $this->registry->by_projection( Kadence_Palette_Slot::get_projection_key() ) as $id => $token ) {
+			$slot = Kadence_Palette_Slot::from_token( $token );
+
+			if ( $slot === null ) {
+				continue;
+			}
+
+			$slots[ $slot->slug ] = $id;
+		}
+
+		return $slots;
+	}
+}

--- a/includes/resources/Design_Tokens/Theme_Style_Guide/Style_Guide_Reader.php
+++ b/includes/resources/Design_Tokens/Theme_Style_Guide/Style_Guide_Reader.php
@@ -1,0 +1,145 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Contracts\Style_Guide_Source;
+use KadenceWP\KadenceBlocks\Utils\Cast;
+
+/**
+ * Reads the Kadence theme's Style Guide: the global palette option and the theme settings the mapper
+ * asks for. The only class in this namespace that touches WordPress or the theme.
+ *
+ * Returns null when the Kadence theme is not active, so every other theme resolves tokens exactly
+ * as it did before this layer existed.
+ *
+ * The theme is not part of the plugin's static-analysis scan, so it is called through a validated
+ * callable and every result is narrowed here rather than typed against theme classes.
+ *
+ * @since TBD
+ */
+final class Style_Guide_Reader implements Style_Guide_Source {
+
+	/**
+	 * The theme's palette option key.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const PALETTE_OPTION = 'kadence_global_palette';
+
+	/**
+	 * The theme's accessor function; returns its Template_Tags proxy.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const THEME_ACCESSOR = 'Kadence\kadence';
+
+	/**
+	 * The theme class whose presence means the theme is active.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const THEME_CLASS = 'Kadence\Theme';
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function snapshot(): ?array {
+		$theme = $this->theme();
+
+		if ( $theme === null ) {
+			return null;
+		}
+
+		$settings = [];
+		$option   = [ $theme, 'option' ];
+
+		if ( is_callable( $option ) ) {
+			foreach ( Style_Guide_Mapper::setting_keys() as $key ) {
+				$settings[ $key ] = call_user_func( $option, $key );
+			}
+		}
+
+		return [
+			'palette'  => $this->palette( $theme ),
+			'settings' => $settings,
+		];
+	}
+
+	/**
+	 * The theme's palette option key, for callers that need to invalidate on its change.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_palette_option_key(): string {
+		return self::PALETTE_OPTION;
+	}
+
+	/**
+	 * The decoded palette option, falling back to the theme's (filterable) defaults when the option is
+	 * absent, so a never-customized site reads the colors the theme actually renders.
+	 *
+	 * Read with get_option(), never through the theme's palette_option(): that accessor ends in the
+	 * kadence_palette_option filter the projection layer hooks, which resolves tokens, which builds the
+	 * baseline this reader feeds — a loop. get_option() still passes the theme's own normalize filter.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $theme The theme's Template_Tags proxy.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function palette( object $theme ): array {
+		$stored = get_option( self::PALETTE_OPTION );
+
+		// A site can filter option_kadence_global_palette to return the decoded array. Treating that as
+		// "absent" would silently swap the user's Style Guide for the theme's defaults, so take it as-is.
+		if ( is_array( $stored ) ) {
+			return $stored;
+		}
+
+		$raw      = is_string( $stored ) ? $stored : '';
+		$defaults = [ $theme, 'get_default_palette' ];
+
+		if ( $raw === '' && is_callable( $defaults ) ) {
+			$raw = Cast::to_string( call_user_func( $defaults ) );
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+
+	/**
+	 * The theme's Template_Tags proxy, or null when the Kadence theme is not active or not yet loaded.
+	 *
+	 * @since TBD
+	 *
+	 * @return object|null
+	 */
+	private function theme(): ?object {
+		/** @var callable-string $accessor The theme's accessor; guarded by function_exists() below. */
+		$accessor = self::THEME_ACCESSOR;
+
+		// The theme is not in the plugin's static-analysis scope, so its class and function are unknown
+		// symbols here. Both checks are real at runtime; the indirection keeps the analyzer from folding
+		// them to a constant false and reporting the rest of this method as dead.
+		if ( ! class_exists( self::THEME_CLASS ) || ! function_exists( $accessor ) ) {
+			return null;
+		}
+
+		$theme = call_user_func( $accessor );
+
+		return is_object( $theme ) ? $theme : null;
+	}
+}

--- a/tests/_support/Classes/Fake_Style_Guide_Source.php
+++ b/tests/_support/Classes/Fake_Style_Guide_Source.php
@@ -1,0 +1,75 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\Support\Classes;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Contracts\Style_Guide_Source;
+
+/**
+ * A Style Guide source the tests drive directly, so the overlay can be exercised without the Kadence
+ * theme being active.
+ */
+final class Fake_Style_Guide_Source implements Style_Guide_Source {
+
+	/**
+	 * The snapshot to return, or null to model "the Kadence theme is not active".
+	 *
+	 * @var array{palette: array<string, mixed>, settings: array<string, mixed>}|null
+	 */
+	private ?array $snapshot;
+
+	/**
+	 * @param array{palette: array<string, mixed>, settings: array<string, mixed>}|null $snapshot The snapshot to return.
+	 */
+	public function __construct( ?array $snapshot = null ) {
+		$this->snapshot = $snapshot;
+	}
+
+	/**
+	 * A source whose active set carries the given slot colors.
+	 *
+	 * @param array<string, string> $colors Slot slug => color.
+	 * @param string                $set    The palette set to put them in, and to mark active.
+	 *
+	 * @return self
+	 */
+	public static function with_palette( array $colors, string $set = 'palette' ): self {
+		$entries = [];
+
+		foreach ( $colors as $slug => $color ) {
+			$entries[] = [
+				'color' => $color,
+				'name'  => strtoupper( $slug ),
+				'slug'  => $slug,
+			];
+		}
+
+		return new self(
+			[
+				'palette'  => [
+					'active' => $set,
+					$set     => $entries,
+				],
+				'settings' => [],
+			]
+		);
+	}
+
+	/**
+	 * Replace the snapshot this source returns.
+	 *
+	 * @param array{palette: array<string, mixed>, settings: array<string, mixed>}|null $snapshot The new snapshot.
+	 *
+	 * @return void
+	 */
+	public function set( ?array $snapshot ): void {
+		$this->snapshot = $snapshot;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function snapshot(): ?array {
+		return $this->snapshot;
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_OverlayTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_OverlayTest.php
@@ -1,0 +1,143 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Theme_Style_Guide;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Mapper;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
+use Tests\Support\Classes\Fake_Style_Guide_Source;
+use Tests\Support\Classes\TestCase;
+
+final class Style_Guide_OverlayTest extends TestCase {
+
+	/**
+	 * Without the Kadence theme there is nothing to overlay, and the signature stays blank so a cache
+	 * key that folds it in is byte-identical to what it was before this layer existed.
+	 *
+	 * @return void
+	 */
+	public function testValuesAreEmptyAndSignatureIsBlankWithoutATheme(): void {
+		$overlay = $this->overlay( new Fake_Style_Guide_Source( null ) );
+
+		$this->assertSame( [], $overlay->values() );
+		$this->assertSame( '', $overlay->signature() );
+	}
+
+	/**
+	 * The overlay keys its values by the token ids the registry maps the theme's slots to.
+	 *
+	 * @return void
+	 */
+	public function testValuesFollowTheSlotTokensFromTheRegistry(): void {
+		$overlay = $this->overlay( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+
+		$this->assertSame( '#111111', $overlay->values()['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * The overlay reads whichever palette set the theme has active, not always the first.
+	 *
+	 * @return void
+	 */
+	public function testValuesFollowTheThemesActivePaletteSet(): void {
+		$overlay = $this->overlay(
+			Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#222222' ], 'second-palette' )
+		);
+
+		$this->assertSame( '#222222', $overlay->values()['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * A changed color changes the signature; the same colors give the same signature whatever order
+	 * they were stored in. That is what makes the signature usable in a cache key.
+	 *
+	 * @return void
+	 */
+	public function testSignatureChangesWhenAColorChanges(): void {
+		$first  = $this->overlay( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+		$second = $this->overlay( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#999999' ] ) );
+
+		$this->assertNotSame( $first->signature(), $second->signature() );
+
+		$same = $this->overlay( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+
+		$this->assertSame( $first->signature(), $same->signature() );
+	}
+
+	/**
+	 * Two overlays holding the same colors in a different stored order share a signature, so a
+	 * reordered palette option does not needlessly bust every cache.
+	 *
+	 * @return void
+	 */
+	public function testSignatureIgnoresTheStoredOrder(): void {
+		$forward = $this->overlay(
+			Fake_Style_Guide_Source::with_palette(
+				[
+					'palette1' => '#111111',
+					'palette3' => '#333333',
+				]
+			)
+		);
+		$reverse = $this->overlay(
+			Fake_Style_Guide_Source::with_palette(
+				[
+					'palette3' => '#333333',
+					'palette1' => '#111111',
+				]
+			)
+		);
+
+		$this->assertSame( $forward->signature(), $reverse->signature() );
+	}
+
+	/**
+	 * Values are computed once per request, so the baseline decorator and the cache-version service
+	 * cannot disagree within a single request.
+	 *
+	 * @return void
+	 */
+	public function testValuesAreMemoizedPerRequest(): void {
+		$source  = Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] );
+		$overlay = $this->overlay( $source );
+
+		$this->assertSame( '#111111', $overlay->values()['primitive.color.brand.primary'] );
+
+		$source->set( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#999999' ] )->snapshot() );
+
+		$this->assertSame( '#111111', $overlay->values()['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * Flushing the memo lets a caller that changed the Style Guide see the new values in the same
+	 * request.
+	 *
+	 * @return void
+	 */
+	public function testFlushDropsTheMemo(): void {
+		$source  = Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] );
+		$overlay = $this->overlay( $source );
+
+		$overlay->values();
+		$source->set( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#999999' ] )->snapshot() );
+		$overlay->flush();
+
+		$this->assertSame( '#999999', $overlay->values()['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * An overlay over the given source, with the real mapper and the real registry.
+	 *
+	 * @param Fake_Style_Guide_Source $source The source to read from.
+	 *
+	 * @return Style_Guide_Overlay
+	 */
+	private function overlay( Fake_Style_Guide_Source $source ): Style_Guide_Overlay {
+		return new Style_Guide_Overlay(
+			$source,
+			new Style_Guide_Mapper(),
+			$this->container->get( Token_Registry::class )
+		);
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_ReaderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_ReaderTest.php
@@ -1,0 +1,95 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Theme_Style_Guide;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Contracts\Style_Guide_Source;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Reader;
+use Tests\Support\Classes\TestCase;
+
+final class Style_Guide_ReaderTest extends TestCase {
+
+	/**
+	 * The test suite runs a non-Kadence theme, so the reader reports "nothing to read" and every other
+	 * theme keeps resolving tokens exactly as it did before this layer existed.
+	 *
+	 * @return void
+	 */
+	public function testSnapshotIsNullWhenTheKadenceThemeIsNotActive(): void {
+		$this->assertNull( ( new Style_Guide_Reader() )->snapshot() );
+	}
+
+	/**
+	 * The palette option key is exposed for callers that invalidate on its change.
+	 *
+	 * @return void
+	 */
+	public function testPaletteOptionKeyIsTheThemesOption(): void {
+		$this->assertSame( 'kadence_global_palette', Style_Guide_Reader::get_palette_option_key() );
+	}
+
+	/**
+	 * A stored palette option alone does not make the reader believe the theme is active: the class
+	 * check gates it, so a leftover option on a non-Kadence site changes nothing.
+	 *
+	 * @return void
+	 */
+	public function testAStoredPaletteOptionAloneDoesNotProduceASnapshot(): void {
+		update_option(
+			Style_Guide_Reader::get_palette_option_key(),
+			(string) wp_json_encode(
+				[
+					'palette' => [
+						[
+							'color' => '#111111',
+							'name'  => 'P1',
+							'slug'  => 'palette1',
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertNull( ( new Style_Guide_Reader() )->snapshot() );
+
+		delete_option( Style_Guide_Reader::get_palette_option_key() );
+	}
+
+	/**
+	 * The overlay's memo is dropped when the Customizer preview starts.
+	 *
+	 * The Kadence_Option boot pass reads the overlay on init:20, and WordPress installs the
+	 * Customizer's pre_option_* preview filters later on wp_loaded. Without this hook the overlay is
+	 * pinned to the saved palette before the previewed value exists, and the preview shows no change.
+	 *
+	 * @return void
+	 */
+	public function testTheOverlayIsFlushedWhenTheCustomizerPreviewStarts(): void {
+		// has_action() alone would pass on WordPress's own callback, which runs at the default priority.
+		// The flush is registered at 0 precisely so it lands before anything renders, so assert that.
+		$this->assertArrayHasKey( 0, $GLOBALS['wp_filter']['customize_preview_init']->callbacks );
+		$this->assertNotEmpty( $GLOBALS['wp_filter']['customize_preview_init']->callbacks[0] );
+	}
+
+	/**
+	 * The overlay's memo is dropped when the theme's palette option is saved in this request.
+	 *
+	 * @return void
+	 */
+	public function testTheOverlayIsFlushedWhenThePaletteOptionIsWritten(): void {
+		$key = Style_Guide_Reader::get_palette_option_key();
+
+		foreach ( [ 'add_option_', 'update_option_', 'delete_option_' ] as $prefix ) {
+			$this->assertNotFalse( has_action( $prefix . $key ), $prefix . ' is not hooked' );
+		}
+	}
+
+	/**
+	 * The container resolves the source contract to the Kadence reader.
+	 *
+	 * @return void
+	 */
+	public function testTheContainerBindsTheReaderAsTheSource(): void {
+		$this->assertInstanceOf( Style_Guide_Reader::class, $this->container->get( Style_Guide_Source::class ) );
+	}
+}


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/3f7bf1ff5960448399a02dd96fd18f49)

## Summary

Reads the Kadence theme's Style Guide and composes it into the per-request overlay.

The pure mapper this builds on is the previous PR. This one is the WordPress side: reading the
theme, and composing reader + mapper into something the baseline decorator and the cache-version
service can both consume.

No behavior change: nothing consumes the overlay until the final PR.

## What's in it

- `Theme_Style_Guide/Contracts/Style_Guide_Source.php` — the interface. Tests hand the overlay a
  fake.
- `Style_Guide_Reader.php` — the only class here that touches WordPress or the theme. Returns `null`
  when the Kadence theme is not active, so every other theme resolves exactly as before. Reads
  `kadence_global_palette` with `get_option()`, deliberately **not** the theme's `palette_option()`:
  that accessor ends in the filter slice 3 hooks, which resolves tokens, which builds the baseline
  this reader feeds. It falls back to the theme's own filterable defaults, so a site that never
  opened the Customizer still reads the colors it actually renders.
- `Style_Guide_Overlay.php` — memoized values plus an order-independent signature, which is what
  lets a Customizer save invalidate caches in slice 5. Flushed on `customize_preview_init` and on
  add/update/delete of the palette option.
- `Theme_Style_Guide/Provider.php`, registered between `Schema` and `Resolver`.

## Why the flush hooks matter

The overlay memoizes for the request, and the boot pass reads it on `init:20`. WordPress installs
the Customizer's `pre_option_*` preview filters later, on `wp_loaded`. Without the flush the overlay
is pinned to the **saved** palette before the previewed value exists, and the preview shows no
change at all. All three option hooks are needed: a site that never opened the Customizer has no
option, so its first publish is an `add_option`, not an `update_option`.

## Test plan

`slic run wpunit Resources/Design_Tokens/Theme_Style_Guide`

Overlay (memoization, signature stability and
order-independence, flush) and reader (null without the theme, the option key, the container
binding, and the flush hooks).

Verified in a browser: with an unsaved Customizer change on a slot with no token override, the
refreshed preview showed the unsaved value rather than the saved one.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reading theme style-guide palettes and settings.
  - Added automatic mapping of registered color palette slots to design tokens.
  - Added cache invalidation when palette settings change or during Customizer previews.

- **Tests**
  - Added coverage for theme availability, palette selection, token mapping, caching, signatures, and invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->