### PR TITLE
[DTM] SOFT-4320 [4/8]: map a theme Style Guide snapshot onto token values

### DIFF
--- a/includes/resources/Design_Tokens/Theme_Style_Guide/Style_Guide_Mapper.php
+++ b/includes/resources/Design_Tokens/Theme_Style_Guide/Style_Guide_Mapper.php
@@ -1,0 +1,156 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide;
+
+/**
+ * Pure translation from a theme Style Guide snapshot to `token id => $value`.
+ *
+ * No WordPress calls, no globals, no I/O: the reader hands raw data in and the overlay takes the map
+ * out, so every rule here is unit-testable without a database or a theme.
+ *
+ * The palette half honors the theme's "active" pointer — palette / second-palette / third-palette —
+ * because that is the set the theme renders. Only slots the caller passes in (the tokens declaring a
+ * kadence_slot) are produced, so the mapper can never introduce a token id of its own.
+ *
+ * @since TBD
+ */
+final class Style_Guide_Mapper {
+
+	/**
+	 * The palette option key naming the set the theme renders.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const ACTIVE_KEY = 'active';
+
+	/**
+	 * The palette set the theme falls back to when "active" is missing or empty.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const DEFAULT_SET = 'palette';
+
+	/**
+	 * The theme stores this on palette10 to mean "derive the complement of palette1 at render time".
+	 * It is a marker, not a color, so it must never become a token value.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const COMPLEMENT_MARKER = '#FfFfFf';
+
+	/**
+	 * Accepts hex, rgb()/rgba(), hsl()/hsla(). Anything else (an empty string, a CSS var, a gradient) is
+	 * skipped so a bad theme value never reaches the resolver.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	private const COLOR_PATTERN = '/^(#[0-9a-f]{3,8}|rgba?\([^)]*\)|hsla?\([^)]*\))$/i';
+
+	/**
+	 * Map a snapshot onto the tokens that claim palette slots.
+	 *
+	 * @since TBD
+	 *
+	 * @param array{palette: array<string, mixed>, settings: array<string, mixed>} $snapshot    The reader's snapshot.
+	 * @param array<string, string>                                                $slot_tokens Slot slug => token id, from the registry.
+	 *
+	 * @return array<string, string> Token id => literal color, for every claimed slot with a usable color.
+	 */
+	public function map( array $snapshot, array $slot_tokens ): array {
+		$set    = $this->active_set( $snapshot['palette'] );
+		$values = [];
+
+		foreach ( $slot_tokens as $slug => $token_id ) {
+			$color = $this->color_of( $set, $slug );
+
+			if ( $color === null ) {
+				continue;
+			}
+
+			$values[ $token_id ] = $color;
+		}
+
+		return $values;
+	}
+
+	/**
+	 * The theme setting keys the reader must fetch. Empty until a mapping consumes one.
+	 *
+	 * @since TBD
+	 *
+	 * @return string[]
+	 */
+	public static function setting_keys(): array {
+		return [];
+	}
+
+	/**
+	 * The slot slug => color map of the palette set the theme renders.
+	 *
+	 * Mirrors the theme's palette_option(): the "active" pointer names the set; a missing or empty
+	 * pointer means "palette"; a pointer naming a set that does not exist yields nothing (the theme
+	 * renders empty values in that case, so re-valuing nothing keeps the two in step).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $palette The decoded kadence_global_palette option.
+	 *
+	 * @return array<string, string>
+	 */
+	public function active_set( array $palette ): array {
+		$active = $palette[ self::ACTIVE_KEY ] ?? null;
+		$key    = is_string( $active ) && $active !== '' ? $active : self::DEFAULT_SET;
+		$list   = $palette[ $key ] ?? null;
+
+		if ( ! is_array( $list ) ) {
+			return [];
+		}
+
+		$set = [];
+
+		foreach ( $list as $entry ) {
+			if (
+				! is_array( $entry )
+				|| ! isset( $entry['slug'], $entry['color'] )
+				|| ! is_string( $entry['slug'] )
+				|| ! is_string( $entry['color'] )
+			) {
+				continue;
+			}
+
+			$set[ $entry['slug'] ] = $entry['color'];
+		}
+
+		return $set;
+	}
+
+	/**
+	 * The usable color stored on a slot, or null when the slot is absent, empty, the complement marker,
+	 * or not a color literal.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, string> $set  Slot slug => color of the active set.
+	 * @param string                $slug The slot slug.
+	 *
+	 * @return string|null
+	 */
+	private function color_of( array $set, string $slug ): ?string {
+		$color = trim( $set[ $slug ] ?? '' );
+
+		if ( $color === self::COMPLEMENT_MARKER || preg_match( self::COLOR_PATTERN, $color ) !== 1 ) {
+			return null;
+		}
+
+		return $color;
+	}
+}

