### PR TITLE
[DTM] SOFT-4321 [2/5]: Record whether a shadow is a pick, not whether it paints

### DIFF
--- a/src/blocks/image/__tests__/box-shadow.test.js
+++ b/src/blocks/image/__tests__/box-shadow.test.js
@@ -99,4 +99,16 @@ describe('imageBoxShadowCss', () => {
 	it('applies the historic per-leg defaults for missing axes', () => {
 		expect(imageBoxShadowCss(true, [{ color: '#000000', vOffset: 4 }])).toBe('0px 4px 14px 0px rgba(#000000, 0.2)');
 	});
+
+	/**
+	 * A color picked before any geometry raises the block's flag but still paints nothing, so the
+	 * canvas emits no shadow until an axis moves.
+	 *
+	 * @return {void}
+	 */
+	it('emits nothing for a color with no geometry even with the flag raised', () => {
+		const colorOnly = { color: '#3182ce', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0, inset: false };
+
+		expect(imageBoxShadowCss(true, [colorOnly])).toBeUndefined();
+	});
 });

--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -66,7 +66,7 @@ import {
 	presetValueForDevice,
 } from '../../extension/token-indicators/normalize';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
-import { EditorShadowControl, hasVisibleShadow } from '../../extension/design-tokens/components/EditorShadowControl';
+import { EditorShadowControl } from '../../extension/design-tokens/components/EditorShadowControl';
 import { imageBoxShadowCss } from './box-shadow';
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
 import { useColorGroups } from '../../extension/design-tokens/hooks/use-color-groups';
@@ -1322,21 +1322,19 @@ export default function Image({
 									allowEmpty={true}
 								/>
 							)}
-							{/* `displayBoxShadow` is no longer a control -- it is derived from the value on every
-							    write. It has to keep existing because Gutenberg omits an attribute equal to its
-							    default, so a block saved with the old toggle OFF stored no flag at all and is
-							    indistinguishable from one saved with it on. Deriving it forward means legacy
-							    content keeps whatever the flag said, while anything edited from here on has a
-							    flag that simply agrees with its own geometry. */}
+							{/* `displayBoxShadow` is no longer a control -- the editor writes it from the value on
+							    every change, recording whether the value is a pick rather than whether it paints.
+							    It cannot follow visibility: a color chosen before any geometry paints nothing yet,
+							    and a flag lowered on that write reads the pick straight back as unset. It has to
+							    keep existing because Gutenberg omits an attribute equal to its default, so a block
+							    saved with the old toggle OFF stored no flag at all, and a lowered flag is the only
+							    thing keeping those values -- and the shipped visible default -- unpainted. */}
 							<EditorShadowControl
 								label={__('Box Shadow', 'kadence-blocks')}
 								value={boxShadow}
 								enabled={displayBoxShadow}
