### PR TITLE
[DTM] SOFT-4321 [1/5]: Floor the shadow blur field at zero

### DIFF
--- a/src/style-library/__tests__/shadow-field-blur-floor.test.js
+++ b/src/style-library/__tests__/shadow-field-blur-floor.test.js
@@ -1,0 +1,155 @@
+/* eslint-env jest */
+/**
+ * External dependencies
+ */
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+// Stand-ins, not the real controls: this suite is only after the numeric axes, and the real
+// `Dropdown`/`ColorPicker` pull in a popover tree that has nothing to do with the blur floor.
+jest.mock('@wordpress/components', () => ({
+	__experimentalNumberControl: ({ value, onChange, disabled, min }) => (
+		<input
+			type="number"
+			value={value}
+			min={min}
+			disabled={disabled}
+			onChange={(event) => onChange(event.target.value)}
+		/>
+	),
+	ColorIndicator: () => null,
+	ColorPicker: () => null,
+	Dropdown: ({ renderToggle }) => renderToggle({ isOpen: false, onToggle: () => {} }),
+	ToggleControl: ({ label }) => <div>{label}</div>,
+}));
+
+jest.mock('@wordpress/i18n', () => ({ __: (text) => text }));
+jest.mock('../components/molecules/fields/ShadowField.scss', () => ({}), { virtual: true });
+
+// eslint-disable-next-line import/first -- must follow the jest.mock calls above.
+import { ShadowField } from '../components/molecules/fields/ShadowField';
+
+let container;
+let root;
+
+beforeEach(() => {
+	global.IS_REACT_ACT_ENVIRONMENT = true;
+	container = document.createElement('div');
+	document.body.appendChild(container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	container.remove();
+	delete global.IS_REACT_ACT_ENVIRONMENT;
+});
+
+/**
+ * Mount the field and return its four numeric inputs, in X / Y / Blur / Spread order.
+ *
+ * @param {Function} onChange The change handler to pass through.
+ *
+ * @since TBD
+ *
+ * @return {Array<HTMLElement>} The rendered number inputs.
+ */
+function renderField(onChange = jest.fn()) {
+	act(() => {
+		root.render(
+			createElement(ShadowField, {
+				field: { label: 'Shadow' },
+				value: { color: '#000000', offsetX: 0, offsetY: 2, blur: 8, spread: 0, inset: false },
+				onChange,
+			})
+		);
+	});
+
+	return [...container.querySelectorAll('input[type="number"]')];
+}
+
+/**
+ * Type a value into one of the numeric inputs, the way a user replacing its contents would.
+ *
+ * @param {HTMLElement} input The input to type into.
+ * @param {string}      next  The value to type.
+ *
+ * @since TBD
+ *
+ * @return {void}
+ */
+function typeInto(input, next) {
+	act(() => {
+		Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, next);
+		input.dispatchEvent(new Event('change', { bubbles: true }));
+	});
+}
+
+describe('ShadowField blur floor', () => {
+	/**
+	 * Blur is floored at zero and the other three axes stay unbounded: CSS rejects a negative blur
+	 * radius, and one invalid component makes the browser drop the whole `box-shadow`.
+	 *
+	 * @return {void}
+	 */
+	it('floors only the blur input at zero', () => {
+		const [x, y, blur, spread] = renderField();
+
+		expect(blur.getAttribute('min')).toBe('0');
+		expect(x.getAttribute('min')).toBeNull();
+		expect(y.getAttribute('min')).toBeNull();
+		expect(spread.getAttribute('min')).toBeNull();
+	});
+
+	/**
+	 * A negative blur typed past the input's own `min` is still held at zero on the way to the stored
+	 * value, so the screen can never write a shadow that CSS discards.
+	 *
+	 * @return {void}
+	 */
+	it('clamps a typed negative blur to zero', () => {
+		const onChange = jest.fn();
+		const [, , blur] = renderField(onChange);
+
+		typeInto(blur, '-9');
+
+		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ blur: 0 }));
+	});
+
+	/**
+	 * The floor covers the whole shadow, not just the blur input: a negative blur already in the value
+	 * is held at zero by a write to any other field.
+	 *
+	 * @return {void}
+	 */
+	it('floors a negative blur already in the value when another field is edited', () => {
+		const onChange = jest.fn();
+		act(() => {
+			root.render(
+				createElement(ShadowField, {
+					field: { label: 'Shadow' },
+					value: { color: '#000000', offsetX: 0, offsetY: 2, blur: -6, spread: 0, inset: false },
+					onChange,
+				})
+			);
+		});
+
+		typeInto([...container.querySelectorAll('input[type="number"]')][0], '5');
+
+		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ offsetX: 5, blur: 0 }));
+	});
+
+	/**
+	 * A negative spread is valid CSS — it shrinks the shadow — so it is stored unchanged.
+	 *
+	 * @return {void}
+	 */
+	it('stores a negative spread unchanged', () => {
+		const onChange = jest.fn();
+		const [, , , spread] = renderField(onChange);
+
+		typeInto(spread, '-4');
+
+		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ spread: -4 }));
+	});
+});