--- a/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_MapperTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_MapperTest.php
@@ -1,0 +1,360 @@
+<?php declare( strict_types=1 );
+// cspell:ignore palette .
+
+namespace Tests\wpunit\Resources\Design_Tokens\Theme_Style_Guide;
+
+use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Mapper;
+use Tests\Support\Classes\TestCase;
+
+final class Style_Guide_MapperTest extends TestCase {
+
+	/**
+	 * Slot slug => token id, the shape the registry hands the mapper.
+	 *
+	 * @var array<string, string>
+	 */
+	private const SLOT_TOKENS = [
+		'palette1' => 'primitive.color.brand.primary',
+		'palette2' => 'primitive.color.brand.secondary',
+		'palette3' => 'primitive.color.neutral.900',
+	];
+
+	/**
+	 * Only the palette set the theme names as active is read.
+	 *
+	 * @dataProvider activeSetProvider
+	 *
+	 * @param string $active   The set the theme renders.
+	 * @param string $expected The color that set carries on palette1.
+	 *
+	 * @return void
+	 */
+	public function testMapsClaimedSlotsOfTheActiveSet( string $active, string $expected ): void {
+		$values = ( new Style_Guide_Mapper() )->map( $this->snapshot( $active ), self::SLOT_TOKENS );
+
+		$this->assertSame( $expected, $values['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * Each of the theme's three palette sets, with a color unique to it.
+	 *
+	 * @return Generator
+	 */
+	public function activeSetProvider(): Generator {
+		yield 'first set' => [
+			'active'   => 'palette',
+			'expected' => '#111111',
+		];
+		yield 'second set' => [
+			'active'   => 'second-palette',
+			'expected' => '#222222',
+		];
+		yield 'third set' => [
+			'active'   => 'third-palette',
+			'expected' => '#333333',
+		];
+	}
+
+	/**
+	 * A missing or empty "active" pointer means the first set, matching the theme's own fallback.
+	 *
+	 * @dataProvider absentActiveProvider
+	 *
+	 * @param array<string, mixed> $palette The decoded palette option.
+	 *
+	 * @return void
+	 */
+	public function testFallsBackToPaletteWhenActiveIsMissingOrEmpty( array $palette ): void {
+		$values = ( new Style_Guide_Mapper() )->map(
+			[
+				'palette'  => $palette,
+				'settings' => [],
+			],
+			self::SLOT_TOKENS
+		);
+
+		$this->assertSame( '#111111', $values['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * Palette options whose "active" pointer does not name a set.
+	 *
+	 * @return Generator
+	 */
+	public function absentActiveProvider(): Generator {
+		$entries = [
+			[
+				'color' => '#111111',
+				'name'  => 'P1',
+				'slug'  => 'palette1',
+			],
+		];
+
+		yield 'active absent' => [ 'palette' => [ 'palette' => $entries ] ];
+		yield 'active empty' => [
+			'palette' => [
+				'active'  => '',
+				'palette' => $entries,
+			],
+		];
+	}
+
+	/**
+	 * An "active" pointer naming a set that does not exist yields nothing, matching the empty values
+	 * the theme renders in that case.
+	 *
+	 * @return void
+	 */
+	public function testYieldsNothingWhenActiveNamesAMissingSet(): void {
+		$snapshot                      = $this->snapshot( 'palette' );
+		$snapshot['palette']['active'] = 'fourth-palette';
+
+		$this->assertSame( [], ( new Style_Guide_Mapper() )->map( $snapshot, self::SLOT_TOKENS ) );
+	}
+
+	/**
+	 * A stored value that is not a usable color leaves the token to its baseline value.
+	 *
+	 * @dataProvider unusableColorProvider
+	 *
+	 * @param string $color The value stored on the slot.
+	 *
+	 * @return void
+	 */
+	public function testSkipsUnusableColors( string $color ): void {
+		$values = ( new Style_Guide_Mapper() )->map(
+			[
+				'palette'  => [
+					'active'  => 'palette',
+					'palette' => [
+						[
+							'color' => $color,
+							'name'  => 'P1',
+							'slug'  => 'palette1',
+						],
+					],
+				],
+				'settings' => [],
+			],
+			self::SLOT_TOKENS
+		);
+
+		$this->assertArrayNotHasKey( 'primitive.color.brand.primary', $values );
+	}
+
+	/**
+	 * Values the theme can store that must never become a token value.
+	 *
+	 * @return Generator
+	 */
+	public function unusableColorProvider(): Generator {
+		yield 'complement marker' => [ 'color' => '#FfFfFf' ];
+		yield 'empty' => [ 'color' => '' ];
+		yield 'whitespace' => [ 'color' => '   ' ];
+		yield 'css var' => [ 'color' => 'var(--global-palette1)' ];
+		yield 'gradient' => [ 'color' => 'linear-gradient(#fff, #000)' ];
+		yield 'bare word' => [ 'color' => 'red' ];
+	}
+
+	/**
+	 * Every color notation the theme's picker can store is accepted.
+	 *
+	 * @dataProvider usableColorProvider
+	 *
+	 * @param string $color The value stored on the slot.
+	 *
+	 * @return void
+	 */
+	public function testAcceptsHexRgbaAndHsla( string $color ): void {
+		$values = ( new Style_Guide_Mapper() )->map(
+			[
+				'palette'  => [
+					'active'  => 'palette',
+					'palette' => [
+						[
+							'color' => $color,
+							'name'  => 'P1',
+							'slug'  => 'palette1',
+						],
+					],
+				],
+				'settings' => [],
+			],
+			self::SLOT_TOKENS
+		);
+
+		$this->assertSame( $color, $values['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * Color notations the theme's picker produces.
+	 *
+	 * @return Generator
+	 */
+	public function usableColorProvider(): Generator {
+		yield 'hex 3' => [ 'color' => '#abc' ];
+		yield 'hex 6' => [ 'color' => '#3182CE' ];
+		yield 'hex 8' => [ 'color' => '#aabbccdd' ];
+		yield 'rgb' => [ 'color' => 'rgb(1,2,3)' ];
+		yield 'rgba' => [ 'color' => 'rgba(0,0,0,.5)' ];
+		yield 'hsl' => [ 'color' => 'hsl(10 20% 30%)' ];
+		yield 'hsla' => [ 'color' => 'hsla(10,20%,30%,.4)' ];
+	}
+
+	/**
+	 * A claimed slot the theme's set does not carry is left out rather than mapped to an empty value.
+	 *
+	 * @return void
+	 */
+	public function testIgnoresSlotTokensNotInTheSet(): void {
+		$values = ( new Style_Guide_Mapper() )->map(
+			[
+				'palette'  => [
+					'active'  => 'palette',
+					'palette' => [
+						[
+							'color' => '#111111',
+							'name'  => 'P1',
+							'slug'  => 'palette1',
+						],
+					],
+				],
+				'settings' => [],
+			],
+			self::SLOT_TOKENS
+		);
+
+		$this->assertSame( [ 'primitive.color.brand.primary' => '#111111' ], $values );
+	}
+
+	/**
+	 * The mapper can never introduce a token id the caller did not ask for, however many slots the
+	 * theme stores. That is what keeps the baseline decorator unable to add ids.
+	 *
+	 * @return void
+	 */
+	public function testProducesNoTokenIdOutsideSlotTokens(): void {
+		$entries = [];
+
+		foreach ( range( 1, 15 ) as $index ) {
+			$entries[] = [
+				'color' => sprintf( '#%02d0000', $index ),
+				'name'  => 'P' . $index,
+				'slug'  => 'palette' . $index,
+			];
+		}
+
+		$values = ( new Style_Guide_Mapper() )->map(
+			[
+				'palette'  => [
+					'active'  => 'palette',
+					'palette' => $entries,
+				],
+				'settings' => [],
+			],
+			self::SLOT_TOKENS
+		);
+
+		$this->assertEmpty( array_diff( array_keys( $values ), array_values( self::SLOT_TOKENS ) ) );
+		$this->assertCount( 3, $values );
+	}
+
+	/**
+	 * Malformed entries in the stored set are skipped without affecting their siblings.
+	 *
+	 * @return void
+	 */
+	public function testSkipsMalformedEntries(): void {
+		$values = ( new Style_Guide_Mapper() )->map(
+			[
+				'palette'  => [
+					'active'  => 'palette',
+					'palette' => [
+						'not-an-array',
+						[ 'color' => '#111111' ],
+						[ 'slug' => 'palette2' ],
+						[
+							'color' => 123,
+							'slug'  => 'palette2',
+						],
+						[
+							'color' => '#333333',
+							'slug'  => 'palette3',
+						],
+					],
+				],
+				'settings' => [],
+			],
+			self::SLOT_TOKENS
+		);
+
+		$this->assertSame( [ 'primitive.color.neutral.900' => '#333333' ], $values );
+	}
+
+	/**
+	 * A slot the theme leaves unusable is not mapped, so the token keeps its shipped baseline value and
+	 * the palette filter answers that slot with it.
+	 *
+	 * Pinned deliberately: the theme renders an empty custom property for such a slot, while the plugin
+	 * renders the shipped color. That difference is a known consequence of "tokens always win" and is
+	 * raised as an open question rather than changed here.
+	 *
+	 * @return void
+	 */
+	public function testAnUnusableSlotIsLeftToTheBaseline(): void {
+		$values = ( new Style_Guide_Mapper() )->map(
+			[
+				'palette'  => [
+					'active'  => 'palette',
+					'palette' => [
+						[
+							'color' => '',
+							'name'  => 'P1',
+							'slug'  => 'palette1',
+						],
+						[
+							'color' => '#333333',
+							'name'  => 'P3',
+							'slug'  => 'palette3',
+						],
+					],
+				],
+				'settings' => [],
+			],
+			self::SLOT_TOKENS
+		);
+
+		$this->assertArrayNotHasKey( 'primitive.color.brand.primary', $values );
+		$this->assertSame( '#333333', $values['primitive.color.neutral.900'] );
+	}
+
+	/**
+	 * A snapshot carrying all three palette sets, each with its own color on palette1.
+	 *
+	 * @param string $active The set to mark active.
+	 *
+	 * @return array{palette: array<string, mixed>, settings: array<string, mixed>}
+	 */
+	private function snapshot( string $active ): array {
+		$set = static function ( string $color ): array {
+			return [
+				[
+					'color' => $color,
+					'name'  => 'P1',
+					'slug'  => 'palette1',
+				],
+			];
+		};
+
+		return [
+			'palette'  => [
+				'active'         => $active,
+				'palette'        => $set( '#111111' ),
+				'second-palette' => $set( '#222222' ),
+				'third-palette'  => $set( '#333333' ),
+			],
+			'settings' => [],
+		];
+	}
+}


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/3f7bf1ff5960448399a02dd96fd18f49)

## Summary

The pure translation from a Kadence theme Style Guide snapshot to `token id => $value`.

No WordPress calls, no globals, no I/O: raw theme data in, a token map out. Nothing uses it yet —
the reader that feeds it and the overlay that composes it are the next PR, and nothing consumes the
result until the baseline decorator.

Split out from the reader PR so the rules here can be reviewed on their own, without needing any
knowledge of the theme's WordPress surface.

## The rules it encodes

- **The active set wins.** The theme's `active` pointer names which of `palette`, `second-palette`
  or `third-palette` it renders; a missing or empty pointer means the first, and a pointer naming a
  set that does not exist yields nothing — matching the empty values the theme itself renders in
  that case.
- **`#FfFfFf` on `palette10` is a marker, not a colour.** The theme uses it to mean "derive the
  complement of palette1 at render time", so it must never become a token value.
- **Only colour literals.** Hex, `rgb()/rgba()`, `hsl()/hsla()`. An empty string, a CSS variable or
  a gradient is skipped, so a bad theme value cannot reach the resolver.
- **It can only emit ids the caller passed in.** The slot-to-token map comes from the registry, so
  the mapper can never introduce a token id of its own. That is what later lets the baseline
  decorator promise it adds no ids.

## Test plan

`slic run wpunit Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_MapperTest`

Provider-driven: each of the three palette sets, both fallback shapes, a pointer naming a missing
set, every colour notation the theme's picker produces, every unusable value it can store, malformed
entries, a slot the set does not carry, and a 15-slot set proving the produced ids stay a subset of
what the caller asked for.

One behaviour is pinned deliberately rather than changed: a slot the theme leaves unusable is left
to its baseline value, so the plugin renders the shipped colour where the theme renders an empty
custom property. Raised as an open question rather than altered late.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved theme palette handling by selecting the active palette and applying valid slot colors consistently.
  * Added safer handling for incomplete, malformed, or unmapped color entries.
  * Preserved existing defaults when a usable color is unavailable.

* **Tests**
  * Added comprehensive coverage for palette selection, fallback behavior, color validation, slot matching, and malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->