-								onChange={(value) =>
-									setAttributes({
-										boxShadow: value,
-										displayBoxShadow: hasVisibleShadow(value?.[0]),
-									})
+								onChange={(value, displayBoxShadow) =>
+									setAttributes({ boxShadow: value, displayBoxShadow })
 								}
 								tokens={shadowTokens}
 								defaultValue={shadowPresetValue}

--- a/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
+++ b/src/blocks/singlebtn/components/backend-styles/__tests__/index.test.js
@@ -318,6 +318,23 @@ describe('BackendStyles shadow flag gating', () => {
 	});
 
 	/**
+	 * A color picked before any geometry raises the flag but paints nothing, so the base state still
+	 * emits no box-shadow — the flag records the pick, the geometry decides the painting.
+	 *
+	 * @return {void}
+	 */
+	it('emits no box-shadow for a color with no geometry even when displayShadow is raised', () => {
+		const colorOnly = { hOffset: 0, vOffset: 0, blur: 0, spread: 0, color: '#3182ce', opacity: 1, inset: false };
+
+		BackendStyles({
+			attributes: { uniqueID: 'abc123', displayShadow: true, shadow: [colorOnly] },
+			previewDevice: 'Desktop',
+		});
+
+		expect(boxShadowFor(fakeCss.rules, BASE_SELECTOR)).toBe('none');
+	});
+
+	/**
 	 * A lowered `displayHoverShadow` suppresses the hover state's box-shadow even though the stored
 	 * shadow itself is visible, matching the PHP renderer's own gate for this state.
 	 *

--- a/src/blocks/singlebtn/edit.js
+++ b/src/blocks/singlebtn/edit.js
@@ -95,7 +95,7 @@ import {
 } from '../../extension/token-indicators/normalize';
 import { EditorBoxControl } from '../../extension/design-tokens/components/EditorBoxControl';
 import { EditorBorderControl } from '../../extension/design-tokens/components/EditorBorderControl';
-import { EditorShadowControl, hasVisibleShadow } from '../../extension/design-tokens/components/EditorShadowControl';
+import { EditorShadowControl } from '../../extension/design-tokens/components/EditorShadowControl';
 import { renderShadowColor } from '../../extension/design-tokens/components/shadow-color';
 import { BorderColorField } from '../../extension/design-tokens/components/border-color';
 import { pickableTokensForControl, pickableTokensForKey } from '../../extension/token-picker';
@@ -1345,10 +1345,10 @@ export default function KadenceButtonEdit(props) {
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadowHover}
 															enabled={displayHoverShadow}
-															onChange={(value) =>
+															onChange={(value, displayHoverShadow) =>
 																setAttributes({
 																	shadowHover: value,
-																	displayHoverShadow: hasVisibleShadow(value?.[0]),
+																	displayHoverShadow,
 																})
 															}
 															tokens={shadowPickableTokens}
@@ -1472,24 +1472,22 @@ export default function KadenceButtonEdit(props) {
 															max={borderRadiusIsRelative ? 24 : 500}
 															step={borderRadiusIsRelative ? 0.1 : 1}
 														/>
-														{/* The `display*Shadow` flags are no longer controls — the editor derives each
-														    from its own value on every write. They still have to EXIST, because
-														    Gutenberg omits an attribute equal to its default: a button saved with
-														    the old toggle OFF stored no flag at all while keeping the values behind
-														    it, so geometry alone cannot tell it from one saved with the toggle on.
-														    Deriving them forward leaves legacy content exactly as it renders today
-														    and gives anything edited from here on a flag that agrees with its own
-														    geometry. */}
+														{/* The `display*Shadow` flags are no longer controls — the editor writes each
+														    from its own value on every change, recording whether the value is a
+														    pick rather than whether it paints. They cannot follow visibility: a
+														    color chosen before any geometry paints nothing yet, and a flag lowered
+														    on that write reads the pick straight back as unset. They still have to
+														    EXIST, because Gutenberg omits an attribute equal to its default: a
+														    button saved with the old toggle OFF stored no flag at all while keeping
+														    the values behind it, and a lowered flag is the only thing keeping those
+														    — and the shipped visible default — unpainted. */}
 														<EditorShadowControl
 															defaultValue={shadowPresetValue}
 															label={__('Box Shadow', 'kadence-blocks')}
 															value={shadow}
 															enabled={displayShadow}
-															onChange={(value) =>
-																setAttributes({
-																	shadow: value,
-																	displayShadow: hasVisibleShadow(value?.[0]),
-																})
+															onChange={(value, displayShadow) =>
+																setAttributes({ shadow: value, displayShadow })
 															}
 															tokens={shadowPickableTokens}
 															renderColor={renderShadowColor}
@@ -1640,12 +1638,10 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowTransparentHover}
 																enabled={displayHoverShadowTransparent}
-																onChange={(value) =>
+																onChange={(value, displayHoverShadowTransparent) =>
 																	setAttributes({
 																		shadowTransparentHover: value,
-																		displayHoverShadowTransparent: hasVisibleShadow(
-																			value?.[0]
-																		),
+																		displayHoverShadowTransparent,
 																	})
 																}
 																tokens={shadowPickableTokens}
@@ -1773,12 +1769,10 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowTransparent}
 																enabled={displayShadowTransparent}
-																onChange={(value) =>
+																onChange={(value, displayShadowTransparent) =>
 																	setAttributes({
 																		shadowTransparent: value,
-																		displayShadowTransparent: hasVisibleShadow(
-																			value?.[0]
-																		),
+																		displayShadowTransparent,
 																	})
 																}
 																tokens={shadowPickableTokens}
@@ -1922,12 +1916,10 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowStickyHover}
 																enabled={displayHoverShadowSticky}