--- a/src/style-library/components/molecules/fields/ShadowField.js
+++ b/src/style-library/components/molecules/fields/ShadowField.js
@@ -40,9 +40,26 @@ const DEFAULT_SHADOW = { color: '#000000', offsetX: 0, offsetY: 0, blur: 0, spre
 const NUMERIC_FIELDS = [
 	{ key: 'offsetX', label: __('X', 'kadence-blocks') },
 	{ key: 'offsetY', label: __('Y', 'kadence-blocks') },
-	{ key: 'blur', label: __('Blur', 'kadence-blocks') },
+	// Blur is the only field with a floor, for the reason `BoxShadowControl`'s own axis list gives:
+	// CSS rejects a negative blur radius, and one invalid component makes the browser drop the whole
+	// `box-shadow`, so a stray `-2` removes the shadow rather than softening it.
+	{ key: 'blur', label: __('Blur', 'kadence-blocks'), min: 0 },
 	{ key: 'spread', label: __('Spread', 'kadence-blocks') },
 ];
+
+/**
+ * Hold a numeric field's value at its own floor, when it has one.
+ *
+ * @param {number}  value The value being written.
+ * @param {?number} min   The field's floor, or undefined when it has none.
+ *
+ * @since TBD
+ *
+ * @return {number} The value, never below the floor.
+ */
+function clampToMin(value, min) {
+	return min === undefined ? value : Math.max(value, min);
+}
 
 /**
  * Render the shadow field.
@@ -64,7 +81,12 @@ export function ShadowField({ field, value, onChange }) {
 			return;
 		}
 
-		onChange({ ...shadow, [key]: next });
+		// The floor belongs to the value, not to the blur input's own change event: applying it on every
+		// write means a negative blur arriving from anywhere is held at zero rather than committed into
+		// a shadow CSS refuses to render.
+		const merged = { ...shadow, [key]: next };
+
+		onChange({ ...merged, blur: Math.max(Number(merged.blur) || 0, 0) });
 	};
 
 	return (
@@ -98,14 +120,17 @@ export function ShadowField({ field, value, onChange }) {
 				)}
 			/>
 			<div className="kadence-blocks-style-library__field-shadow-row">
-				{NUMERIC_FIELDS.map(({ key, label }) => (
+				{NUMERIC_FIELDS.map(({ key, label, min }) => (
 					<div key={key} className="kadence-blocks-style-library__field-shadow-number">
 						<span className="kadence-blocks-style-library__field-shadow-number-label">{label}</span>
 						<NumberControl
 							__next40pxDefaultSize
+							min={min}
 							value={shadow[key]}
 							disabled={field.readOnly}
-							onChange={(next) => setPart(key, next === '' ? 0 : Number(next))}
+							// `min` stops the spinner and arrow keys; a typed or pasted value still arrives
+							// here, so the floor is applied to what gets stored too.
+							onChange={(next) => setPart(key, next === '' ? 0 : clampToMin(Number(next), min))}
 						/>
 					</div>
 				))}

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -47,13 +47,14 @@ jest.mock('@wordpress/components', () => ({
 			</div>
 		);
 	},
-	__experimentalNumberControl: ({ label, value, onChange, disabled }) => (
+	__experimentalNumberControl: ({ label, value, onChange, disabled, min }) => (
 		<label>
 			{label}
 			<input
 				aria-label={label}
 				type="number"
 				value={value}
+				min={min}
 				disabled={disabled}
 				onChange={(event) => onChange(event.target.value)}
 			/>
@@ -391,6 +392,87 @@ describe('BoxShadowControl initial tab', () => {
 		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
 
 		expect(numberInput('X')).not.toBeNull();
+	});
+
+	/**
+	 * Blur is floored at zero, and the other three axes stay unbounded. CSS rejects a negative blur
+	 * radius, and one invalid component makes the browser drop the whole `box-shadow` — so a negative
+	 * blur removes the shadow instead of softening it, while X, Y and spread take negatives happily.
+	 *
+	 * @return {void}
+	 */
+	it('floors the Blur input at zero and leaves the other axes unbounded', () => {
+		renderControl({ value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' } });
+
+		expect(numberInput('Blur').getAttribute('min')).toBe('0');
+		expect(numberInput('X').getAttribute('min')).toBeNull();
+		expect(numberInput('Y').getAttribute('min')).toBeNull();
+		expect(numberInput('Spread').getAttribute('min')).toBeNull();
+	});
+
+	/**
+	 * A negative blur typed or pasted past the input's own `min` is still held at zero on the way to
+	 * the stored value, so the shadow can never be written into the state CSS discards.
+	 *
+	 * @return {void}
+	 */
+	it('clamps a typed negative blur to zero before storing it', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' },
+			onChange,
+		});
+
+		act(() => {
+			const input = numberInput('Blur');
+			Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '-9');
+			input.dispatchEvent(new Event('change', { bubbles: true }));
+		});
+
+		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ blur: '0px' }));
+	});
+
+	/**
+	 * The floor covers the whole composite, not just the blur input: a negative blur already in the
+	 * value is held at zero by a write to any other axis.
+	 *
+	 * @return {void}
+	 */
+	it('floors a negative blur already in the value when another axis is edited', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '-6px', spread: '0px' },
+			onChange,
+		});
+
+		act(() => {
+			const input = numberInput('X');
+			Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '5');
+			input.dispatchEvent(new Event('change', { bubbles: true }));
+		});
+
+		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ offsetX: '5px', blur: '0px' }));
+	});
+
+	/**
+	 * A negative spread is valid CSS — it shrinks the shadow — so it passes through untouched.
+	 *
+	 * @return {void}
+	 */
+	it('stores a negative spread unchanged', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: { color: '#000000', offsetX: '2px', offsetY: '2px', blur: '4px', spread: '0px' },
+			onChange,
+		});
+
+		act(() => {
+			const input = numberInput('Spread');
+			Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '-4');
+			input.dispatchEvent(new Event('change', { bubbles: true }));
+		});
+
+		expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ spread: '-4px' }));
 	});
 
 	/**

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -77,9 +77,31 @@ import '../styles/token-controls.scss';
 const AXES = [
 	{ key: 'offsetX', label: __('X', 'kadence-blocks') },
 	{ key: 'offsetY', label: __('Y', 'kadence-blocks') },
-	{ key: 'blur', label: __('Blur', 'kadence-blocks') },
+	// Blur is the only axis with a floor. CSS rejects a negative blur radius outright, and an invalid
+	// component makes the browser drop the WHOLE `box-shadow` declaration — so a stray `-2` does not
+	// merely soften the shadow, it silently removes it while the control still shows the value. X, Y
+	// and spread all take negative values legitimately and stay unbounded.
+	{ key: 'blur', label: __('Blur', 'kadence-blocks'), min: 0 },
 	{ key: 'spread', label: __('Spread', 'kadence-blocks') },
 ];
+
+/**
+ * Hold an axis value at its own floor, when it has one.
+ *
+ * `NumberControl`'s `min` already stops the spinner and arrow keys, but a typed or pasted value
+ * still arrives through `onChange`, so the floor is applied to the value being stored rather than
+ * only to the input.
+ *
+ * @param {number}  value The axis value being written.
+ * @param {?number} min   The axis's floor, or undefined when it has none.
+ *
+ * @since TBD
+ *
+ * @return {number} The value, never below the floor.
+ */
+function clampAxis(value, min) {
+	return min === undefined ? value : Math.max(value, min);
+}
 
 /**
  * Apply a patch to the current shadow composite, writing the result through `onChange` with `inset`
@@ -97,7 +119,28 @@ const AXES = [
 function commitShadow(shadow, patch) {
 	const { inset, ...rest } = { ...shadow, ...patch };
 
-	return inset === true ? { ...rest, inset: true } : rest;
+	// The floor belongs to the value, not to the blur input's own change event: every write passes
+	// through here, so a negative blur arriving from anywhere — a pasted value, a preset, a token's
+	// stored legs — is held at zero rather than committed into a shadow CSS refuses to render.
+	const next = { ...rest, blur: floorBlur(rest.blur) };
+
+	return inset === true ? { ...next, inset: true } : next;
+}
+
+/**
+ * Hold a blur length at zero when it is negative, leaving anything that is not a number — a token
+ * alias, an empty slot — exactly as it was.
+ *
+ * @param {*} value The composite's blur slot.
+ *
+ * @since TBD
+ *
+ * @return {*} The blur, never a negative length.
+ */
+function floorBlur(value) {
+	const parsed = Number.parseFloat(value);
+
+	return Number.isFinite(parsed) && parsed < 0 ? '0px' : value;
 }
 
 /**
@@ -212,13 +255,14 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
 				</div>
 			)}
 			<div className="kb-box-shadow-control__axes">
-				{AXES.map(({ key, label }) => (
+				{AXES.map(({ key, label, min }) => (
 					<NumberControl
 						key={key}
 						label={label}
+						min={min}
 						value={Number.parseFloat(shadow[key]) || 0}
 						disabled={disabled}
-						onChange={(next) => setPart(key, `${Number(next) || 0}px`)}
+						onChange={(next) => setPart(key, `${clampAxis(Number(next) || 0, min)}px`)}
 					/>
 				))}
 			</div>


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/b1a4c066dd6348b9a9d4f64ffe317497)

## Summary

CSS rejects a negative blur radius, and one invalid component makes the browser drop the **whole**
`box-shadow` declaration. So a stray `-2` in a Blur field does not soften the shadow, it silently
deletes it while the control still shows the value.

Blur now has a floor of `0` in every control that offers one:

- `BoxShadowControl` — the block editor's Custom tab, and the Style Library's Button preset field
- `ShadowField` — the Style Library's Shadow screen

Blur is the only one of the four axes that gets a floor. X, Y and spread all take negative values
legitimately — a negative spread shrinks the shadow — so they stay unbounded, and tests pin that so
nobody "tidies up" later by clamping all four.

## Why the floor is applied twice

`min` on the input stops the spinner and the arrow keys, but a typed or pasted value still arrives
through `onChange`. The floor therefore also applies to the value being written, at the single point
every write passes through (`commitShadow`, and `ShadowField`'s `setPart`) rather than only on the
blur field's own change event. A negative blur arriving from anywhere — a paste, a preset, a token's
stored legs — is held at zero instead of being committed into a shadow that cannot render.

## Test plan

- `box-shadow-control.test.js`: the floor is on Blur only; a typed `-9` clamps to `0`; a negative
  spread stores unchanged; a negative blur already in the value is floored by a write to another axis.
- New `shadow-field-blur-floor.test.js` covers the same four for the Shadow screen, which had no
  render harness before.
- Full JS suite green on this branch alone: 1893 tests.
- CodeRabbit CLI against `feature/design-tokens-module`: 0 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shadow blur values can no longer be set below zero.
  * Negative blur values are corrected when editing blur or other shadow properties.
  * X, Y, and spread values remain unrestricted, including negative spread values.
  * Numeric shadow inputs now consistently enforce their field-specific minimums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
