### PR TITLE
[DTM] SOFT-4320 [7/8]: resolve tokens from the theme's Style Guide

### DIFF
--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Palette_Filter.php
@@ -71,8 +71,8 @@ final class Palette_Filter {
 	private Palette_Builder $builder;
 
 	/**
-	 * Per-request memo of slug => { color, name }. Null until first built; cleared when a token is written
-	 * or the active library changes, the two inputs it is built from.
+	 * Per-request memo of slug => { color, name }. Null until first built; cleared when any input it is
+	 * built from changes: a token write, an active-library switch, or a change to the theme's Style Guide.
 	 *
 	 * @since TBD
 	 *
@@ -123,8 +123,8 @@ final class Palette_Filter {
 
 	/**
 	 * Drop the per-request memo so a change made in this request is visible to later palette reads in the
-	 * same request. Bound to both inputs the memo is built from: the store's changed action and the
-	 * active-library pointer's.
+	 * same request. Bound to every input the memo is built from: the store's changed action, the
+	 * active-library pointer's, the theme's palette option hooks and the Customizer preview init.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
+++ b/includes/resources/Design_Tokens/Projection/Kadence_Option/Provider.php
@@ -4,12 +4,13 @@ namespace KadenceWP\KadenceBlocks\Design_Tokens\Projection\Kadence_Option;
 
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Reader;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
 
 /**
  * Registers the Kadence option projection: binds the builder, projector and palette filter as
  * singletons, wires the reconcile to a once-per-request boot pass and to the token-changed action,
- * and hooks the theme's palette reads.
+ * hooks the theme's palette reads, and clears the palette memo on every input it is built from.
  *
  * @since TBD
  */
@@ -51,12 +52,26 @@ final class Provider extends Provider_Contract {
 		);
 
 		// The memo is built from the active library's resolved tokens, so moving the pointer invalidates it
-		// for the same reason a write does. Both inputs have to clear it or a read after the switch answers
+		// for the same reason a write does. Every input has to clear it or a read after the switch answers
 		// with the previous library's colors.
 		add_action(
 			Active_Token_Library_Store::changed_action(),
 			$this->container->callback( Palette_Filter::class, 'on_tokens_changed' ),
 			5
 		);
+
+		// The memo is also built from the theme's Style Guide: the resolver reads the baseline decorated
+		// with it, so a Customizer save changes the colors with no token write and no library switch.
+		// Same hooks the Style Guide overlay flushes on. Priority 20 because the overlay flushes at 10 on
+		// the option hooks and at 0 on the preview init, and this has to run after it: a palette read
+		// between the two would rebuild the memo from the overlay's stale values and nothing would clear
+		// it again in this request.
+		$clear = $this->container->callback( Palette_Filter::class, 'on_tokens_changed' );
+
+		foreach ( [ 'add_option_', 'update_option_', 'delete_option_' ] as $prefix ) {
+			add_action( $prefix . Style_Guide_Reader::get_palette_option_key(), $clear, 20 );
+		}
+
+		add_action( 'customize_preview_init', $clear, 20 );
 	}
 }