-																onChange={(value) =>
+																onChange={(value, displayHoverShadowSticky) =>
 																	setAttributes({
 																		shadowStickyHover: value,
-																		displayHoverShadowSticky: hasVisibleShadow(
-																			value?.[0]
-																		),
+																		displayHoverShadowSticky,
 																	})
 																}
 																tokens={shadowPickableTokens}
@@ -2049,12 +2041,10 @@ export default function KadenceButtonEdit(props) {
 																label={__('Box Shadow', 'kadence-blocks')}
 																value={shadowSticky}
 																enabled={displayShadowSticky}
-																onChange={(value) =>
+																onChange={(value, displayShadowSticky) =>
 																	setAttributes({
 																		shadowSticky: value,
-																		displayShadowSticky: hasVisibleShadow(
-																			value?.[0]
-																		),
+																		displayShadowSticky,
 																	})
 																}
 																tokens={shadowPickableTokens}

--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -348,9 +348,9 @@ export function hasVisibleShadow(item) {
 
 	// A bound item is decided by its binding alone, never by its stored legs — the same rule the
 	// renderers' two copies of this predicate apply. Backed, its real value lives in the token and is
-	// unknown here, so it counts as visible and the derived enable flag stays raised under a shadow the
-	// token does paint. Unbacked, the renderers paint nothing, so raising the flag would leave the
-	// inspector claiming a shadow the page does not show.
+	// unknown here, so it counts as visible and the renderers keep painting the shadow the token does
+	// paint. Unbacked, the renderers paint nothing, so counting it as visible would leave the inspector
+	// claiming a shadow the page does not show.
 	const bound = boundShadowToken(item);
 
 	if (bound) {
@@ -369,12 +369,62 @@ export function hasVisibleShadow(item) {
 }
 
 /**
+ * Whether a native shadow item carries no pick at all: unbound, transparent (or fully see-through),
+ * and with no geometry. This is the item both Reset and the fixed "None" entry write.
+ *
+ * @param {Object} item One `shadow[0]`-shaped item.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the item is the cleared shadow.
+ */
+function isClearedShadow(item) {
+	if (boundShadowToken(item)) {
+		return false;
+	}
+
+	// Inset is a pick in its own right. It paints nothing on its own, so leaving it out here would let
+	// the flag drop on the very write that set it, and the toggle would spring back the way a
+	// color-only pick used to.
+	if (item.inset === true) {
+		return false;
+	}
+
+	const isTransparent = !item.color || item.color === 'transparent' || Number(item.opacity) === 0;
+
+	return isTransparent && !hasVisibleShadow(item);
+}
+
+/**
+ * Whether a stored native shadow is a pick of the block's own — what a host's `display*` flag
+ * records on every write.
+ *
+ * The flag cannot follow visibility. A color chosen before any geometry paints nothing yet, so a
+ * visibility-derived flag lowered itself on that very write, the control read the value back as
+ * unset, and the pick was thrown away. Raising it on every write instead would go too far the other
+ * way: Reset and the fixed "None" entry both arrive as the cleared item and have to keep reading as
+ * unset. A pick is therefore anything but that cleared item. Whether it paints stays with the
+ * renderers, which gate on `hasVisibleShadow()` as well and never trust the flag alone.
+ *
+ * @param {?Array} native The stored native shadow attribute value.
+ *
+ * @since TBD
+ *
+ * @return {boolean} Whether the host's enable flag should be raised for this value.
+ */
+export function hasShadowPick(native) {
+	const item = native?.[0];
+
+	return Boolean(item) && !isClearedShadow(item);
+}
+
+/**
  * Whether a stored native shadow should be treated as "the block sets no shadow of its own".
  *
  * A host that pairs the value with its own enable flag (`kadence/singlebtn`) settles it first: the
  * shipped schema defaults that value to a visible shadow, so geometry alone would read a brand-new
- * button as customized. A lowered flag is the block saying it sets no shadow here, whatever the
- * value's default geometry happens to be.
+ * button as customized. A lowered flag is the block saying it stores no pick of its own here,
+ * whatever the value's default geometry happens to be.
  *
  * Without such a flag, an invisible shadow is a real override only when there is a preset shadow for
  * it to suppress. With nothing behind it, it suppresses nothing and reads as unset.
@@ -409,10 +459,9 @@ export function isUnsetShadow(native, defaultValue, enabled = true) {
 		return false;
 	}
 
-	const isTransparent = !source.color || source.color === 'transparent' || Number(source.opacity) === 0;
-	const hasNoGeometry = ['hOffset', 'vOffset', 'blur', 'spread'].every((axis) => !parseFloat(source[axis]));
-
-	return isTransparent && hasNoGeometry;
+	// The same definition the write side uses for the flag, so the inspector cannot disagree with what
+	// it just stored.
+	return isClearedShadow(source);
 }
 
 /**
@@ -424,7 +473,10 @@ export function isUnsetShadow(native, defaultValue, enabled = true) {
  * @param {string}    props.label         The control's label.
  * @param {?Array}    props.value         The native shadow attribute value, optionally carrying a
  *                                        `shadowToken` binding.
- * @param {Function}  props.onChange      Called with the next native shadow attribute value.
+ * @param {Function}  props.onChange      Called with the next native shadow attribute value, and with
+ *                                        the value the host's own enable flag should take — `true`
+ *                                        when the value is a pick of the block's own, `false` for the
+ *                                        cleared shadow that Reset and "None" write.
  * @param {Array}     [props.tokens]      Pickable `shadow`-type tokens, `[{id, label, value, alias}]`.
  * @param {*}         [props.defaultValue] The active preset's own resolved shadow, or nothing when it
  *                                        declares none — shown MUTED while the block stores no shadow
@@ -461,7 +513,14 @@ export function EditorShadowControl({
 			<BoxShadowControl
 				label={label}
 				value={isUnsetShadow(value, defaultValue, enabled) ? '' : bound || fromNativeShadow(value)}
-				onChange={(next) => onChange(toNativeShadow(next, tokens))}
+				onChange={(next) => {
+					const native = toNativeShadow(next, tokens);
+
+					// The flag travels with the value rather than being recomputed by each host. Seven call
+					// sites would otherwise each have to remember it, and one that forgot would silently
+					// read its own writes back as unset.
+					onChange(native, hasShadowPick(native));
+				}}
 				tokens={tokens}
 				defaultValue={defaultValue}
 				renderColor={renderColor}

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -10,6 +10,7 @@ import {
 	toNativeShadow,
 	fromNativeShadow,
 	hasVisibleShadow,
+	hasShadowPick,
 	isUnsetShadow,
 } from '../EditorShadowControl';
 import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
@@ -163,17 +164,20 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 			inset: false,
 		});
 
-		expect(onChange).toHaveBeenCalledWith([
-			{
-				color: '#111111',
-				opacity: 0.4,
-				hOffset: 9,
-				vOffset: 3,
-				blur: 4,
-				spread: 5,
-				inset: false,
-			},
-		]);
+		expect(onChange).toHaveBeenCalledWith(
+			[
+				{
+					color: '#111111',
+					opacity: 0.4,
+					hOffset: 9,
+					vOffset: 3,
+					blur: 4,
+					spread: 5,
+					inset: false,
+				},
+			],
+			true
+		);
 	});
 
 	/**
@@ -314,17 +318,20 @@ describe('EditorShadowControl native <-> BoxShadowControl value bridging', () =>
 
 		shadowControl.props.onChange('primitive.shadow.unknown');
 
-		expect(onChange).toHaveBeenCalledWith([
-			{
-				color: 'transparent',
-				opacity: 1,
-				hOffset: 0,
-				vOffset: 0,
-				blur: 0,
-				spread: 0,
-				inset: false,
-			},
-		]);
+		expect(onChange).toHaveBeenCalledWith(
+			[
+				{
+					color: 'transparent',
+					opacity: 1,
+					hOffset: 0,
+					vOffset: 0,
+					blur: 0,
+					spread: 0,
+					inset: false,
+				},
+			],
+			false
+		);
 	});
 
 	/**
@@ -709,6 +716,165 @@ describe('EditorShadowControl unset rendering', () => {
 		});
 
 		expect(shadowControl.props.value).not.toBe('');
+	});
+});
+
+describe('hasShadowPick', () => {
+	const CLEARED = [{ color: 'transparent', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0, inset: false }];
+
+	/**
+	 * With nothing stored there is no pick, so the host's enable flag stays lowered.
+	 *
+	 * @return {void}
+	 */
+	it('reads an absent attribute as no pick', () => {
+		expect(hasShadowPick(undefined)).toBe(false);
+		expect(hasShadowPick([])).toBe(false);
+	});
+
+	/**
+	 * The item Reset and the fixed "None" entry both write is the cleared shadow, which must lower the
+	 * flag so the control goes back to its muted "Default" instead of claiming a bold "None".
+	 *
+	 * @return {void}
+	 */
+	it('reads the cleared item Reset and None write as no pick', () => {
+		expect(hasShadowPick(CLEARED)).toBe(false);
+	});
+
+	/**
+	 * The bug this predicate exists for: a color chosen before any geometry is a real pick, even
+	 * though it paints nothing yet. Deriving the flag from visibility lowered it on this very write
+	 * and threw the color away on the next render.
+	 *
+	 * @return {void}
+	 */
+	it('reads a color with no geometry as a pick', () => {
+		expect(hasShadowPick([{ color: '#3182ce', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0 }])).toBe(
+			true
+		);
+	});
+
+	/**
+	 * A fully see-through color is as good as no color, so it stays the cleared item however it was
+	 * spelled.
+	 *
+	 * @return {void}
+	 */
+	it('reads a fully transparent color with no geometry as no pick', () => {
+		expect(hasShadowPick([{ color: '#3182ce', opacity: 0, spread: 0, blur: 0, hOffset: 0, vOffset: 0 }])).toBe(
+			false
+		);
+	});
+
+	/**
+	 * Geometry on its own is a pick too — the user moved an axis, whatever the color says.
+	 *
+	 * @return {void}
+	 */
+	it('reads geometry with no color as a pick', () => {
+		expect(hasShadowPick([{ color: 'transparent', opacity: 1, spread: 0, blur: 4, hOffset: 0, vOffset: 0 }])).toBe(
+			true
+		);
+	});
+
+	/**
+	 * A binding is a deliberate pick even with all-zero stored legs; the token carries the real value.
+	 *
+	 * @return {void}
+	 */
+	it('reads a bound item with zero legs as a pick', () => {
+		const bound = [
+			{
+				color: 'transparent',
+				opacity: 1,
+				spread: 0,
+				blur: 0,
+				hOffset: 0,
+				vOffset: 0,
+				[SHADOW_TOKEN_KEY]: '{semantic.shadow.button}',
+			},
+		];
+
+		expect(hasShadowPick(bound)).toBe(true);
+	});
+
+	/**
+	 * Inset paints nothing by itself, but flipping it is still a deliberate pick — counting it as
+	 * cleared would drop the flag on the write that set it and spring the toggle back.
+	 *
+	 * @return {void}
+	 */
+	it('reads a bare inset toggle as a pick', () => {
+		const inset = [{ color: 'transparent', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0, inset: true }];
+
+		expect(hasShadowPick(inset)).toBe(true);
+		expect(isUnsetShadow(inset, undefined, true)).toBe(false);
+	});
+
+	/**
+	 * `block.json`'s shipped default is a visible, colored shadow, so by value alone it reads as a
+	 * pick. What keeps a freshly inserted block clean is its lowered flag, never the value — this is
+	 * the pairing `isUnsetShadow` relies on.
+	 *
+	 * @return {void}
+	 */
+	it("reads block.json's shipped default as a pick, leaving the flag to keep a fresh block clean", () => {
+		const shipped = [{ color: '#000000', opacity: 0.2, spread: 0, blur: 2, hOffset: 1, vOffset: 1, inset: false }];
+
+		expect(hasShadowPick(shipped)).toBe(true);
+		expect(isUnsetShadow(shipped, undefined, false)).toBe(true);
+	});
+
+	/**
+	 * The write side and the read side share one definition of "cleared", so a color picked on an
+	 * unset control is stored as a pick and read straight back as set rather than snapping away.
+	 *
+	 * @return {void}
+	 */
+	it('agrees with isUnsetShadow on a color picked from the Custom tab', () => {
+		const written = toNativeShadow({
+			color: '#3182ce',
+			offsetX: '0px',
+			offsetY: '0px',
+			blur: '0px',
+			spread: '0px',
+			inset: false,
+		});
+
+		expect(hasShadowPick(written)).toBe(true);
+		expect(isUnsetShadow(written, undefined, true)).toBe(false);
+	});
+});
+
+describe('EditorShadowControl colored zero-geometry pick', () => {
+	const COLOR_ONLY = [{ color: '#3182ce', opacity: 1, spread: 0, blur: 0, hOffset: 0, vOffset: 0, inset: false }];
+
+	/**
+	 * With the flag raised, a color-only pick reaches `BoxShadowControl` as a composite, so the Custom
+	 * tab keeps showing the chosen color instead of falling back to transparent.
+	 *
+	 * @return {void}
+	 */
+	it('passes the composite down so the picked color survives the round trip', () => {
+		const { shadowControl } = renderEditorShadowControl({ value: COLOR_ONLY, defaultValue: undefined });
+
+		expect(shadowControl.props.value.color).toBe('#3182ce');
+	});
+
+	/**
+	 * A lowered flag still wins, which is what keeps a freshly inserted block reading as unset.
+	 *
+	 * @return {void}
+	 */
+	it('still passes an empty value down when the enable flag is lowered', () => {
+		const { shadowControl } = renderEditorShadowControl({
+			value: COLOR_ONLY,
+			defaultValue: undefined,
+			enabled: false,
+		});
+
+		expect(shadowControl.props.value).toBe('');
 	});
 });
 


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/b1a4c066dd6348b9a9d4f64ffe317497)

Based on #1514.

## Summary

Choosing a shadow color before touching any axis did not stick — the control snapped straight back
to transparent. Same for flipping Inset on an otherwise-empty shadow.

The cause is a round trip. Every call site wrote its enable flag from **visibility**:

```js
displayShadow: hasVisibleShadow(value?.[0])   // geometry alone decides
```

`hasVisibleShadow()` reads geometry only, so a color with all four axes still at `0` is "not
visible". The flag dropped on that very write, `isUnsetShadow()` then short-circuits on a lowered
flag, and the control was handed `''` — falling back to `DEFAULT_COMPOSITE`, i.e. transparent. The
pick reached the attribute and was discarded on the next render.

## What changed

The flag now records **whether the value is a pick**, not whether it paints:

```js
onChange={ ( value, displayShadow ) => setAttributes( { shadow: value, displayShadow } ) }
```

The control derives it and hands it out, rather than every host recomputing it. No block imports
`hasShadowPick`, and a call site cannot forget it or get it wrong — with seven of them, one that
forgot would silently read its own writes back as unset.

A pick is anything but the cleared item — a binding, a non-transparent color, geometry, or a bare
Inset toggle. Painting stays with the renderers, which already AND the flag with `hasVisibleShadow()`
on every path (`backend-styles/index.js:926`, `image/box-shadow.js:34`, and the PHP equivalents), so
nothing renders a zero-geometry shadow either way. **No PHP change** — `ImageTest.php` already pins
the colored-zero-geometry case, so PHP already implemented these semantics.

`isUnsetShadow()` now shares one definition of "cleared" with the write side, so the inspector cannot
disagree with what it just stored.

## Why not simply always write `true`

Reset and the fixed "None" entry both arrive as the cleared item. Forcing the flag up would show a
bold "None" over an active preset. The predicate keeps those behaving exactly as they do today.

## Why `isUnsetShadow` keeps its lowered-flag short-circuit

`block.json` ships a visible, colored shadow behind a lowered flag for all six button states and the
image. That pairing is what keeps a brand-new block clean, and it is untouched here.

## Test plan

- `hasShadowPick` table: empty, the cleared item Reset/None write, a color with no geometry (the
  bug), a fully transparent color, geometry with no color, a bound item with zero legs, a bare
  Inset toggle, and `block.json`'s shipped default.
- Write/read round trip pinning that the two sides agree, plus `enabled: false` still reading unset.
- Canvas twins: a color with no geometry emits `box-shadow: none` (button) and `undefined` (image).
- Full JS suite green on this branch alone: 1906 tests.
- CodeRabbit CLI against #1514's branch: 0 findings.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shadow settings now preserve valid color-only, inset-only, and token-based selections instead of treating them as empty.
  * Image and button controls consistently reflect whether a shadow is selected, including normal, hover, transparent, and sticky states.
  * Prevented empty box-shadow CSS from being generated when shadow geometry remains zero.
* **Tests**
  * Added coverage for shadow selection, clearing, rendering, defaults, bindings, and enable/disable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
