### PR TITLE
[DTM] SOFT-4320 [8/8]: store only the default palette swatches the site changes

### DIFF
--- a/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
+++ b/includes/resources/Design_Tokens/Resolver/Effective_Palettes.php
@@ -193,6 +193,10 @@ final class Effective_Palettes {
 	 * keyed by the color-token dot-path it sets. A swatch whose `$value` is a RESET sentinel (null under
 	 * `$value`) is omitted, so the token keeps its baseline value. Empty when the palette is absent.
 	 *
+	 * Reads the EFFECTIVE section, so it is neither the full color set nor what the palette stores. For a
+	 * complete set use {@see complete_swatch_values()}; to ask what a palette actually stores use
+	 * {@see stored_swatch_values()}.
+	 *
 	 * @since TBD
 	 *
 	 * @param string $id   The palette id.
@@ -325,6 +329,47 @@ final class Effective_Palettes {
 		$section = $this->palettes_of( $this->baseline->document() );
 
 		return $this->swatch_values_of( $section, $this->pointer_of( $section, Extensions::get_default_key() ) );
+	}
+
+	/**
+	 * The `{ token => $value }` colors a palette ACTUALLY STORES, read straight from the overrides document
+	 * with no baseline merge behind it. This is the "has its own value" question, and it is not the same as
+	 * {@see swatch_values()}: the default palette also lives in the baseline, so its effective node carries
+	 * every shipped swatch whether or not the site has ever edited one.
+	 *
+	 * The default palette stores only the swatches it changes — a swatch left at the baseline keeps its row
+	 * but drops `$value`, so the token follows whatever the baseline resolves to (on a Kadence site, the
+	 * theme's Style Guide). Reading the effective node instead would report every one of those as stored.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id   The palette id.
+	 * @param string $slug The token library slug.
+	 *
+	 * @return array<string, string> token dot-path => the stored literal-or-alias value.
+	 */
+	public function stored_swatch_values( string $id, string $slug = 'default' ): array {
+		return $this->swatch_values_of( $this->palettes_of( $this->raw( $slug ) ), $id );
+	}
+
+	/**
+	 * A palette's COMPLETE color set: the shipped baseline colors, overlaid with the library default palette's
+	 * own swatches, overlaid with the palette's. Every baseline token resolves to a value here, which
+	 * {@see swatch_values()} and {@see effective_swatch_values()} no longer guarantee — a swatch the default
+	 * palette leaves at the baseline stores no `$value` at all.
+	 *
+	 * Use this wherever a caller needs the color a token WILL render as. Use the sparser accessors only to ask
+	 * what a palette stores.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id   The palette id.
+	 * @param string $slug The token library slug.
+	 *
+	 * @return array<string, string> token dot-path => literal-or-alias value.
+	 */
+	public function complete_swatch_values( string $id, string $slug = 'default' ): array {
+		return array_merge( $this->baseline_swatch_values(), $this->effective_swatch_values( $id, $slug ) );
 	}
 
 	/**

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -734,10 +734,10 @@ final class Palettes_Controller extends Controller {
 	 *   - `baseline` — whether the shipped palette defines this swatch. A baseline swatch's row is permanent
 	 *     (see {@see guard_baseline_swatches()}), so the editor offers Reset for it and Delete only for the
 	 *     rest.
-	 *   - `overridden` — whether there is anything to undo. On the DEFAULT palette that means the value
-	 *     differs from the shipped one; on any other palette it means the palette stores its own delta rather
-	 *     than inheriting. Measuring the default palette against its own deltas would mark every swatch
-	 *     overridden, since the default stores them all.
+	 *   - `overridden` — whether there is anything to undo: the palette stores its own value for the swatch.
+	 *     One test serves every palette, the default included, because the default palette stores only the
+	 *     swatches the site changed; a swatch left at the baseline keeps its row but stores no `$value`, so
+	 *     it reads as not overridden and there is nothing to undo.
 	 *
 	 * @since TBD
 	 *

--- a/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
+++ b/includes/resources/Design_Tokens/Rest/V1/Palettes_Controller.php
@@ -392,9 +392,9 @@ final class Palettes_Controller extends Controller {
 			return $locked;
 		}
 
-		// The default palette stores every swatch (it is the base). A non-default palette stores only its
-		// DELTAS: a swatch equal to the default palette's value is inherited, not persisted, so the palette
-		// resolves against the default for everything it does not change.
+		// The default palette keeps every swatch row (it is the structure template). A non-default palette
+		// stores only its DELTAS: a swatch equal to the default palette's value is inherited, not persisted, so
+		// the palette resolves against the default for everything it does not change.
 		$node = $this->prepare_for_storage( $node, $slug, $id === $this->palettes->default_palette( $slug ) );
 
 		// Replace the palette node wholesale (remove-then-merge) rather than a plain merge. A delta-reduced node
@@ -511,7 +511,7 @@ final class Palettes_Controller extends Controller {
 			// instead — a token that is stale or no longer a registered color must still be rejected. A
 			// token this palette has never stored has no current value here; that genuinely-new-token case
 			// is left to the downstream DTCG schema validation, which already rejects it.
-			$current_value = $this->palettes->swatch_values( $id, $slug )[ $token ] ?? null;
+			$current_value = $this->palettes->complete_swatch_values( $id, $slug )[ $token ] ?? null;
 
 			if ( is_string( $current_value ) ) {
 				$guard = $this->guard_swatch_target( $id, $token, $current_value );
@@ -527,7 +527,7 @@ final class Palettes_Controller extends Controller {
 		}
 
 		if ( isset( $fields['value'] ) ) {
-			$default = $this->palettes->swatch_values( $default_id, $slug );
+			$default = $this->palettes->complete_swatch_values( $default_id, $slug );
 
 			// A non-default swatch equal to the default value is inherited, not stored, so setting it back to
 			// the default reverts it — identical to a DELETE. Only applies to a value write; a label-only
@@ -574,9 +574,10 @@ final class Palettes_Controller extends Controller {
 
 		$baseline = $this->palettes->baseline_swatch_values();
 
-		// The default palette is the base — it has nothing to inherit from — so a baseline swatch there is
-		// restored to its shipped value rather than dropped. Every other case drops the palette's own entry:
-		// a non-default palette's delta (leaving it inherited) or a user-added row (retiring it).
+		// The default palette's rows are the permanent swatch set, so a baseline swatch there is written back
+		// at its baseline value rather than dropped — {@see reduce_default_to_overrides()} then strips that
+		// value on the way to the store, leaving the row following the baseline again. Every other case drops
+		// the palette's own entry: a non-default palette's delta (leaving it inherited) or a user-added row.
 		$node = ( $id === $this->palettes->default_palette( $slug ) && array_key_exists( $token, $baseline ) )
 			? $this->set_swatch_fields_in_node( $node, $token, [ 'value' => $baseline[ $token ] ], $slug )
 			: $this->remove_swatch_from_node( $node, $token );
@@ -747,11 +748,10 @@ final class Palettes_Controller extends Controller {
 	 */
 	private function effective_view( string $id, string $slug ): array {
 		$template = $this->palettes->palette( $this->palettes->default_palette( $slug ), $slug ) ?? [];
-		$deltas   = $this->palettes->swatch_values( $id, $slug );
+		$deltas   = $this->palettes->stored_swatch_values( $id, $slug );
 		$own      = $this->palettes->palette( $id, $slug ) ?? [];
 		$baseline = $this->palettes->baseline_swatch_values();
 
-		$is_default   = $id === $this->palettes->default_palette( $slug );
 		$token_key    = Extensions::get_swatch_token_key();
 		$label_key    = Extensions::get_label_key();
 		$value_key    = Sentinels::get_value_key();
@@ -776,15 +776,21 @@ final class Palettes_Controller extends Controller {
 					continue;
 				}
 
-				$token   = $swatch[ $token_key ];
-				$has_own = array_key_exists( $token, $deltas );
-				$value   = $has_own ? $deltas[ $token ] : ( $swatch[ $value_key ] ?? '' );
+				$token          = $swatch[ $token_key ];
+				$has_own        = array_key_exists( $token, $deltas );
+				$template_value = $swatch[ $value_key ] ?? null;
 
-				// The default palette stores every swatch, so "has its own value" is always true there and says
-				// nothing; what can be undone on it is a value that no longer matches the shipped one.
-				$overridden = $is_default
-					? ( array_key_exists( $token, $baseline ) && $baseline[ $token ] !== $value )
-					: $has_own;
+				// A swatch this palette does not store falls back to the template's value, and the template
+				// itself may not carry one — a default-palette swatch left at the baseline keeps its row but
+				// stores no `$value`. The baseline answers that last case, so the row shows the color the
+				// token really renders as (on a Kadence site, the theme's Style Guide color).
+				$value = $has_own
+					? $deltas[ $token ]
+					: ( is_string( $template_value ) && $template_value !== '' ? $template_value : ( $baseline[ $token ] ?? '' ) );
+
+				// There is something to reset exactly when the palette stores its own value — true for every
+				// palette now that the default stores only the swatches it changes.
+				$overridden = $has_own;
 
 				$swatches[] = [
 					$token_key   => $token,
@@ -819,12 +825,13 @@ final class Palettes_Controller extends Controller {
 	 *
 	 * @param array<string, mixed> $node       The full palette node from the request.
 	 * @param string               $slug       The token library slug.
-	 * @param bool                 $is_default Whether this is the library's default palette (which keeps every swatch).
+	 * @param bool                 $is_default Whether this is the library's default palette (which keeps every swatch row;
+	 *                                         {@see reduce_default_to_overrides()} then strips the values it does not need).
 	 *
 	 * @return array<string, mixed>
 	 */
 	private function prepare_for_storage( array $node, string $slug, bool $is_default ): array {
-		$default      = $is_default ? [] : $this->palettes->swatch_values( $this->palettes->default_palette( $slug ), $slug );
+		$default      = $is_default ? [] : $this->palettes->complete_swatch_values( $this->palettes->default_palette( $slug ), $slug );
 		$token_key    = Extensions::get_swatch_token_key();
 		$value_key    = Sentinels::get_value_key();
 		$swatches_key = Extensions::get_swatches_key();
@@ -853,7 +860,8 @@ final class Palettes_Controller extends Controller {
 				$token = $swatch[ $token_key ];
 				$value = $swatch[ $value_key ] ?? null;
 
-				// The default palette keeps every swatch; a non-default palette keeps only swatches that differ
+				// The default palette keeps every swatch ROW — it is the structure template, and dropping a row
+				// there removes it from every palette. A non-default palette keeps only swatches that differ
 				// from the default value (the deltas).
 				if ( $is_default || ! ( array_key_exists( $token, $default ) && $default[ $token ] === $value ) ) {
 					$swatches[] = $swatch;
@@ -1381,10 +1389,75 @@ final class Palettes_Controller extends Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	private function write_palette_node( string $slug, string $id, array $node ) {
+		if ( $id === $this->palettes->default_palette( $slug ) ) {
+			$node = $this->reduce_default_to_overrides( $node );
+		}
+
 		$document  = $this->mutator->remove_by_keys( $this->stored_document( $slug ), $this->palette_keys( $id ) );
 		$candidate = $this->mutator->merge( $document, $this->palette_partial( $id, $node ) );
 
 		return $this->validate_and_save( $candidate, $id, $slug );
+	}
+
+	/**
+	 * Reduce the DEFAULT palette to the swatches it actually changes: drop `$value` from every swatch whose
+	 * color already matches the baseline, keeping the row itself. The row has to stay — it is part of the
+	 * permanent swatch set {@see guard_baseline_swatches()} protects, and the stored groups list REPLACES the
+	 * baseline's once anything is stored ({@see Effective_Palettes::without_superseded_groups()}), so a
+	 * dropped row would vanish from every palette.
+	 *
+	 * Without this a single edit freezes the whole palette. Every write path rebuilds the node from
+	 * {@see Effective_Palettes::palette()}, which is the baseline merged with the overrides, so the node
+	 * carries a `$value` for all 17 swatches whether or not the site chose any of them. Persisting those
+	 * turns each one into a stored override: the palette stops following the baseline, and on a Kadence site
+	 * that means it stops following the theme's Style Guide — change a color in the Customizer afterwards and
+	 * the Style Library still shows the color that was captured at write time.
+	 *
+	 * Runs here rather than in {@see prepare_for_storage()} because the swatch endpoints reach the store
+	 * without passing through that method; this is the one choke point all three write paths share.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string, mixed> $node The default palette node being written.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function reduce_default_to_overrides( array $node ): array {
+		$baseline     = $this->palettes->baseline_swatch_values();
+		$groups_key   = Extensions::get_groups_key();
+		$swatches_key = Extensions::get_swatches_key();
+		$token_key    = Extensions::get_swatch_token_key();
+		$value_key    = Sentinels::get_value_key();
+
+		$groups = $node[ $groups_key ] ?? [];
+
+		if ( ! is_array( $groups ) ) {
+			return $node;
+		}
+
+		foreach ( $groups as $gi => $group ) {
+			if ( ! is_array( $group ) || ! isset( $group[ $swatches_key ] ) || ! is_array( $group[ $swatches_key ] ) ) {
+				continue;
+			}
+
+			foreach ( $group[ $swatches_key ] as $si => $swatch ) {
+				if ( ! is_array( $swatch ) || ! isset( $swatch[ $token_key ] ) || ! is_string( $swatch[ $token_key ] ) ) {
+					continue;
+				}
+
+				$token = $swatch[ $token_key ];
+
+				if ( ! array_key_exists( $token, $baseline ) || ( $swatch[ $value_key ] ?? null ) !== $baseline[ $token ] ) {
+					continue;
+				}
+
+				unset( $groups[ $gi ][ $swatches_key ][ $si ][ $value_key ] );
+			}
+		}
+
+		$node[ $groups_key ] = $groups;
+
+		return $node;
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Rest/V1/Palettes_ControllerTest.php
@@ -752,13 +752,13 @@ final class Palettes_ControllerTest extends TestCase {
 	 * @return void
 	 */
 	public function testUpdateSwatchAcceptsALabelOnlyWrite(): void {
-		$before = $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'];
+		$before = $this->palettes->complete_swatch_values( 'default' )['primitive.color.brand.primary'];
 
 		$response = $this->controller->update_swatch(
 			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', null, 'Brand One' )
 		);
 
-		$this->assertSame( $before, $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
+		$this->assertSame( $before, $this->palettes->complete_swatch_values( 'default' )['primitive.color.brand.primary'] );
 		$this->assertSame( 'Brand One', $this->swatch_label( 'default', 'primitive.color.brand.primary' ) );
 
 		$this->assertEmbeddedListingShape( $response->get_data() );
@@ -909,7 +909,12 @@ final class Palettes_ControllerTest extends TestCase {
 		);
 
 		$this->assertNotInstanceOf( WP_Error::class, $result );
-		$this->assertSame( '#3182CE', $this->palettes->swatch_values( 'default' )['primitive.color.brand.primary'] );
+		$this->assertSame( '#3182CE', $this->palettes->complete_swatch_values( 'default' )['primitive.color.brand.primary'] );
+		$this->assertArrayNotHasKey(
+			'primitive.color.brand.primary',
+			$this->palettes->stored_swatch_values( 'default' ),
+			'A reverted swatch stops being stored, so it follows the baseline again.'
+		);
 	}
 
 	/**
@@ -929,7 +934,7 @@ final class Palettes_ControllerTest extends TestCase {
 			$this->swatch_request( 'DELETE', 'default', 'primitive.color.brand.primary' )
 		);
 
-		$values = $this->palettes->swatch_values( 'default' );
+		$values = $this->palettes->complete_swatch_values( 'default' );
 
 		$this->assertSame( '#3182CE', $values['primitive.color.brand.primary'] );
 		$this->assertSame( '#00ff00', $values['primitive.color.brand.button'], 'Only the reverted swatch may change.' );
@@ -969,12 +974,12 @@ final class Palettes_ControllerTest extends TestCase {
 	public function testDeleteSwatchIsIdempotent( string $id, string $token ): void {
 		$this->controller->update_item( $this->write_request( 'ocean', 'Ocean', '#0000ff' ) );
 
-		$before = $this->palettes->swatch_values( $id );
+		$before = $this->palettes->complete_swatch_values( $id );
 
 		$this->controller->delete_swatch( $this->swatch_request( 'DELETE', $id, $token ) );
 		$this->controller->delete_swatch( $this->swatch_request( 'DELETE', $id, $token ) );
 
-		$this->assertSame( $before, $this->palettes->swatch_values( $id ) );
+		$this->assertSame( $before, $this->palettes->complete_swatch_values( $id ) );
 	}
 
 	/**
@@ -1109,6 +1114,66 @@ final class Palettes_ControllerTest extends TestCase {
 
 		$this->assertNotInstanceOf( WP_Error::class, $result );
 		$this->assertSame( [ 'primitive.color.brand.primary' => '#DD6B20' ], $this->palettes->swatch_values( 'ocean' ) );
+	}
+
+	/**
+	 * Saving the whole default palette — the shape the Style Library sends — persists only the swatch that
+	 * differs from the baseline. The request carries a value for every swatch, so without the reduction each
+	 * one becomes a stored override and the palette stops following the baseline.
+	 *
+	 * @return void
+	 */
+	public function testUpdateItemStoresOnlyTheChangedDefaultSwatches(): void {
+		$request = $this->default_palette_request();
+		$groups  = $request->get_param( 'groups' );
+
+		$groups[0]['swatches'][3]['$value'] = '#abcdef';
+		$request->set_param( 'groups', $groups );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->controller->update_item( $request ) );
+
+		$this->assertSame(
+			[ 'primitive.color.brand.button' => '#abcdef' ],
+			$this->palettes->stored_swatch_values( 'default' )
+		);
+	}
+
+	/**
+	 * Writing one swatch through the sub-route stores that swatch alone, leaving its siblings with nothing
+	 * stored of their own.
+	 *
+	 * @return void
+	 */
+	public function testUpdateSwatchStoresOnlyTheEditedDefaultSwatch(): void {
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', '#0000ff' )
+		);
+
+		$this->assertSame(
+			[ 'primitive.color.brand.primary' => '#0000ff' ],
+			$this->palettes->stored_swatch_values( 'default' )
+		);
+	}
+
+	/**
+	 * A default-palette swatch the site has not edited has nothing to reset, so the Style Library shows no
+	 * reset control for it — the flag tracks a stored override, not a value that happens to differ from the
+	 * shipped hex.
+	 *
+	 * @return void
+	 */
+	public function testEffectiveViewMarksOnlyStoredDefaultSwatchesAsOverridden(): void {
+		$this->controller->update_swatch(
+			$this->swatch_request( 'PUT', 'default', 'primitive.color.brand.primary', '#0000ff' )
+		);
+
+		$swatches = $this->view_swatches( 'default' );
+
+		$this->assertTrue( $swatches['primitive.color.brand.primary']['overridden'] );
+		$this->assertSame( '#0000ff', $swatches['primitive.color.brand.primary']['$value'] );
+
+		$this->assertFalse( $swatches['primitive.color.brand.button']['overridden'] );
+		$this->assertSame( '#3633e1', $swatches['primitive.color.brand.button']['$value'], 'An unedited swatch still shows its color.' );
 	}
 
 	/**

--- a/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_IntegrationTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Theme_Style_Guide/Style_Guide_IntegrationTest.php
@@ -4,6 +4,7 @@
 namespace Tests\wpunit\Resources\Design_Tokens\Theme_Style_Guide;
 
 use Generator;
+use KadenceWP\KadenceBlocks\Design_Tokens\Database\Active_Token_Library_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Database\Token_Store;
 use KadenceWP\KadenceBlocks\Design_Tokens\Document\Mutator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Registry\Baseline\Json_Baseline_Document;
@@ -14,10 +15,14 @@ use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Document;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Palettes;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Effective_Version;
 use KadenceWP\KadenceBlocks\Design_Tokens\Resolver\Token_Resolver;
+use KadenceWP\KadenceBlocks\Design_Tokens\Rest\V1\Palettes_Controller;
+use KadenceWP\KadenceBlocks\Design_Tokens\Schema\Validation\Dtcg_Validator;
 use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Mapper;
 use KadenceWP\KadenceBlocks\Design_Tokens\Theme_Style_Guide\Style_Guide_Overlay;
 use Tests\Support\Classes\Fake_Style_Guide_Source;
 use Tests\Support\Classes\TestCase;
+use WP_Error;
+use WP_REST_Request;
 
 final class Style_Guide_IntegrationTest extends TestCase {
 
@@ -205,6 +210,100 @@ final class Style_Guide_IntegrationTest extends TestCase {
 
 		$this->assertSame( '#a10001', $swatches['primitive.color.brand.primary'] );
 		$this->assertSame( '#a30003', $swatches['primitive.color.neutral.900'] );
+	}
+
+	/**
+	 * Editing one swatch in the Style Library must not freeze the rest of the palette. Every write path
+	 * rebuilds the palette node from the baseline merged with the overrides, so before this the node
+	 * carried a value for all 17 swatches and persisting them turned each into an override — the palette
+	 * stopped following the theme, and a later Customizer change no longer reached it.
+	 *
+	 * @return void
+	 */
+	public function testEditingOneSwatchLeavesTheRestFollowingTheTheme(): void {
+		$source = Fake_Style_Guide_Source::with_palette( self::THEME_COLORS );
+
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_param( 'id', 'default' );
+		$request->set_param( 'token', 'primitive.color.brand.primary' );
+		$request->set_param( '$value', '#0ffc2c' );
+
+		$this->assertNotInstanceOf( WP_Error::class, $this->controller_for( $source )->update_swatch( $request ) );
+
+		// Only the edited token is stored; the other 16 keep their rows but no value of their own.
+		$this->assertSame(
+			[ 'primitive.color.brand.primary' => '#0ffc2c' ],
+			$this->palettes_for( $source )->stored_swatch_values( 'default' )
+		);
+
+		// The user changes a color in the Customizer.
+		$changed             = self::THEME_COLORS;
+		$changed['palette3'] = '#0c0c0c';
+
+		$after = $this->palettes_for( Fake_Style_Guide_Source::with_palette( $changed ) )->complete_swatch_values( 'default' );
+
+		$this->assertSame( '#0ffc2c', $after['primitive.color.brand.primary'], 'The edited swatch stays the user\'s choice.' );
+		$this->assertSame( '#0c0c0c', $after['primitive.color.neutral.900'], 'Every other swatch follows the Customizer.' );
+	}
+
+	/**
+	 * Resetting the edited swatch hands the token back to the theme rather than to the shipped hex.
+	 *
+	 * @return void
+	 */
+	public function testResettingASwatchHandsTheTokenBackToTheTheme(): void {
+		$source     = Fake_Style_Guide_Source::with_palette( self::THEME_COLORS );
+		$controller = $this->controller_for( $source );
+
+		$write = new WP_REST_Request( 'PUT' );
+		$write->set_param( 'id', 'default' );
+		$write->set_param( 'token', 'primitive.color.brand.primary' );
+		$write->set_param( '$value', '#0ffc2c' );
+		$controller->update_swatch( $write );
+
+		$reset = new WP_REST_Request( 'DELETE' );
+		$reset->set_param( 'id', 'default' );
+		$reset->set_param( 'token', 'primitive.color.brand.primary' );
+
+		$this->assertNotInstanceOf( WP_Error::class, $controller->delete_swatch( $reset ) );
+
+		$palettes = $this->palettes_for( $source );
+
+		$this->assertSame( [], $palettes->stored_swatch_values( 'default' ) );
+		$this->assertSame( '#a10001', $palettes->complete_swatch_values( 'default' )['primitive.color.brand.primary'] );
+	}
+
+	/**
+	 * The palette reader over a theme-decorated baseline.
+	 *
+	 * @param Fake_Style_Guide_Source $source The Style Guide source.
+	 *
+	 * @return Effective_Palettes
+	 */
+	private function palettes_for( Fake_Style_Guide_Source $source ): Effective_Palettes {
+		return new Effective_Palettes( $this->baseline_for( $source ), $this->store, $this->container->get( Mutator::class ) );
+	}
+
+	/**
+	 * The palette REST controller composed over a theme-decorated baseline, the way the container composes
+	 * the real one on a Kadence site.
+	 *
+	 * @param Fake_Style_Guide_Source $source The Style Guide source.
+	 *
+	 * @return Palettes_Controller
+	 */
+	private function controller_for( Fake_Style_Guide_Source $source ): Palettes_Controller {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		return new Palettes_Controller(
+			$this->store,
+			$this->container->get( Mutator::class ),
+			$this->resolver_for( $source ),
+			$this->container->get( Dtcg_Validator::class ),
+			$this->palettes_for( $source ),
+			$this->registry,
+			$this->container->get( Active_Token_Library_Store::class )
+		);
 	}
 
 	/**


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/3f7bf1ff5960448399a02dd96fd18f49)

Part of the SOFT-4320 stack. Depends on #1511.

## The problem

Editing one color in the Style Library froze the whole default palette.

Every write path rebuilds the palette node from `Effective_Palettes::palette()`, which is the baseline merged with the stored overrides. That node carries a `$value` for all 17 swatches whether or not the site ever chose any of them, and the node was persisted whole. One edit therefore turned all 17 into stored overrides.

After that the palette stopped following the baseline. On a Kadence site that means it stopped following the theme: change a color in the Customizer and the Style Library still shows the color captured at write time, with a Reset button next to it. On a site with no Kadence theme the same freeze happened against the shipped `baseline.json` hexes.

The swatch endpoints made this easy to hit, because they never passed through `prepare_for_storage()` at all.

## The fix

`write_palette_node()` — the one choke point all three write paths share — now reduces the default palette to what the site actually changed. A swatch whose color already matches the baseline keeps its row but drops its `$value`.

The row has to stay. It is part of the permanent swatch set `guard_baseline_swatches()` protects, and once anything is stored the stored `groups` list replaces the baseline's, so a dropped row would disappear from every palette. Dropping only the value is enough: `swatch_values_of()` already skips a swatch with no value "so the token keeps its baseline value".

Reading it back needed two things:

- **`Effective_Palettes::stored_swatch_values()`** — what a palette actually stores, read straight from the overrides with no baseline behind it. `swatch_values()` reads the effective section, and the default palette also lives in the baseline, so it could not answer "does this swatch have its own value?".
- **`Effective_Palettes::complete_swatch_values()`** — the color a token will render as: baseline, overlaid with the library default's swatches, overlaid with the palette's. The four call sites that needed a complete value set now use it.

`effective_view()` uses the first for the `overridden` flag, so the Reset control appears exactly when the site stored something, and falls back to the baseline for display so an unedited swatch still shows its real color.

## Behavior

| | Before | After |
|---|---|---|
| Edit one default swatch | 17 swatches stored | 1 stored |
| Change a Customizer color afterwards | Style Library keeps the old color | Every unedited swatch follows |
| Reset a swatch | Restores the shipped hex | Hands the token back to the baseline — the theme's color on a Kadence site |
| No Kadence theme | — | Unchanged: the baseline is the shipped `baseline.json` |

No migration. Nothing is running the Style Library yet, and a stored document with all 17 values still resolves the same way — it just keeps overriding until each swatch is reset.

## Tests

5 new tests, all of which fail without the fix:

- `Style_Guide_IntegrationTest` — editing one swatch leaves the rest following the theme across a Customizer change; resetting hands the token back to the theme.
- `Palettes_ControllerTest` — a full-node write and a single-swatch write each store only what changed; the effective view marks only stored swatches as overridden. These run against the undecorated shipped baseline, so they cover the no-theme case.

Full wpunit suite green: 2835 tests, 8971 assertions.

Verified on a Kadence site by reproducing the reported flow: set `brand.primary` in the Style Library, change palette 3 in the Customizer, and confirm the edited swatch keeps its color while the changed one follows and shows no Reset control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012enLvkgTEK1APG8oUYUCzr



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Palette views now include complete effective colors, including inherited and baseline values.
  * Editing a default palette stores only the swatches that differ from the baseline, while preserving the remaining palette structure.
  * Updating one swatch no longer interrupts other swatches from following theme-derived color changes.
  * Resetting a swatch removes its override and restores the corresponding theme color.
* **Bug Fixes**
  * Improved consistency between displayed palette values, stored overrides, and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->