--- a/includes/resources/Design_Tokens/Registry/Baseline/Theme_Style_Guide_Baseline_Document.php
+++ b/includes/resources/Design_Tokens/Registry/Baseline/Theme_Style_Guide_Baseline_Document.php
@@ -1,0 +1,270 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline;
+
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Sentinels;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
+
+/**
+ * The shipped baseline with the active theme's Style Guide written onto it.
+ *
+ * Decorates the real baseline (Json_Baseline_Document): document() is the inner document with every
+ * theme-derived value set on the leaf it names, so the effective document — and therefore every
+ * resolved token — starts from the site's existing look instead of the plugin's shipped values.
+ * Stored overrides still merge on top (Effective_Document), so tokens always win.
+ *
+ * has() delegates unchanged. That is the rule "the theme may only re-value tokens that already have a
+ * baseline entry", enforced structurally: a theme value whose dot-path has no $value leaf in the inner
+ * document is skipped, no id is ever added, and the fail-closed guard sees exactly the shipped ids.
+ *
+ * The $default color palette's swatches are re-valued alongside the tokens they point at, so the Style
+ * Library shows the theme's colors and "reset swatch" restores them rather than the shipped hex.
+ *
+ * @since TBD
+ */
+final class Theme_Style_Guide_Baseline_Document implements Baseline_Document {
+
+	/**
+	 * The shipped baseline being decorated.
+	 *
+	 * @since TBD
+	 *
+	 * @var Baseline_Document
+	 */
+	private Baseline_Document $inner;
+
+	/**
+	 * The theme-derived token values for this request.
+	 *
+	 * @since TBD
+	 *
+	 * @var Style_Guide_Overlay
+	 */
+	private Style_Guide_Overlay $overlay;
+
+	/**
+	 * The pure structural setter used to write a re-valued leaf back into the document.
+	 *
+	 * @since TBD
+	 *
+	 * @var Mutator
+	 */
+	private Mutator $mutator;
+
+	/**
+	 * Memoized merged document for this request. Null until first built.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	private ?array $document = null;
+
+	/**
+	 * The overlay signature the memoized document was built from, so a signature change within a request
+	 * (the overlay finishing its own memo, a test swapping the source) rebuilds it.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private string $signature = '';
+
+	/**
+	 * @since TBD
+	 *
+	 * @param Baseline_Document   $inner   The shipped baseline.
+	 * @param Style_Guide_Overlay $overlay The theme Style Guide overlay.
+	 * @param Mutator             $mutator The pure structural setter.
+	 */
+	public function __construct( Baseline_Document $inner, Style_Guide_Overlay $overlay, Mutator $mutator ) {
+		$this->inner   = $inner;
+		$this->overlay = $overlay;
+		$this->mutator = $mutator;
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id The token id.
+	 *
+	 * @return bool
+	 */
+	public function has( string $id ): bool {
+		return $this->inner->has( $id );
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @since TBD
+	 */
+	public function document(): array {
+		$signature = $this->overlay->signature();
+
+		if ( $this->document !== null && $this->signature === $signature ) {
+			return $this->document;
+		}
+
+		$document = $this->inner->document();
+
+		// An empty inner document means the shipped file is missing or unreadable; the guard fails closed
+		// on it, and writing theme values onto nothing would hand the resolver a partial baseline.
+		if ( $document === [] || $signature === '' ) {
+			return $this->remember( $document, $signature );
+		}
+
+		$values = $this->overlay->values();
+
+		// Only the ids actually written: a value whose id has no $value leaf is skipped, and its swatch
+		// must be skipped with it or the Style Library would show a color the token does not carry.
+		$applied = [];
+
+		foreach ( $values as $id => $value ) {
+			$leaf = Document_Path::node_at( $document, $id );
+
+			if ( $leaf === null || ! array_key_exists( Sentinels::get_value_key(), $leaf ) ) {
+				continue;
+			}
+
+			$leaf[ Sentinels::get_value_key() ] = $value;
+			$document                           = $this->mutator->set( $document, $id, $leaf );
+			$applied[ $id ]                     = $value;
+		}
+
+		return $this->remember( $this->revalue_default_swatches( $document, $applied ), $signature );
+	}
+
+	/**
+	 * Write the theme value into every swatch of the $default color palette whose token was re-valued.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed>  $document The document with re-valued token leaves.
+	 * @param array<string, string> $values   Token id => value that was applied.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function revalue_default_swatches( array $document, array $values ): array {
+		$section = $this->section_at( $document, Extensions::get_color_palettes_path() );
+
+		if ( $section === null ) {
+			return $document;
+		}
+
+		$default = $section[ Extensions::get_default_key() ] ?? null;
+
+		if ( ! is_string( $default ) || ! isset( $section[ $default ] ) || ! is_array( $section[ $default ] ) ) {
+			return $document;
+		}
+
+		$groups_key   = Extensions::get_groups_key();
+		$swatches_key = Extensions::get_swatches_key();
+		$token_key    = Extensions::get_swatch_token_key();
+		$value_key    = Sentinels::get_value_key();
+		$groups       = $section[ $default ][ $groups_key ] ?? null;
+
+		if ( ! is_array( $groups ) ) {
+			return $document;
+		}
+
+		foreach ( $groups as $group_index => $group ) {
+			if ( ! is_array( $group ) || ! isset( $group[ $swatches_key ] ) || ! is_array( $group[ $swatches_key ] ) ) {
+				continue;
+			}
+
+			foreach ( $group[ $swatches_key ] as $swatch_index => $swatch ) {
+				if ( ! is_array( $swatch ) || ! isset( $swatch[ $token_key ] ) || ! is_string( $swatch[ $token_key ] ) ) {
+					continue;
+				}
+
+				if ( ! isset( $values[ $swatch[ $token_key ] ] ) ) {
+					continue;
+				}
+
+				$groups[ $group_index ][ $swatches_key ][ $swatch_index ][ $value_key ] = $values[ $swatch[ $token_key ] ];
+			}
+		}
+
+		$section[ $default ][ $groups_key ] = $groups;
+
+		return $this->set_section_at( $document, Extensions::get_color_palettes_path(), $section );
+	}
+
+	/**
+	 * The array at a key path, or null when any step is missing. Key paths (not dot-paths) because the
+	 * extensions namespace key contains dots.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The document.
+	 * @param string[]             $path     The key path.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function section_at( array $document, array $path ): ?array {
+		$node = $document;
+
+		foreach ( $path as $key ) {
+			if ( ! isset( $node[ $key ] ) || ! is_array( $node[ $key ] ) ) {
+				return null;
+			}
+
+			$node = $node[ $key ];
+		}
+
+		return $node;
+	}
+
+	/**
+	 * Replace the array at a key path. The caller has proved the path exists.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document The document.
+	 * @param string[]             $path     The key path.
+	 * @param array<string, mixed> $section  The replacement.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function set_section_at( array $document, array $path, array $section ): array {
+		$cursor = &$document;
+
+		foreach ( $path as $key ) {
+			if ( ! isset( $cursor[ $key ] ) || ! is_array( $cursor[ $key ] ) ) {
+				$cursor[ $key ] = [];
+			}
+
+			$cursor = &$cursor[ $key ];
+		}
+
+		$cursor = $section;
+		unset( $cursor );
+
+		return $document;
+	}
+
+	/**
+	 * Memoize the merged document with the signature it was built from.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $document  The merged document.
+	 * @param string               $signature The overlay signature it reflects.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function remember( array $document, string $signature ): array {
+		$this->document  = $document;
+		$this->signature = $signature;
+
+		return $document;
+	}
+}

--- a/includes/resources/Design_Tokens/Registry/Provider.php
+++ b/includes/resources/Design_Tokens/Registry/Provider.php
@@ -6,6 +6,9 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Json_Baseline_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
 use KadenceWP\KadenceBlocks\StellarWP\ProphecyMonorepo\Container\Contracts\Provider as Provider_Contract;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Theme_Style_Guide_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
 
 /**
  * Wires the Token Registry: binds the singleton and the shipped baseline, defines the global helper,
@@ -23,12 +26,26 @@ final class Provider extends Provider_Contract {
 	public function register(): void {
 		$this->container->singleton( Token_Registry::class, Token_Registry::class );
 
-		// Bind the baseline contract to the shipped, read-only DTCG document (baseline.json). Every
-		// declared token must now have a matching baseline entry or the guard fails closed. The version
-		// keys the decoded-document cache, so a baseline shipped with a new plugin build invalidates it.
+		// Bind the baseline contract to the shipped, read-only DTCG document (baseline.json), decorated with
+		// the active theme's Style Guide so resolution starts from the site's existing look. Every declared
+		// token must still have a matching shipped entry or the guard fails closed — the decorator's has()
+		// delegates. The version keys the decoded-document cache, so a baseline shipped with a new plugin
+		// build invalidates it. Bound lazily: the theme and the declarations are not loaded when providers
+		// register, and the first document() read happens on init or later.
 		$this->container->singleton(
 			Baseline_Document::class,
-			new Json_Baseline_Document( __DIR__ . '/Baseline/baseline.json', KADENCE_BLOCKS_VERSION )
+			function (): Baseline_Document {
+				/** @var Style_Guide_Overlay $overlay */
+				$overlay = $this->container->get( Style_Guide_Overlay::class );
+				/** @var Mutator $mutator */
+				$mutator = $this->container->get( Mutator::class );
+
+				return new Theme_Style_Guide_Baseline_Document(
+					new Json_Baseline_Document( __DIR__ . '/Baseline/baseline.json', KADENCE_BLOCKS_VERSION ),
+					$overlay,
+					$mutator
+				);
+			}
 		);
 
 		$this->load_helper();

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -189,9 +189,12 @@ $font_size_primitive_tokens = array_map(
 /**
  * The brand + neutral primitives ARE the site's global color palette: each claims a Kadence palette slot
  * (palette1..9), so --global-paletteN follows the primitive and the legacy kadence_blocks_colors palette
- * stays in sync. Values mirror Kadence's default palette (brand at 1-2, a dark→light neutral ramp at 3-9,
- * white at 9), so activation changes nothing until a primitive is overridden. Semantic colors deliberately
- * do NOT claim a slot — they deliver at the block level — so writing a semantic never re-skins the palette.
+ * stays in sync. Baseline values are the plugin's own shipped defaults (brand at 1-2, a dark→light neutral
+ * ramp at 3-9, white at 9) — they match what the plugin emits when the Kadence theme is absent, NOT the
+ * theme's own defaults, which differ at slots 1 and 2. On a Kadence site the theme Style Guide layer
+ * re-values these nine primitives from the active palette set, so resolution starts from the colors the
+ * site already renders. Semantic colors deliberately do NOT claim a slot — they deliver at the block
+ * level — so writing a semantic never re-skins the palette.
  */
 $palette_slots = [
 	'primitive.color.brand.primary'   => [ 'palette1', __( 'Brand Primary', 'kadence-blocks' ) ],

--- a/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
@@ -302,13 +302,16 @@ final class Effective_Palettes {
 	}
 
 	/**
-	 * The shipped baseline `$default` palette flattened to a `{ token => $value }` map — the colors the
-	 * plugin ships, independent of any stored library.
+	 * The baseline `$default` palette flattened to a `{ token => $value }` map, independent of any stored
+	 * library. The baseline it reads is the decorated one, so on a Kadence site these are the theme's Style
+	 * Guide colors (see `Theme_Style_Guide_Baseline_Document`), not the hex values the plugin ships; without
+	 * a Kadence theme they are the shipped values.
 	 *
 	 * Both halves are load-bearing. Its KEYS are the permanent swatch set, whose rows a palette write may
-	 * never drop; its VALUES are what a delete reverts one of those swatches to. No other seam can answer
-	 * either question: {@see Baseline_Document::has()} indexes only the primitive/semantic token layers and
-	 * deliberately skips "$extensions", so it never sees a palette swatch at all.
+	 * never drop; its VALUES are what a delete reverts one of those swatches to — the theme's color on a
+	 * Kadence site, the shipped color elsewhere. No other method can answer either question:
+	 * {@see Baseline_Document::has()} indexes only the primitive/semantic token layers and deliberately
+	 * skips "$extensions", so it never sees a palette swatch at all.
 	 *
 	 * Returned whole rather than behind a per-token predicate because every caller needs the values too,
 	 * or walks the whole set — and the flatten re-walks the baseline document, so a predicate would redo it
@@ -316,7 +319,7 @@ final class Effective_Palettes {
 	 *
 	 * @since TBD
 	 *
-	 * @return array<string, string> token dot-path => the shipped literal-or-alias value.
+	 * @return array<string, string> token dot-path => the baseline literal-or-alias value.
 	 */
 	public function baseline_swatch_values(): array {
 		$section = $this->palettes_of( $this->baseline->document() );

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Kadence_Option/Palette_FilterTest.php
@@ -14,7 +14,11 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Contracts\Style_Guide_Source;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Reader;
 use ReflectionProperty;
+use Tests\Support\Classes\Fake_Style_Guide_Source;
 use Tests\Support\Classes\Fake_Baseline_Document;
 use Tests\Support\Classes\TestCase;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
@@ -49,6 +53,7 @@ final class Palette_FilterTest extends TestCase {
 
 	protected function tearDown(): void {
 		$this->registry->activate();
+		$this->restore_style_guide_source();
 		$this->container->get( Active_Token_Library_Store::class )->set( Token_Store::default_slug() );
 		$this->store->delete( self::OTHER_LIBRARY );
 		$this->filter->on_tokens_changed();
@@ -282,6 +287,68 @@ final class Palette_FilterTest extends TestCase {
 	}
 
 	/**
+	 * A Style Guide change clears the memo through the provider's hook, after the overlay flushed.
+	 *
+	 * The memo is built from the resolver, and the resolver reads the baseline decorated with the theme's
+	 * Style Guide, so a Customizer save invalidates it with no token write and no library switch. The probe
+	 * read runs on the same hook just before the overlay flushes: if the memo were cleared before the flush
+	 * instead of after, the probe would rebuild it from the stale overlay and nothing would clear it again.
+	 *
+	 * @dataProvider styleGuideHookProvider
+	 *
+	 * @param string $hook           The hook the theme fires when the Style Guide changes.
+	 * @param int    $probe_priority One step before the overlay's own flush on that hook.
+	 *
+	 * @return void
+	 */
+	public function testStyleGuideChangeClearsTheMemoThroughTheHook( string $hook, int $probe_priority ): void {
+		$source = Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] );
+		$this->swap_style_guide_source( $source );
+
+		// Build the memo from the first Style Guide, so the test fails if the change does not clear it.
+		$this->assertSame( '#111111', $this->filter->filter( '#old', 'palette1' ) );
+
+		$source->set( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#222222' ] )->snapshot() );
+
+		$probe = function (): void {
+			$this->filter->filter( '#old', 'palette1' );
+		};
+		add_action( $hook, $probe, $probe_priority );
+
+		try {
+			do_action( $hook );
+		} finally {
+			remove_action( $hook, $probe, $probe_priority );
+		}
+
+		$this->assertSame( '#222222', $this->filter->filter( '#old', 'palette1' ) );
+	}
+
+	/**
+	 * The four hooks the overlay flushes on, each with a probe priority one step before that flush.
+	 *
+	 * @return Generator
+	 */
+	public function styleGuideHookProvider(): Generator {
+		yield 'palette option added' => [
+			'hook'           => 'add_option_' . Style_Guide_Reader::get_palette_option_key(),
+			'probe_priority' => 9,
+		];
+		yield 'palette option updated' => [
+			'hook'           => 'update_option_' . Style_Guide_Reader::get_palette_option_key(),
+			'probe_priority' => 9,
+		];
+		yield 'palette option deleted' => [
+			'hook'           => 'delete_option_' . Style_Guide_Reader::get_palette_option_key(),
+			'probe_priority' => 9,
+		];
+		yield 'customizer preview init' => [
+			'hook'           => 'customize_preview_init',
+			'probe_priority' => -1,
+		];
+	}
+
+	/**
 	 * A read taken before the declarations register does not pin an empty map for the rest of the request.
 	 *
 	 * The theme reads the palette earlier than init:0 (its own CSS and the Customizer both call
@@ -309,6 +376,31 @@ final class Palette_FilterTest extends TestCase {
 
 		// The same filter instance must not answer this read from the empty map it saw first.
 		$this->assertNotSame( '#theme', $filter->filter( '#theme', 'palette1' ) );
+	}
+
+	/**
+	 * Point the container's Style Guide overlay at a source the test controls, so the real overlay,
+	 * decorator, resolver and filter chain runs against a Style Guide without the Kadence theme installed.
+	 *
+	 * @param Style_Guide_Source $source The source to read from.
+	 *
+	 * @return void
+	 */
+	private function swap_style_guide_source( Style_Guide_Source $source ): void {
+		$overlay  = $this->container->get( Style_Guide_Overlay::class );
+		$property = new ReflectionProperty( Style_Guide_Overlay::class, 'source' );
+		$property->setAccessible( true );
+		$property->setValue( $overlay, $source );
+		$overlay->flush();
+	}
+
+	/**
+	 * Put the real reader back on the container's overlay, so later tests see the suite's empty Style Guide.
+	 *
+	 * @return void
+	 */
+	private function restore_style_guide_source(): void {
+		$this->swap_style_guide_source( $this->container->get( Style_Guide_Source::class ) );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Theme_Style_Guide_Baseline_DocumentTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Registry/Baseline/Theme_Style_Guide_Baseline_DocumentTest.php
@@ -1,0 +1,259 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Registry\Baseline;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Document_Path;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Theme_Style_Guide_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Contracts\Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Vocabulary\Extensions;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Mapper;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
+use Tests\Support\Classes\Fake_Baseline_Document;
+use Tests\Support\Classes\Fake_Style_Guide_Source;
+use Tests\Support\Classes\TestCase;
+
+final class Theme_Style_Guide_Baseline_DocumentTest extends TestCase {
+
+	private Token_Registry $registry;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = $this->container->get( Token_Registry::class );
+	}
+
+	/**
+	 * has() delegates to the inner document: a re-valued id stays true, an unknown id stays false.
+	 *
+	 * @dataProvider hasProvider
+	 *
+	 * @param string $id       The token id.
+	 * @param bool   $expected Whether the inner baseline defines it.
+	 *
+	 * @return void
+	 */
+	public function testHasDelegatesToTheInnerDocument( string $id, bool $expected ): void {
+		$document = $this->decorated( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) );
+
+		$this->assertSame( $expected, $document->has( $id ) );
+	}
+
+	/**
+	 * Ids the hand-written inner baseline does and does not define.
+	 *
+	 * @return Generator
+	 */
+	public function hasProvider(): Generator {
+		yield 'defined and re-valued' => [
+			'id'       => 'primitive.color.brand.primary',
+			'expected' => true,
+		];
+		yield 'defined, not re-valued' => [
+			'id'       => 'primitive.color.neutral.900',
+			'expected' => true,
+		];
+		yield 'not defined' => [
+			'id'       => 'primitive.color.brand.extra',
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * A theme value lands on an existing leaf's $value and keeps the leaf's $type and siblings.
+	 *
+	 * @return void
+	 */
+	public function testRevaluesAnExistingLeafKeepingItsType(): void {
+		$document = $this->decorated( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) )->document();
+		$leaf     = Document_Path::node_at( $document, 'primitive.color.brand.primary' );
+
+		$this->assertSame( '#111111', $leaf['$value'] );
+		$this->assertSame( 'color', $leaf['$type'] );
+		$this->assertSame( 'Brand Primary', $leaf['$description'] );
+	}
+
+	/**
+	 * A slot the theme does not carry leaves its baseline value untouched.
+	 *
+	 * @return void
+	 */
+	public function testLeavesUnmappedLeavesAlone(): void {
+		$document = $this->decorated( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) )->document();
+		$leaf     = Document_Path::node_at( $document, 'primitive.color.neutral.900' );
+
+		$this->assertSame( '#1A202C', $leaf['$value'] );
+	}
+
+	/**
+	 * A theme value whose id has no leaf in the inner document is dropped — no token id is ever added.
+	 *
+	 * @return void
+	 */
+	public function testNeverAddsATokenId(): void {
+		// palette2 maps to primitive.color.brand.secondary, which this inner baseline does not define.
+		$source   = Fake_Style_Guide_Source::with_palette(
+			[
+				'palette1' => '#111111',
+				'palette2' => '#222222',
+			]
+		);
+		$document = $this->decorated( $source )->document();
+
+		$this->assertNull( Document_Path::node_at( $document, 'primitive.color.brand.secondary' ) );
+	}
+
+	/**
+	 * The $default palette swatch pointing at a re-valued token carries the theme value; other swatches
+	 * keep theirs, so the Style Library shows the theme's colors and "reset swatch" restores them.
+	 *
+	 * @return void
+	 */
+	public function testRevaluesTheDefaultPaletteSwatches(): void {
+		$document = $this->decorated( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) )->document();
+		$swatches = $document['$extensions']['com.kadence.designTokens']['colorPalettes']['brand']['groups'][0]['swatches'];
+		$by_token = array_column( $swatches, null, 'token' );
+
+		$this->assertSame( '#111111', $by_token['primitive.color.brand.primary']['$value'] );
+		$this->assertSame( '#1A202C', $by_token['primitive.color.neutral.900']['$value'] );
+	}
+
+	/**
+	 * An empty inner document (a missing or unreadable baseline.json) stays empty, so the guard still
+	 * fails closed rather than being handed a partial baseline.
+	 *
+	 * @return void
+	 */
+	public function testEmptyInnerDocumentStaysEmpty(): void {
+		$document = new Theme_Style_Guide_Baseline_Document(
+			new Fake_Baseline_Document( [] ),
+			$this->overlay( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] ) ),
+			$this->container->get( Mutator::class )
+		);
+
+		$this->assertSame( [], $document->document() );
+	}
+
+	/**
+	 * With no theme the decorated document equals the inner document byte for byte, so a non-Kadence
+	 * site resolves exactly as it did before this layer existed.
+	 *
+	 * @return void
+	 */
+	public function testEqualsInnerDocumentWithoutATheme(): void {
+		$inner     = new Fake_Baseline_Document( $this->inner_document() );
+		$decorated = new Theme_Style_Guide_Baseline_Document(
+			$inner,
+			$this->overlay( new Fake_Style_Guide_Source( null ) ),
+			$this->container->get( Mutator::class )
+		);
+
+		$this->assertSame( $inner->document(), $decorated->document() );
+	}
+
+	/**
+	 * A changed Style Guide rebuilds the memoized document rather than serving the previous one.
+	 *
+	 * @return void
+	 */
+	public function testRebuildsWhenTheSignatureChanges(): void {
+		$source    = Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] );
+		$overlay   = $this->overlay( $source );
+		$decorated = new Theme_Style_Guide_Baseline_Document(
+			new Fake_Baseline_Document( $this->inner_document() ),
+			$overlay,
+			$this->container->get( Mutator::class )
+		);
+
+		$first = Document_Path::node_at( $decorated->document(), 'primitive.color.brand.primary' );
+		$this->assertSame( '#111111', $first['$value'] );
+
+		$source->set( Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#999999' ] )->snapshot() );
+		$overlay->flush();
+
+		$second = Document_Path::node_at( $decorated->document(), 'primitive.color.brand.primary' );
+		$this->assertSame( '#999999', $second['$value'] );
+	}
+
+	/**
+	 * The decorator over a hand-written inner baseline.
+	 *
+	 * @param Fake_Style_Guide_Source $source The Style Guide source.
+	 *
+	 * @return Baseline_Document
+	 */
+	private function decorated( Fake_Style_Guide_Source $source ): Baseline_Document {
+		return new Theme_Style_Guide_Baseline_Document(
+			new Fake_Baseline_Document( $this->inner_document() ),
+			$this->overlay( $source ),
+			$this->container->get( Mutator::class )
+		);
+	}
+
+	/**
+	 * An overlay over the given source, with the real mapper and the real registry.
+	 *
+	 * @param Fake_Style_Guide_Source $source The Style Guide source.
+	 *
+	 * @return Style_Guide_Overlay
+	 */
+	private function overlay( Fake_Style_Guide_Source $source ): Style_Guide_Overlay {
+		return new Style_Guide_Overlay( $source, new Style_Guide_Mapper(), $this->registry );
+	}
+
+	/**
+	 * A small baseline: two color leaves and a $default color palette naming both.
+	 *
+	 * Deliberately omits primitive.color.brand.secondary, which palette2 claims, so the "never adds an
+	 * id" rule has something to drop.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function inner_document(): array {
+		return [
+			'primitive'   => [
+				'color' => [
+					'brand'   => [
+						'primary' => [
+							'$type'        => 'color',
+							'$value'       => '#3182CE',
+							'$description' => 'Brand Primary',
+						],
+					],
+					'neutral' => [
+						'900' => [
+							'$type'  => 'color',
+							'$value' => '#1A202C',
+						],
+					],
+				],
+			],
+			'$extensions' => [
+				Extensions::get_namespace() => [
+					Extensions::get_section_color_palettes() => [
+						Extensions::get_default_key() => 'brand',
+						'brand'                       => [
+							Extensions::get_groups_key() => [
+								[
+									Extensions::get_swatches_key() => [
+										[
+											Extensions::get_swatch_token_key() => 'primitive.color.brand.primary',
+											'$value' => '#3182CE',
+										],
+										[
+											Extensions::get_swatch_token_key() => 'primitive.color.neutral.900',
+											'$value' => '#1A202C',
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_IntegrationTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_IntegrationTest.php
@@ -1,0 +1,288 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Theme_Style_Guide;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
+use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Json_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Theme_Style_Guide_Baseline_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Token_Registry;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Css_Renderer;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
+use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Mapper;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
+use Tests\Support\Classes\Fake_Style_Guide_Source;
+use Tests\Support\Classes\TestCase;
+
+final class Style_Guide_IntegrationTest extends TestCase {
+
+	/**
+	 * The nine palette slots a token claims, and the color this test gives each one.
+	 *
+	 * @var array<string, string>
+	 */
+	private const THEME_COLORS = [
+		'palette1' => '#a10001',
+		'palette2' => '#a20002',
+		'palette3' => '#a30003',
+		'palette4' => '#a40004',
+		'palette5' => '#a50005',
+		'palette6' => '#a60006',
+		'palette7' => '#a70007',
+		'palette8' => '#a80008',
+		'palette9' => '#a90009',
+	];
+
+	private Token_Registry $registry;
+	private Token_Store $store;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->registry = $this->container->get( Token_Registry::class );
+		$this->store    = $this->container->get( Token_Store::class );
+		$this->store->delete( Token_Store::default_slug() );
+		wp_cache_flush();
+	}
+
+	protected function tearDown(): void {
+		$this->store->delete( Token_Store::default_slug() );
+		wp_cache_flush();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * AC1: on a fresh library the palette primitives resolve to the theme's colors, and the semantics
+	 * that alias them follow, so the site keeps the look it already had.
+	 *
+	 * @return void
+	 */
+	public function testFreshLibraryResolvesToTheThemePalette(): void {
+		$resolved = $this->resolver_for( Fake_Style_Guide_Source::with_palette( self::THEME_COLORS ) )->resolve();
+
+		$this->assertSame( '#a10001', $resolved->value( 'primitive.color.brand.primary' ) );
+		$this->assertSame( '#a30003', $resolved->value( 'primitive.color.neutral.900' ) );
+		$this->assertSame( '#a90009', $resolved->value( 'primitive.color.neutral.0' ) );
+
+		// semantic.color.text aliases neutral.900, so re-valuing the primitive re-tints the semantic.
+		$this->assertSame( '#a30003', $resolved->value( 'semantic.color.text' ) );
+	}
+
+	/**
+	 * AC4: whichever palette set the theme renders is the one the tokens are read from.
+	 *
+	 * @dataProvider activeSetProvider
+	 *
+	 * @param string $set The palette set the theme has active.
+	 *
+	 * @return void
+	 */
+	public function testActiveSetIsHonored( string $set ): void {
+		$source   = Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#abcdef' ], $set );
+		$resolved = $this->resolver_for( $source )->resolve();
+
+		$this->assertSame( '#abcdef', $resolved->value( 'primitive.color.brand.primary' ) );
+	}
+
+	/**
+	 * The theme's three palette sets.
+	 *
+	 * @return Generator
+	 */
+	public function activeSetProvider(): Generator {
+		yield 'first set' => [ 'set' => 'palette' ];
+		yield 'second set' => [ 'set' => 'second-palette' ];
+		yield 'third set' => [ 'set' => 'third-palette' ];
+	}
+
+	/**
+	 * AC3: a token override wins over the theme, and deleting it hands control back to the Customizer
+	 * rather than to the plugin's shipped default.
+	 *
+	 * @return void
+	 */
+	public function testTokenOverrideWinsAndResetRestoresTheThemeColor(): void {
+		$source = Fake_Style_Guide_Source::with_palette( self::THEME_COLORS );
+
+		$this->store->save_document(
+			(string) wp_json_encode(
+				[
+					'primitive' => [
+						'color' => [
+							'brand' => [
+								'primary' => [
+									'$type'  => 'color',
+									'$value' => '#123456',
+								],
+							],
+						],
+					],
+				]
+			)
+		);
+		wp_cache_flush();
+
+		$this->assertSame( '#123456', $this->resolver_for( $source )->resolve()->value( 'primitive.color.brand.primary' ) );
+
+		$this->store->delete( Token_Store::default_slug() );
+		wp_cache_flush();
+
+		$this->assertSame( '#a10001', $this->resolver_for( $source )->resolve()->value( 'primitive.color.brand.primary' ) );
+	}
+
+	/**
+	 * AC5: a site not running the Kadence theme resolves exactly as it does today — the decorated and
+	 * undecorated baselines produce the same map.
+	 *
+	 * @return void
+	 */
+	public function testNonKadenceSiteResolvesExactlyAsShipped(): void {
+		$decorated = $this->resolver_for( new Fake_Style_Guide_Source( null ) )->resolve()->by_id();
+
+		wp_cache_flush();
+
+		$shipped = $this->shipped_resolver()->resolve()->by_id();
+
+		$this->assertSame( $shipped, $decorated );
+	}
+
+	/**
+	 * AC6: a Customizer save is reflected on the next request even though it writes no token, and the
+	 * effective version changes while the store version does not.
+	 *
+	 * @return void
+	 */
+	public function testCustomizerSaveIsReflectedWithoutAStoreWrite(): void {
+		$slug           = Token_Store::default_slug();
+		$before_version = $this->store->get_version( $slug );
+
+		$first     = Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#111111' ] );
+		$overlay   = new Style_Guide_Overlay( $first, new Style_Guide_Mapper(), $this->registry );
+		$versions  = new Effective_Version( $this->store, $overlay );
+		$effective = $versions->for_slug( $slug );
+
+		$this->assertSame( '#111111', $this->resolver_for( $first )->resolve()->value( 'primitive.color.brand.primary' ) );
+
+		// A new request after the Customizer save: a fresh overlay over the changed Style Guide.
+		$second        = Fake_Style_Guide_Source::with_palette( [ 'palette1' => '#999999' ] );
+		$next_overlay  = new Style_Guide_Overlay( $second, new Style_Guide_Mapper(), $this->registry );
+		$next_versions = new Effective_Version( $this->store, $next_overlay );
+
+		$this->assertSame( '#999999', $this->resolver_for( $second )->resolve()->value( 'primitive.color.brand.primary' ) );
+		$this->assertNotSame( $effective, $next_versions->for_slug( $slug ) );
+		$this->assertSame( $before_version, $this->store->get_version( $slug ) );
+	}
+
+	/**
+	 * AC7: has() delegates, so a declared token with no shipped baseline entry is still missing and the
+	 * guard keeps failing closed.
+	 *
+	 * @return void
+	 */
+	public function testGuardStillSeesTheShippedIdsOnly(): void {
+		$baseline = $this->baseline_for( Fake_Style_Guide_Source::with_palette( self::THEME_COLORS ) );
+
+		$this->assertTrue( $baseline->has( 'primitive.color.brand.primary' ) );
+		$this->assertFalse( $baseline->has( 'primitive.color.brand.invented' ) );
+	}
+
+	/**
+	 * AC8: the Style Library's default palette shows the theme's colors, so "reset swatch" restores the
+	 * theme color rather than the shipped hex.
+	 *
+	 * @return void
+	 */
+	public function testDefaultPaletteSwatchesShowTheThemeColors(): void {
+		$baseline = $this->baseline_for( Fake_Style_Guide_Source::with_palette( self::THEME_COLORS ) );
+		$palettes = new Effective_Palettes( $baseline, $this->store, $this->container->get( Mutator::class ) );
+		$swatches = $palettes->baseline_swatch_values();
+
+		$this->assertSame( '#a10001', $swatches['primitive.color.brand.primary'] );
+		$this->assertSame( '#a30003', $swatches['primitive.color.neutral.900'] );
+	}
+
+	/**
+	 * The decorated baseline over the real shipped baseline.json.
+	 *
+	 * @param Fake_Style_Guide_Source $source The Style Guide source.
+	 *
+	 * @return Theme_Style_Guide_Baseline_Document
+	 */
+	private function baseline_for( Fake_Style_Guide_Source $source ): Theme_Style_Guide_Baseline_Document {
+		return new Theme_Style_Guide_Baseline_Document(
+			$this->shipped_baseline( 'integration-' . spl_object_id( $source ) ),
+			new Style_Guide_Overlay( $source, new Style_Guide_Mapper(), $this->registry ),
+			$this->container->get( Mutator::class )
+		);
+	}
+
+	/**
+	 * A resolver over the decorated baseline, composed the way the container composes the real one.
+	 *
+	 * @param Fake_Style_Guide_Source $source The Style Guide source.
+	 *
+	 * @return Token_Resolver
+	 */
+	private function resolver_for( Fake_Style_Guide_Source $source ): Token_Resolver {
+		$overlay  = new Style_Guide_Overlay( $source, new Style_Guide_Mapper(), $this->registry );
+		$baseline = new Theme_Style_Guide_Baseline_Document(
+			$this->shipped_baseline( 'integration-' . spl_object_id( $source ) ),
+			$overlay,
+			$this->container->get( Mutator::class )
+		);
+
+		return $this->resolver_over( $baseline, new Effective_Version( $this->store, $overlay ) );
+	}
+
+	/**
+	 * A resolver over the undecorated shipped baseline, for the "unchanged on other themes" comparison.
+	 *
+	 * @return Token_Resolver
+	 */
+	private function shipped_resolver(): Token_Resolver {
+		$baseline = $this->shipped_baseline( 'integration-shipped' );
+		$overlay  = new Style_Guide_Overlay( new Fake_Style_Guide_Source( null ), new Style_Guide_Mapper(), $this->registry );
+
+		return $this->resolver_over( $baseline, new Effective_Version( $this->store, $overlay ) );
+	}
+
+	/**
+	 * Compose a resolver over a baseline.
+	 *
+	 * @param object            $baseline The baseline document.
+	 * @param Effective_Version $versions The cache-version service.
+	 *
+	 * @return Token_Resolver
+	 */
+	private function resolver_over( $baseline, Effective_Version $versions ): Token_Resolver {
+		return new Token_Resolver(
+			$this->store,
+			new Effective_Document( $baseline ),
+			new Css_Renderer(),
+			new Effective_Palettes( $baseline, $this->store, $this->container->get( Mutator::class ) ),
+			$this->container->get( Mutator::class ),
+			$versions
+		);
+	}
+
+	/**
+	 * The shipped baseline.json, with a per-test cache version so one test's decoded document cannot be
+	 * served to another.
+	 *
+	 * @param string $version The cache version to key the decoded document on.
+	 *
+	 * @return Json_Baseline_Document
+	 */
+	private function shipped_baseline( string $version ): Json_Baseline_Document {
+		return new Json_Baseline_Document(
+			dirname( __DIR__, 4 ) . '/../includes/resources/Design_Tokens/Registry/Baseline/baseline.json',
+			$version
+		);
+	}
+}


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/3f7bf1ff5960448399a02dd96fd18f49)

