### PR TITLE
[DTM] SOFT-4320 [6/8]: key every cache on the effective document version

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Block_Default_Css/Projector.php
@@ -3,11 +3,11 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Block_Default_Css;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Projects the per-block default dimension CSS into the WordPress style pipeline.
@@ -31,14 +31,6 @@ final class Projector extends Abstract_Css_Projector {
 	 */
 	private Token_Registry $registry;
 
-	/**
-	 * The store, for the cache-busting version.
-	 *
-	 * @since TBD
-	 *
-	 * @var Token_Store
-	 */
-	private Token_Store $store;
 
 	/**
 	 * Owns the active-library pointer, read at build time so the projection follows the active library.
@@ -59,18 +51,33 @@ final class Projector extends Abstract_Css_Projector {
 	private Css_Builder $css_builder;
 
 	/**
+	 * Supplies the cache version: the store version, plus the theme Style Guide signature when there is
+	 * one, so a Customizer save invalidates this cache even though it bumps no store version.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry   $registry    The token registry.
-	 * @param Token_Store      $store       The store, for the cache-busting version.
-	 * @param Active_Token_Library_Store $active      Owns the active-library pointer.
-	 * @param Css_Builder      $css_builder The block-default CSS builder.
+	 * @var Effective_Version
 	 */
-	public function __construct( Token_Registry $registry, Token_Store $store, Active_Token_Library_Store $active, Css_Builder $css_builder ) {
+	private Effective_Version $versions;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry             $registry    The token registry.
+	 * @param Active_Token_Library_Store $active      Owns the active-library pointer.
+	 * @param Css_Builder                $css_builder The block-default CSS builder.
+	 * @param Effective_Version          $versions    Supplies the effective cache version for a library.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Active_Token_Library_Store $active,
+		Css_Builder $css_builder,
+		Effective_Version $versions
+	) {
 		$this->registry    = $registry;
-		$this->store       = $store;
 		$this->active      = $active;
 		$this->css_builder = $css_builder;
+		$this->versions    = $versions;
 	}
 
 	/**
@@ -134,7 +141,7 @@ final class Projector extends Abstract_Css_Projector {
 		$slug = $this->active->get();
 
 		try {
-			$version = $this->store->get_version( $slug );
+			$version = $this->versions->for_slug( $slug );
 		} catch ( Throwable $e ) {
 			return '';
 		}
@@ -158,7 +165,7 @@ final class Projector extends Abstract_Css_Projector {
 		$slug = $this->active->get();
 
 		try {
-			$version = $this->store->get_version( $slug );
+			$version = $this->versions->for_slug( $slug );
 		} catch ( Throwable $e ) {
 			return '';
 		}

--- a/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Css_Var/Projector.php
@@ -3,13 +3,13 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Css_Var;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Projects the resolved token library into the WordPress style pipeline.
@@ -39,10 +39,6 @@ final class Projector extends Abstract_Css_Projector {
 	 */
 	private Token_Resolver $resolver;
 
-	/**
-	 * @var Token_Store
-	 */
-	private Token_Store $store;
 
 	/**
 	 * Owns the active-library pointer, read at build time so the projection follows the active library.
@@ -64,29 +60,39 @@ final class Projector extends Abstract_Css_Projector {
 	private Legacy_Filter_Bridge $bridge;
 
 	/**
+	 * Supplies the cache version: the store version, plus the theme Style Guide signature when there is
+	 * one, so a Customizer save invalidates this cache even though it bumps no store version.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry       $registry
-	 * @param Token_Resolver       $resolver
-	 * @param Token_Store          $store
-	 * @param Active_Token_Library_Store     $active
-	 * @param Css_Builder          $css_builder
-	 * @param Legacy_Filter_Bridge $bridge
+	 * @var Effective_Version
+	 */
+	private Effective_Version $versions;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry             $registry    The token registry.
+	 * @param Token_Resolver             $resolver    The token resolver.
+	 * @param Active_Token_Library_Store $active      Owns the active-library pointer.
+	 * @param Css_Builder                $css_builder The CSS-variable builder.
+	 * @param Legacy_Filter_Bridge       $bridge      Rewrites the legacy palette filter off-theme.
+	 * @param Effective_Version          $versions    Supplies the effective cache version for a library.
 	 */
 	public function __construct(
 		Token_Registry $registry,
 		Token_Resolver $resolver,
-		Token_Store $store,
 		Active_Token_Library_Store $active,
 		Css_Builder $css_builder,
-		Legacy_Filter_Bridge $bridge
+		Legacy_Filter_Bridge $bridge,
+		Effective_Version $versions
 	) {
 		$this->registry    = $registry;
 		$this->resolver    = $resolver;
-		$this->store       = $store;
 		$this->active      = $active;
 		$this->css_builder = $css_builder;
 		$this->bridge      = $bridge;
+		$this->versions    = $versions;
 	}
 
 	/**
@@ -171,7 +177,7 @@ final class Projector extends Abstract_Css_Projector {
 		try {
 			$active   = $this->active->get();
 			$resolved = $this->resolver->resolve( $active );
-			$version  = $this->store->get_version( $active );
+			$version  = $this->versions->for_slug( $active );
 		} catch ( Throwable $e ) {
 			return '';
 		}

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -4,8 +4,8 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use RuntimeException;
 
@@ -66,14 +66,6 @@ final class Projector {
 	 */
 	private Token_Resolver $resolver;
 
-	/**
-	 * The token store.
-	 *
-	 * @since TBD
-	 *
-	 * @var Token_Store
-	 */
-	private Token_Store $store;
 
 	/**
 	 * Owns the active-library pointer, read at sync time so the synced options follow the active library.
@@ -100,27 +92,38 @@ final class Projector {
 	 */
 	private bool $reconciled_this_request = false;
 
+
+	/**
+	 * Supplies the sync signature's version part: the store version, plus the theme Style Guide
+	 * signature when there is one, so a Customizer save re-syncs KB's own palette option too.
+	 *
+	 * @since TBD
+	 *
+	 * @var Effective_Version
+	 */
+	private Effective_Version $versions;
+
 	/**
 	 * @since TBD
 	 *
-	 * @param Token_Registry             $registry
-	 * @param Token_Resolver             $resolver
-	 * @param Token_Store                $store
-	 * @param Active_Token_Library_Store $active
-	 * @param Palette_Builder            $builder
+	 * @param Token_Registry             $registry The token registry.
+	 * @param Token_Resolver             $resolver The token resolver.
+	 * @param Active_Token_Library_Store $active   The active-library pointer.
+	 * @param Palette_Builder            $builder  The palette entries builder.
+	 * @param Effective_Version          $versions Supplies the sync signature's version part.
 	 */
 	public function __construct(
 		Token_Registry $registry,
 		Token_Resolver $resolver,
-		Token_Store $store,
 		Active_Token_Library_Store $active,
-		Palette_Builder $builder
+		Palette_Builder $builder,
+		Effective_Version $versions
 	) {
 		$this->registry = $registry;
 		$this->resolver = $resolver;
-		$this->store    = $store;
 		$this->active   = $active;
 		$this->builder  = $builder;
+		$this->versions = $versions;
 	}
 
 	/**
@@ -166,7 +169,7 @@ final class Projector {
 		}
 
 		$slug      = $this->active->get();
-		$signature = KADENCE_BLOCKS_VERSION . ':' . $slug . ':' . $this->store->get_version( $slug );
+		$signature = KADENCE_BLOCKS_VERSION . ':' . $slug . ':' . $this->versions->for_slug( $slug );
 
 		// Skip the resolve + write when nothing the sync depends on has changed since the last successful
 		// one. The signature names all three inputs rather than relying on the version alone: a library

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Projector.php
@@ -39,8 +39,8 @@ final class Projector {
 	private const KB_COLORS_OPTION = 'kadence_blocks_colors';
 
 	/**
-	 * Marker option storing the last-synced "{plugin-version}:{library-slug}:{store-version}" signature, so a request
-	 * where nothing changed skips resolution entirely.
+	 * Marker option storing the last-synced "{plugin-version}:{library-slug}:{effective-version}" signature, so a
+	 * request where nothing changed skips resolution entirely.
 	 *
 	 * @since TBD
 	 *
@@ -191,14 +191,15 @@ final class Projector {
 		$entries = $this->builder->entries( $resolved );
 
 		// Empty entries is a valid resolved state (no token values set yet). Still advance the marker so
-		// the next request short-circuits rather than re-resolving. When the user writes token values the
-		// store version changes, the signature flips, and the next reconcile re-enters the write path.
+		// the next request short-circuits rather than re-resolving. When the user writes token values (or
+		// saves the Customizer) the effective version changes, the signature flips, and the next reconcile
+		// re-enters the write path.
 		if ( $entries !== [] ) {
 			$this->sync_kb_colors( $entries );
 		}
 
 		// Autoloaded: the boot pass reads this marker on every request to short-circuit, so it must not
-		// cost a dedicated query. It is a tiny "{plugin-version}:{library-slug}:{store-version}" string.
+		// cost a dedicated query. It is a tiny "{plugin-version}:{library-slug}:{effective-version}" string.
 		update_option( self::SYNC_MARKER_OPTION, $signature, true );
 	}
 

--- a/includes/resources/Design_Tokens/Projection/Palette/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Palette/Projector.php
@@ -3,7 +3,6 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Palette;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Palette_Slot;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Css_Builder as Preset_Css_Builder;
@@ -12,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Projects the per-block palette switch layer into the WordPress style pipeline.
@@ -41,12 +41,6 @@ final class Projector extends Abstract_Css_Projector {
 	 */
 	private Token_Registry $registry;
 
-	/**
-	 * @var Token_Store The store, for the cache-busting version.
-	 *
-	 * @since TBD
-	 */
-	private Token_Store $store;
 
 	/**
 	 * Owns the active-library pointer, read at build time so the projection follows the active library.
@@ -94,33 +88,44 @@ final class Projector extends Abstract_Css_Projector {
 	 */
 	private array $memo = [];
 
+
+	/**
+	 * Supplies the cache version: the store version, plus the theme Style Guide signature when there is
+	 * one, so a Customizer save invalidates this cache even though it bumps no store version.
+	 *
+	 * @since TBD
+	 *
+	 * @var Effective_Version
+	 */
+	private Effective_Version $versions;
+
 	/**
 	 * @since TBD
 	 *
 	 * @param Token_Registry             $registry    The token registry.
-	 * @param Token_Store                $store       The store, for the cache-busting version.
 	 * @param Active_Token_Library_Store $active      Owns the active-library pointer.
 	 * @param Effective_Palettes         $palettes    Reads the active library's effective palettes.
 	 * @param Token_Resolver             $resolver    Resolves each palette's full color graph.
 	 * @param Preset_Css_Builder         $presets     Supplies the canonical preset-var declarations.
 	 * @param Css_Builder                $css_builder The palette switch-layer builder.
+	 * @param Effective_Version          $versions    Supplies the effective cache version for a library.
 	 */
 	public function __construct(
 		Token_Registry $registry,
-		Token_Store $store,
 		Active_Token_Library_Store $active,
 		Effective_Palettes $palettes,
 		Token_Resolver $resolver,
 		Preset_Css_Builder $presets,
-		Css_Builder $css_builder
+		Css_Builder $css_builder,
+		Effective_Version $versions
 	) {
 		$this->registry    = $registry;
-		$this->store       = $store;
 		$this->active      = $active;
 		$this->palettes    = $palettes;
 		$this->resolver    = $resolver;
 		$this->presets     = $presets;
 		$this->css_builder = $css_builder;
+		$this->versions    = $versions;
 	}
 
 	/**
@@ -180,7 +185,7 @@ final class Projector extends Abstract_Css_Projector {
 	public function css(): string {
 		try {
 			$active  = $this->active->get();
-			$version = $this->store->get_version( $active );
+			$version = $this->versions->for_slug( $active );
 		} catch ( Throwable $e ) {
 			return '';
 		}

--- a/includes/resources/Design_Tokens/Projection/Palette/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Palette/Projector.php
@@ -8,10 +8,10 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Palette_Slot;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset\Css_Builder as Preset_Css_Builder;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
-use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Projects the per-block palette switch layer into the WordPress style pipeline.
@@ -40,7 +40,6 @@ final class Projector extends Abstract_Css_Projector {
 	 * @since TBD
 	 */
 	private Token_Registry $registry;
-
 
 	/**
 	 * Owns the active-library pointer, read at build time so the projection follows the active library.
@@ -80,14 +79,13 @@ final class Projector extends Abstract_Css_Projector {
 	private Css_Builder $css_builder;
 
 	/**
-	 * Per-request memo of built CSS, keyed on the active slug and store version.
+	 * Per-request memo of built CSS, keyed on the active slug and effective version.
 	 *
 	 * @since TBD
 	 *
 	 * @var array<string, string>
 	 */
 	private array $memo = [];
-
 
 	/**
 	 * Supplies the cache version: the store version, plus the theme Style Guide signature when there is
@@ -175,7 +173,7 @@ final class Projector extends Abstract_Css_Projector {
 	}
 
 	/**
-	 * Build the palette switch layer for the active library, memoised per request and cached on the store
+	 * Build the palette switch layer for the active library, memoized per request and cached on the effective
 	 * version. Returns an empty string when the active library cannot be read, so the page never crashes.
 	 *
 	 * @since TBD

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -3,7 +3,6 @@
 
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset;
 
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Composes_Selector_Suffix;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Identifier;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Traits\Sanitizes_Css_Value;
@@ -14,6 +13,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Preset_Bindings;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 use RuntimeException;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Builds the scoped CSS for selectable Kadence block presets for the single active token library.
@@ -129,12 +129,6 @@ final class Css_Builder {
 	 */
 	private Preset_Resolver $presets;
 
-	/**
-	 * @var Token_Store The store, read for the cache-busting version the collect memo keys on.
-	 *
-	 * @since TBD
-	 */
-	private Token_Store $store;
 
 	/**
 	 * Per-request memo of built CSS, keyed on the active library's object-cache key, so a write (which bumps the
@@ -158,16 +152,30 @@ final class Css_Builder {
 	private array $collected = [];
 
 	/**
+	 * Supplies the cache version: the store version, plus the theme Style Guide signature when there is
+	 * one, so a Customizer save invalidates this cache even though it bumps no store version.
+	 *
 	 * @since TBD
 	 *
-	 * @param Token_Registry  $registry The token registry.
-	 * @param Preset_Resolver $presets  The preset resolver.
-	 * @param Token_Store     $store    The store, for the cache-busting version.
+	 * @var Effective_Version
 	 */
-	public function __construct( Token_Registry $registry, Preset_Resolver $presets, Token_Store $store ) {
+	private Effective_Version $versions;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Registry    $registry The token registry.
+	 * @param Preset_Resolver   $presets  The preset resolver.
+	 * @param Effective_Version $versions Supplies the effective cache version for a library.
+	 */
+	public function __construct(
+		Token_Registry $registry,
+		Preset_Resolver $presets,
+		Effective_Version $versions
+	) {
 		$this->registry = $registry;
 		$this->presets  = $presets;
-		$this->store    = $store;
+		$this->versions = $versions;
 	}
 
 	/**
@@ -331,7 +339,7 @@ final class Css_Builder {
 	 * @return array<string, array{selector:string, default:string, presets:array<string, array<string, array{target:?string, value:string, dimension:bool, prop:?string, state:?string, editor:?string}>>}>
 	 */
 	private function collect( string $slug ): array {
-		$key = $slug . '_' . $this->store->get_version( $slug );
+		$key = $slug . '_' . $this->versions->for_slug( $slug );
 
 		if ( isset( $this->collected[ $key ] ) ) {
 			return $this->collected[ $key ];

--- a/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Css_Builder.php
@@ -141,9 +141,9 @@ final class Css_Builder {
 	private array $memo = [];
 
 	/**
-	 * Per-request memo of the collected preset structure, keyed on the library slug AND its store version, so the
-	 * registry/resolver walk runs once per library even when several layers read it, yet a write (which bumps the
-	 * version) produces a fresh collection rather than serving the pre-write structure.
+	 * Per-request memo of the collected preset structure, keyed on the library slug AND its effective version, so
+	 * the registry/resolver walk runs once per library even when several layers read it, yet a token write or a
+	 * Customizer save (either changes that version) produces a fresh collection rather than serving the stale one.
 	 *
 	 * @since TBD
 	 *
@@ -216,16 +216,16 @@ final class Css_Builder {
 
 	/**
 	 * Cached version of css(): assembles the active library's preset CSS from the object cache with a per-request
-	 * memo. A write bumps the library's store version, which changes the cache key, so a fresh build is produced on
-	 * the next request.
+	 * memo. A token write or a Customizer save changes the effective version, which changes the cache key, so a
+	 * fresh build is produced on the next request.
 	 *
-	 * The plugin version is folded into the cache key alongside the store version, so the cache also busts on a
-	 * plugin build (shipped preset definitions and the baseline can change with it).
+	 * The plugin version is folded into the cache key alongside the effective version, so the cache also busts on
+	 * a plugin build (shipped preset definitions and the baseline can change with it).
 	 *
 	 * @since TBD
 	 *
 	 * @param string                $active_slug The active library's slug.
-	 * @param string                $version     The store version the active library was built from.
+	 * @param string                $version     The effective version the active library was built from.
 	 * @param array<string, string> $breakpoints Breakpoint => media-query string, for the per-breakpoint
 	 *                                           redeclarations.
 	 *
@@ -244,7 +244,7 @@ final class Css_Builder {
 	 * @since TBD
 	 *
 	 * @param string                $active_slug The active library's slug.
-	 * @param string                $version     The store version the active library was built from.
+	 * @param string                $version     The effective version the active library was built from.
 	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
 	 *
 	 * @return string
@@ -278,7 +278,7 @@ final class Css_Builder {
 	 * @since TBD
 	 *
 	 * @param string                $active_slug The active library's slug.
-	 * @param string                $version     The store version the active library was built from.
+	 * @param string                $version     The effective version the active library was built from.
 	 * @param array<string, string> $breakpoints Breakpoint => media-query string.
 	 * @param bool                  $editor      Whether to build the editor-scoped CSS.
 	 *

--- a/includes/resources/Design_Tokens/Projection/Preset/Projector.php
+++ b/includes/resources/Design_Tokens/Projection/Preset/Projector.php
@@ -3,12 +3,12 @@
 namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Preset;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
-use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Projection\Contracts\Abstract_Css_Projector;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Responsive;
 use KadenceWP\KadenceBlocks\Design_Tokens\Utils\Location;
 use Throwable;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Projects the selectable-preset CSS into the WordPress style pipeline.
@@ -29,12 +29,6 @@ final class Projector extends Abstract_Css_Projector {
 	 */
 	private Token_Registry $registry;
 
-	/**
-	 * @var Token_Store
-	 *
-	 * @since TBD
-	 */
-	private Token_Store $store;
 
 	/**
 	 * Owns the active-library pointer, read at build time so the projection follows the active library.
@@ -52,19 +46,35 @@ final class Projector extends Abstract_Css_Projector {
 	 */
 	private Css_Builder $css_builder;
 
+
+	/**
+	 * Supplies the cache version: the store version, plus the theme Style Guide signature when there is
+	 * one, so a Customizer save invalidates this cache even though it bumps no store version.
+	 *
+	 * @since TBD
+	 *
+	 * @var Effective_Version
+	 */
+	private Effective_Version $versions;
+
 	/**
 	 * @since TBD
 	 *
 	 * @param Token_Registry             $registry    The token registry.
-	 * @param Token_Store                $store       The store, for the cache-busting version.
 	 * @param Active_Token_Library_Store $active      Owns the active-library pointer.
 	 * @param Css_Builder                $css_builder The preset CSS builder.
+	 * @param Effective_Version          $versions    Supplies the effective cache version for a library.
 	 */
-	public function __construct( Token_Registry $registry, Token_Store $store, Active_Token_Library_Store $active, Css_Builder $css_builder ) {
+	public function __construct(
+		Token_Registry $registry,
+		Active_Token_Library_Store $active,
+		Css_Builder $css_builder,
+		Effective_Version $versions
+	) {
 		$this->registry    = $registry;
-		$this->store       = $store;
 		$this->active      = $active;
 		$this->css_builder = $css_builder;
+		$this->versions    = $versions;
 	}
 
 	/**
@@ -128,7 +138,7 @@ final class Projector extends Abstract_Css_Projector {
 	public function css(): string {
 		try {
 			$active  = $this->active->get();
-			$version = $this->store->get_version( $active );
+			$version = $this->versions->for_slug( $active );
 
 			return $this->css_builder->css_for_version( $active, $version, $this->breakpoints() );
 		} catch ( Throwable $e ) {
@@ -154,7 +164,7 @@ final class Projector extends Abstract_Css_Projector {
 	public function editor_css(): string {
 		try {
 			$active  = $this->active->get();
-			$version = $this->store->get_version( $active );
+			$version = $this->versions->for_slug( $active );
 
 			return $this->css_builder->editor_css_for_version( $active, $version, $this->breakpoints() );
 		} catch ( Throwable $e ) {

--- a/includes/resources/Design_Tokens/Resolver/Effective_Version.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Version.php
@@ -1,0 +1,69 @@
+<?php declare( strict_types=1 );
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
+
+/**
+ * The version of a library's EFFECTIVE document — everything the resolved values depend on that can
+ * change at runtime: the stored overrides (the store version) and the theme Style Guide the baseline
+ * is re-valued from (the overlay signature).
+ *
+ * Every resolved-tokens and projected-CSS cache keys on this instead of the store version alone, so a
+ * Customizer save — which bumps no store version — still invalidates them. On a site where the overlay
+ * is empty (no Kadence theme) this IS the store version, so those cache keys are unchanged.
+ *
+ * Not for optimistic concurrency: the REST layer keeps comparing the store version, because a
+ * Customizer save does not change the stored document a client is editing.
+ *
+ * @since TBD
+ */
+final class Effective_Version {
+
+	/**
+	 * The token store.
+	 *
+	 * @since TBD
+	 *
+	 * @var Token_Store
+	 */
+	private Token_Store $store;
+
+	/**
+	 * The theme-derived overlay whose signature is folded in.
+	 *
+	 * @since TBD
+	 *
+	 * @var Style_Guide_Overlay
+	 */
+	private Style_Guide_Overlay $overlay;
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Token_Store         $store   The token store.
+	 * @param Style_Guide_Overlay $overlay The theme Style Guide overlay.
+	 */
+	public function __construct( Token_Store $store, Style_Guide_Overlay $overlay ) {
+		$this->store   = $store;
+		$this->overlay = $overlay;
+	}
+
+	/**
+	 * The effective version for a library: the store version, extended with the overlay signature when
+	 * there is one.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The token library slug.
+	 *
+	 * @return string
+	 */
+	public function for_slug( string $slug ): string {
+		$version   = $this->store->get_version( $slug );
+		$signature = $this->overlay->signature();
+
+		return $signature === '' ? $version : $version . '-' . $signature;
+	}
+}

--- a/includes/resources/Design_Tokens/Resolver/Provider.php
+++ b/includes/resources/Design_Tokens/Resolver/Provider.php
@@ -18,6 +18,7 @@ final class Provider extends Provider_Contract {
 	 */
 	public function register(): void {
 		$this->container->singleton( Effective_Document::class );
+		$this->container->singleton( Effective_Version::class );
 		$this->container->singleton( Css_Renderer::class );
 		$this->container->singleton( Token_Resolver::class );
 		$this->container->singleton( Preset_Resolver::class );

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -67,7 +67,7 @@ final class Token_Resolver {
 
 	/**
 	 * Per-request memo of resolved results, keyed on the same cache key load() uses for the object cache:
-	 * the cache prefix "resolved_tokens_{slug}" followed by the store version, e.g.
+	 * the cache prefix "resolved_tokens_{slug}" followed by the effective version, e.g.
 	 * "resolved_tokens_default_v3".
 	 *
 	 * @var array<string,Resolved_Tokens>
@@ -75,7 +75,7 @@ final class Token_Resolver {
 	private array $memo = [];
 
 	/**
-	 * Per-request memo of effective (baseline-merged) documents, keyed on the slug and store version, so the
+	 * Per-request memo of effective (baseline-merged) documents, keyed on the slug and effective version, so the
 	 * stored document is decoded and merged once per version no matter how many callers need the authored
 	 * view — the resolve path itself, the responsive feed, and the REST resolved read all share one build.
 	 *
@@ -84,6 +84,16 @@ final class Token_Resolver {
 	 * @var array<string,array<string,mixed>>
 	 */
 	private array $effective_memo = [];
+
+	/**
+	 * Supplies the cache version: the store version, plus the theme Style Guide signature when there is
+	 * one, so a Customizer save invalidates these caches even though it bumps no store version.
+	 *
+	 * @since TBD
+	 *
+	 * @var Effective_Version
+	 */
+	private Effective_Version $versions;
 
 	/**
 	 * Wire the token store, effective-document builder, and value renderer.
@@ -95,23 +105,26 @@ final class Token_Resolver {
 	 * @param Css_Renderer       $renderer  Renders a flattened value to a CSS-ready string.
 	 * @param Effective_Palettes $palettes  Reads the library's effective color palettes for the `:root` overlay.
 	 * @param Mutator            $mutator   The pure structural setter for the palette overlay.
+	 * @param Effective_Version  $versions  Supplies the effective cache version for a library.
 	 */
 	public function __construct(
 		Token_Store $store,
 		Effective_Document $effective,
 		Css_Renderer $renderer,
 		Effective_Palettes $palettes,
-		Mutator $mutator
+		Mutator $mutator,
+		Effective_Version $versions
 	) {
 		$this->store     = $store;
 		$this->effective = $effective;
 		$this->renderer  = $renderer;
 		$this->palettes  = $palettes;
 		$this->mutator   = $mutator;
+		$this->versions  = $versions;
 	}
 
 	/**
-	 * Resolve a stored token library into flat maps. Memoized per request on the store version,
+	 * Resolve a stored token library into flat maps. Memoized per request on the effective version,
 	 * which is bumped on every write, so the memo invalidates automatically.
 	 *
 	 * @since TBD
@@ -143,14 +156,14 @@ final class Token_Resolver {
 	 * @throws Dangling_Alias_Exception When a stored alias references a path with no token leaf.
 	 */
 	private function load( string $slug, string $cache_prefix ): Resolved_Tokens {
-		$version   = $this->store->get_version( $slug );
+		$version   = $this->versions->for_slug( $slug );
 		$cache_key = $cache_prefix . '_' . $version;
 
 		if ( isset( $this->memo[ $cache_key ] ) ) {
 			return $this->memo[ $cache_key ];
 		}
 
-		// L2: persistent object cache (requires a drop-in such as Memcached or Redis) — survives across requests, keyed on the store version.
+		// L2: persistent object cache (requires a drop-in such as Memcached or Redis) — survives across requests, keyed on the effective version.
 		$cached = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
 
 		if ( $found && $cached instanceof Resolved_Tokens ) {
@@ -189,7 +202,7 @@ final class Token_Resolver {
 	 * The baseline-merged effective document for a stored library, with $extensions intact — the authored view
 	 * the resolved maps flatten away. This is the source the responsive feed and the REST resolved read need
 	 * to recover a token's authored responsive / clamp shape (aliases preserved, unrendered), which the flat
-	 * by_id / by_var maps have already dropped. Memoised per request on the store version like resolve(), so
+	 * by_id / by_var maps have already dropped. Memoized per request on the effective version like resolve(), so
 	 * the stored document is decoded and merged once rather than rebuilt by every caller.
 	 *
 	 * The library's `$current` color palette is overlaid onto the color token leaves here, before the resolved
@@ -203,7 +216,7 @@ final class Token_Resolver {
 	 * @return array<string,mixed> The effective document.
 	 */
 	public function effective_document( string $slug = 'default' ): array {
-		$cache_key = $slug . '_' . $this->store->get_version( $slug );
+		$cache_key = $slug . '_' . $this->versions->for_slug( $slug );
 
 		if ( isset( $this->effective_memo[ $cache_key ] ) ) {
 			return $this->effective_memo[ $cache_key ];
@@ -223,7 +236,7 @@ final class Token_Resolver {
 	 * Resolve the active library's tokens as if a SPECIFIC palette were current, rather than the library's stored
 	 * `$current`. The per-block palette switch layer emits each palette's fully-resolved color graph so a
 	 * `[data-kb-palette="<id>"]` override re-skins its subtree — semantic colors and shadow composites
-	 * included, not just the primitives it re-tints. Memoized per request and cached on the store version
+	 * included, not just the primitives it re-tints. Memoized per request and cached on the effective version
 	 * (bumped on every write) keyed additionally on the palette id.
 	 *
 	 * @since TBD
@@ -237,7 +250,7 @@ final class Token_Resolver {
 	 * @throws Dangling_Alias_Exception When a stored alias references a path with no token leaf.
 	 */
 	public function resolve_palette( string $slug, string $palette_id ): Resolved_Tokens {
-		$version   = $this->store->get_version( $slug );
+		$version   = $this->versions->for_slug( $slug );
 		$cache_key = 'resolved_tokens_palette_' . $palette_id . '_' . $slug . '_' . $version;
 
 		if ( isset( $this->memo[ $cache_key ] ) ) {

--- a/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
+++ b/includes/resources/Design_Tokens/Resolver/Token_Resolver.php
@@ -142,8 +142,9 @@ final class Token_Resolver {
 	}
 
 	/**
-	 * Shared resolve path: per-request memo over a persistent object-cache entry, both keyed on the store
-	 * version (bumped on every write, so they self-invalidate).
+	 * Shared resolve path: per-request memo over a persistent object-cache entry, both keyed on the effective
+	 * version (the store version plus the theme Style Guide signature, so a token write and a Customizer save
+	 * both self-invalidate).
 	 *
 	 * @since TBD
 	 *

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/Feed_AssemblerTest.php
@@ -19,6 +19,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use ReflectionProperty;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Covers Feed_Assembler in isolation — the pipeline both the Localizer and Feed_Controller share
@@ -173,7 +174,8 @@ final class Feed_AssemblerTest extends TestCase {
 			),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
 		$assembler = new Feed_Assembler(

--- a/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Admin/Feed/LocalizerTest.php
@@ -24,6 +24,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use ReflectionProperty;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 final class LocalizerTest extends TestCase {
 
@@ -227,7 +228,8 @@ final class LocalizerTest extends TestCase {
 			),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
 		$assembler = new Feed_Assembler(

--- a/tests/wpunit/Resources/Design_Tokens/Editor/Attribute_Default_CatalogTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Editor/Attribute_Default_CatalogTest.php
@@ -11,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Exercises the editor per-block attribute-default catalog the block-registration filter in
@@ -111,7 +112,8 @@ final class Attribute_Default_CatalogTest extends TestCase {
 			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
 		return new Attribute_Default_Catalog( $resolver );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Icon_Size_AdapterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Adapter/Icon_Size_AdapterTest.php
@@ -16,6 +16,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use Tests\helpers\CSSTestHelper;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 final class Icon_Size_AdapterTest extends TestCase {
 
@@ -66,7 +67,8 @@ final class Icon_Size_AdapterTest extends TestCase {
 			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_BridgeTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Css_Var/Legacy_Filter_BridgeTest.php
@@ -14,6 +14,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 final class Legacy_Filter_BridgeTest extends TestCase {
 
@@ -53,7 +54,8 @@ final class Legacy_Filter_BridgeTest extends TestCase {
 			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
 		return new Legacy_Filter_Bridge( $this->registry, $resolver );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
@@ -17,6 +17,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use ReflectionProperty;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 final class Palette_FilterTest extends TestCase {
 
@@ -188,7 +189,8 @@ final class Palette_FilterTest extends TestCase {
 			),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
 		$filter = new Palette_Filter(

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/ProjectorTest.php
@@ -16,6 +16,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use ReflectionProperty;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 final class ProjectorTest extends TestCase {
 
@@ -253,15 +254,16 @@ final class ProjectorTest extends TestCase {
 			),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
 		$projector = new Projector(
 			$this->registry,
 			$corrupt_resolver,
-			$this->container->get( Token_Store::class ),
 			$this->container->get( Active_Token_Library_Store::class ),
-			$this->container->get( Palette_Builder::class )
+			$this->container->get( Palette_Builder::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
 		$projector->reconcile();

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/Css_BuilderTest.php
@@ -9,6 +9,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Exercises the selectable-preset CSS builder against the real shipped Button preset bindings, so these
@@ -389,7 +390,7 @@ final class Css_BuilderTest extends TestCase {
 	 * @return Css_Builder
 	 */
 	private function builder( Token_Registry $registry ): Css_Builder {
-		return new Css_Builder( $registry, $this->resolver, $this->store );
+		return new Css_Builder( $registry, $this->resolver, $this->container->get( Effective_Version::class ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Preset/ProjectorTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Preset/ProjectorTest.php
@@ -11,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Preset_Resolver;
 use ReflectionProperty;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Covers the preset projector: it appends the scoped preset CSS to KB's front-end and editor style
@@ -101,7 +102,12 @@ final class ProjectorTest extends TestCase {
 	 * Build the projector with a given registry, the real preset resolver and the store.
 	 */
 	private function projector( Token_Registry $registry ): Projector {
-		return new Projector( $registry, $this->store, $this->active, new Css_Builder( $registry, $this->resolver, $this->store ) );
+		return new Projector(
+			$registry,
+			$this->active,
+			new Css_Builder( $registry, $this->resolver, $this->container->get( Effective_Version::class ) ),
+			$this->container->get( Effective_Version::class )
+		);
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VersionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Effective_VersionTest.php
@@ -1,0 +1,144 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Resolver;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Mapper;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
+use Tests\Support\Classes\Fake_Style_Guide_Source;
+use Tests\Support\Classes\TestCase;
+
+final class Effective_VersionTest extends TestCase {
+
+	private Token_Store $store;
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store    = $this->container->get( Token_Store::class );
+		$this->registry = $this->container->get( Token_Registry::class );
+	}
+
+	protected function tearDown(): void {
+		$this->store->delete( Token_Store::default_slug() );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * With no overlay (a site not running the Kadence theme) the effective version is exactly the store
+	 * version, so every cache key that folds it in is byte-identical to what it was before this layer.
+	 *
+	 * @return void
+	 */
+	public function testEqualsStoreVersionWhenOverlayIsEmpty(): void {
+		$slug     = Token_Store::default_slug();
+		$versions = $this->versions( new Fake_Style_Guide_Source( null ) );
+
+		$this->assertSame( $this->store->get_version( $slug ), $versions->for_slug( $slug ) );
+	}
+
+	/**
+	 * Two different Style Guides give two different effective versions for the same store version.
+	 * That is what makes a Customizer save invalidate the resolved and projected caches.
+	 *
+	 * @return void
+	 */
+	public function testDiffersWhenTheStyleGuideDiffers(): void {
+		$slug  = Token_Store::default_slug();
+		$first = $this->versions( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+		$other = $this->versions( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#222222' ] ) );
+
+		$this->assertNotSame( $first->for_slug( $slug ), $other->for_slug( $slug ) );
+	}
+
+	/**
+	 * The same Style Guide gives the same effective version, so an unchanged theme does not churn the
+	 * caches on every request.
+	 *
+	 * @return void
+	 */
+	public function testIsStableForAnUnchangedStyleGuide(): void {
+		$slug  = Token_Store::default_slug();
+		$first = $this->versions( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+		$same  = $this->versions( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+
+		$this->assertSame( $first->for_slug( $slug ), $same->for_slug( $slug ) );
+	}
+
+	/**
+	 * The store version stays a prefix of the effective version, so a token write still changes it even
+	 * while a Style Guide is overlaid.
+	 *
+	 * @return void
+	 */
+	public function testKeepsTheStoreVersionAsItsPrefix(): void {
+		$slug = Token_Store::default_slug();
+
+		// A library with nothing stored has an empty version, so write one to have a prefix to assert.
+		$this->store->save_document( (string) wp_json_encode( [ 'primitive' => [] ] ) );
+
+		$versions = $this->versions( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+		$version  = $this->store->get_version( $slug );
+
+		$this->assertNotSame( '', $version );
+		$this->assertStringStartsWith( $version, $versions->for_slug( $slug ) );
+	}
+
+	/**
+	 * A token write changes the effective version even though the Style Guide did not change.
+	 *
+	 * @return void
+	 */
+	public function testChangesWhenTheStoredDocumentChanges(): void {
+		$slug     = Token_Store::default_slug();
+		$versions = $this->versions( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+		$before   = $versions->for_slug( $slug );
+
+		$this->store->save_document(
+			(string) wp_json_encode(
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									'$type'  => 'color',
+									'$value' => '#abcdef',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+
+		$this->assertNotSame( $before, $versions->for_slug( $slug ) );
+	}
+
+	/**
+	 * The container wires the service, so every projector resolves the same instance.
+	 *
+	 * @return void
+	 */
+	public function testTheContainerBindsIt(): void {
+		$this->assertInstanceOf( Effective_Version::class, $this->container->get( Effective_Version::class ) );
+	}
+
+	/**
+	 * An Effective_Version over the given Style Guide source, with the real store and registry.
+	 *
+	 * @param Fake_Style_Guide_Source $source The Style Guide source.
+	 *
+	 * @return Effective_Version
+	 */
+	private function versions( Fake_Style_Guide_Source $source ): Effective_Version {
+		return new Effective_Version(
+			$this->store,
+			new Style_Guide_Overlay( $source, new Style_Guide_Mapper(), $this->registry )
+		);
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Icon_Size_ResolutionTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Icon_Size_ResolutionTest.php
@@ -11,6 +11,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 /**
  * Confirms that `semantic.icon-size.default` and `semantic.color.icon` resolve through the existing
@@ -34,7 +35,8 @@ final class Icon_Size_ResolutionTest extends TestCase {
 			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 	}
 

--- a/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Resolver/Token_ResolverTest.php
@@ -14,6 +14,7 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Resolved_Tokens;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 
 final class Token_ResolverTest extends TestCase {
 
@@ -29,7 +30,8 @@ final class Token_ResolverTest extends TestCase {
 			new Effective_Document( new Fake_Baseline_Document( $baseline ) ),
 			new Css_Renderer(),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 	}
 
@@ -599,10 +601,11 @@ final class Token_ResolverTest extends TestCase {
 			$this->container->get( Effective_Document::class ),
 			$this->container->get( Css_Renderer::class ),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
-		$version   = $store->get_version();
+		$version   = $this->container->get( Effective_Version::class )->for_slug( 'default' );
 		$cache_key = 'resolved_tokens_default_' . $version;
 
 		wp_cache_delete( $cache_key, 'kb_design_tokens' );
@@ -627,10 +630,11 @@ final class Token_ResolverTest extends TestCase {
 			$this->container->get( Effective_Document::class ),
 			$this->container->get( Css_Renderer::class ),
 			$this->container->get( Effective_Palettes::class ),
-			$this->container->get( Mutator::class )
+			$this->container->get( Mutator::class ),
+			$this->container->get( Effective_Version::class )
 		);
 
-		$version   = $store->get_version();
+		$version   = $this->container->get( Effective_Version::class )->for_slug( 'default' );
 		$cache_key = 'resolved_tokens_default_' . $version;
 		$sentinel  = new Resolved_Tokens(
 			[ 'sentinel.token' => '#sentinel' ],


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/3f7bf1ff5960448399a02dd96fd18f49)

## Summary

Keys every resolved-tokens and projected-CSS cache on the **effective** document version rather than
the store version alone.

A Customizer save changes no store version. Once the theme's Style Guide starts feeding the baseline
(slice 6), the old colors would keep being served from cache until the next token write. This adds
`Resolver/Effective_Version`: the store version, extended with the Style Guide overlay's signature
when there is one.

On a site with no overlay — anything but the Kadence theme — it returns the store version unchanged,
so those cache keys are byte-for-byte what they are today.

## What's in it

`Effective_Version` plus all eleven cache sites switched to it:

- `Token_Resolver` — `load()`, `effective_document()`, `resolve_palette()`
- the `Css_Var`, `Palette`, `Block_Default_Css` (×2) and `Preset` (×2) projectors
- `Preset/Css_Builder::collect()`
- the `Kadence_Option` sync marker

Left alone deliberately: `Feed_Assembler` and the REST controllers keep comparing the store version.
Those are optimistic concurrency, not caching — a Customizer save does not change the stored document
a client is editing.

## A cleanup that fell out of it

With every read going through the new service, `Token_Store` became write-only in six classes.
PHPStan flagged it, so the dead dependency is removed rather than left wired. That changed
constructor signatures, hence the test churn: eleven hand-built `Token_Resolver` call sites and three
projector/builder ones.

## Test plan

`slic run wpunit Resources/Design_Tokens`

New `Effective_VersionTest`: equals the store version when the overlay is empty, differs when the
Style Guide differs, is stable when it does not, keeps the store version as its prefix, and still
changes on a token write.

`grep -rn '\->store->get_version(' includes/resources/Design_Tokens/{Projection,Resolver}` should
return only `Effective_Version` itself.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved design-token cache invalidation so changes to theme Style Guide overlays are reflected in generated CSS, presets, palettes, and resolved token data.
  - Preserved fail-open behavior by returning empty stylesheets when version resolution fails.

- **Tests**
  - Added coverage for effective version handling, including overlay changes, stable styles, stored document updates, and cache behavior.
  - Updated existing tests to validate the revised version resolution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->