## Summary

Makes token resolution start from the colors the site already renders.

`Theme_Style_Guide_Baseline_Document` decorates the shipped baseline: `document()` returns it with
the theme's Style Guide values written onto the leaves they name, so the effective document — and
therefore every resolved token — starts from the site's existing look instead of the plugin's
shipped defaults. Stored overrides still merge on top, so tokens always win.

This is the slice the previous four were building toward.

## Why `has()` delegates

`has()` passes straight through to the shipped baseline. That is the rule "the theme may only
re-value tokens that already have a baseline entry", enforced structurally rather than by
convention: a theme value whose dot-path has no `$value` leaf is skipped, no id is ever added, and
`Baseline_Guard` still sees exactly the shipped set.

The `$default` color palette's swatches are re-valued alongside the tokens they point at — and only
for the leaves actually written — so the Style Library shows the theme's colors and "reset swatch"
restores them rather than the shipped hex.

## Also here

`Registry/declarations.php` claimed the baseline "mirrors Kadence's default palette". It does not:
it mirrors the plugin's **own** no-theme fallback, which differs from the theme at slots 1 and 2.
Comment corrected.

The binding in `Registry/Provider.php` is a closure, because neither the theme nor the declarations
are loaded when providers register.

## Test plan

`slic run wpunit Resources/Design_Tokens`

- `Theme_Style_Guide_Baseline_DocumentTest` — `has()` delegation, re-valuing a leaf while keeping its
  `$type` and siblings, never adding an id, the default-palette swatches, an empty inner document
  staying empty, equality with the inner document when there is no theme, and rebuilding when the
  Style Guide changes.
- `Style_Guide_IntegrationTest` — end to end over the real shipped baseline, registry and store,
  covering a fresh library resolving to the theme palette, the active set being honored, an override
  winning and its removal restoring the theme color, a non-Kadence site resolving byte-for-byte as
  shipped, a Customizer save reflected with no store write, the guard, and the swatches.

Verified in a browser on a site with a customized palette: the front end and a refreshed Customizer
preview agree, an override wins in both, and removing it returns the Customizer's color.

## Known limitation

While a color is being dragged in the Customizer, the preview shows the **theme's** value rather
than the token's. The theme's preview script writes `--global-paletteN` inline on the document
(`inc/customizer/js/kadence-customizer-preview.js`), which never reaches PHP, and an inline root
style outranks anything the plugin emits. It corrects on refresh. Fixing it properly needs a small
hook in the theme, so it ships as a coordinated follow-up rather than here. Accepted in review.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Design-token colors now adapt to the active theme’s Style Guide palette.
  * Theme-based values apply to existing tokens while preserving plugin defaults and metadata.
  * Default palette swatches reflect the active theme’s colors.
  * Theme updates are reflected without requiring a design-token store write.
  * Non-Kadence sites continue using the shipped token values.

* **Documentation**
  * Clarified the distinction between plugin-provided baseline colors and theme palette values.

* **Tests**
  * Added coverage for theme mapping, overrides, resets, palette selection, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->