### PR TITLE
[DTM] SOFT-4321 [4/5]: Open the shared color popover from the Style Library's shadow field

### DIFF
--- a/src/style-library/__tests__/border-shadow-field-rendering.test.js
+++ b/src/style-library/__tests__/border-shadow-field-rendering.test.js
@@ -389,6 +389,62 @@ describe('BoxShadowField', () => {
 		window[PICKABLE_TOKENS_GLOBAL] = originalPool;
 	});
 
+	/**
+	 * The color sub-field is the shared `ColorControl`, the same popover the block editor's shadow
+	 * field opens, so both hosts offer one picker rather than two.
+	 *
+	 * @return {void}
+	 */
+	it('renders the color sub-field through the shared ColorControl', () => {
+		act(() => {
+			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange: jest.fn() }));
+		});
+
+		const element = latestBoxShadowControlProps.renderColor({ value: '', onChange: jest.fn() });
+
+		expect(element.type.name).toBe('ColorControl');
+	});
+
+	/**
+	 * A token pick arrives from the popover as a bracket alias and is written back as the BARE id this
+	 * host stores, so a saved preset still compares equal and does not read as dirty.
+	 *
+	 * @return {void}
+	 */
+	it('writes a color pick back as a bare token id', () => {
+		const onColorChange = jest.fn();
+
+		act(() => {
+			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange: jest.fn() }));
+		});
+
+		const element = latestBoxShadowControlProps.renderColor({ value: '', onChange: onColorChange });
+
+		element.props.onPick('{semantic.color.accent.main}');
+
+		expect(onColorChange).toHaveBeenCalledWith('semantic.color.accent.main');
+	});
+
+	/**
+	 * A Custom-tab literal carries its own alpha inline, so it is written through untouched rather than
+	 * bridged as a token id.
+	 *
+	 * @return {void}
+	 */
+	it('writes a custom color through untouched, alpha included', () => {
+		const onColorChange = jest.fn();
+
+		act(() => {
+			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange: jest.fn() }));
+		});
+
+		const element = latestBoxShadowControlProps.renderColor({ value: '', onChange: onColorChange });
+
+		element.props.onCustom('#abcdef80');
+
+		expect(onColorChange).toHaveBeenCalledWith('#abcdef80');
+	});
+
 	it("sources tokens via pickableTokensForType('shadow', 'shadow', ...), excluding the Brand-group semantics", () => {
 		act(() => {
 			root.render(createElement(BoxShadowField, { field: { label: 'Shadow' }, value: '', onChange: jest.fn() }));

--- a/src/style-library/components/molecules/fields/BoxShadowField.js
+++ b/src/style-library/components/molecules/fields/BoxShadowField.js
@@ -15,9 +15,10 @@
  * shadow, so this adapter reads and writes `field.path`'s value directly, with no breakpoint
  * envelope — unlike `BorderField`/`BoxTokenField`.
  *
- * Color stays out of scope here — a shadow's color packs opacity into the same value, which the
- * shared color popover has no place for — so `renderColor` still wraps `TokenColorSelectField`.
- * `BorderField` no longer does; this is now the only field that renders it.
+ * Color is the shared `ColorControl`, the same popover the block editor's own shadow field opens, so
+ * the two hosts offer one picker rather than two. A shadow's color packs opacity into the same value,
+ * which the popover carries inline as `#rrggbbaa` — the host that needs the pair split back out does
+ * it on its own side.
  */
 
 /**
@@ -32,8 +33,9 @@ import { pickableTokensForType } from '../../../helpers/tokens';
 import { BoxShadowControl } from '../../../../token-controls/controls/BoxShadowControl';
 import { boundTokenIds } from './BoxTokenField';
 import { isTokenAlias } from '../../../../token-controls/helpers/token-summary';
-import { TokenColorSelectField } from './TokenColorSelectField';
-import { noneEntryForRole, parseResolvedShadow } from '../../../../token-controls';
+import { ColorControl, noneEntryForRole, parseResolvedShadow } from '../../../../token-controls';
+import { useActivePaletteGroups } from '../../../hooks/use-active-palette-groups';
+import { resolveLiteral, toControlValue, toStoredValue } from '../../../helpers/color-values';
 
 /**
  * The bare token id a stored shadow holds, or the value unchanged when it holds a composite shadow
@@ -153,6 +155,7 @@ export function resolveShadowPick(picked, tokens) {
  * @return {JSX.Element} The field.
  */
 export function BoxShadowField({ field, value, onChange }) {
+	const groups = useActivePaletteGroups();
 	// `BoxShadowControl` takes no `defaultValue`, so a semantic's VALUE cannot be shown here the way
 	// the box fields show it; unset is the honest reading until that prop exists.
 	const shown = toControlShadow(value);
@@ -179,10 +182,16 @@ export function BoxShadowField({ field, value, onChange }) {
 			tokens={tokens}
 			defaultValue={field.defaultValue}
 			renderColor={({ value: color, onChange: onColorChange }) => (
-				<TokenColorSelectField
-					field={{ label: __('Color', 'kadence-blocks'), readOnly: field.readOnly }}
-					value={color}
-					onChange={onColorChange}
+				<ColorControl
+					label={__('Color', 'kadence-blocks')}
+					// This host stores a BARE token id, never a bracket alias, so the value is bridged in
+					// both directions with the same pair `BorderField` and `ColorSelectField` use.
+					value={toControlValue(color)}
+					groups={groups}
+					onPick={(alias) => onColorChange(toStoredValue(alias))}
+					onCustom={onColorChange}
+					resolveLiteral={resolveLiteral}
+					disabled={field.readOnly}
 				/>
 			)}
 			disabled={field.readOnly}

--- a/src/style-library/components/molecules/fields/ColorSelectField.js
+++ b/src/style-library/components/molecules/fields/ColorSelectField.js
@@ -3,9 +3,8 @@
  * screen's Text / Background rows): the same trigger-plus-popover control the block editor's
  * `singlebtn` inspector uses, bridged to this host's own palette data and stored-value shape.
  *
- * `TokenColorSelectField.js` stays in place unchanged — it is now `BoxShadowField`'s own color
- * sub-field alone, shadow being out of this control's scope (a shadow's color packs opacity into the
- * same value). This is a second, additive field type, not a replacement.
+ * `TokenColorSelectField.js` stays in place unchanged, still backing the `token-color-select` field
+ * type the preset schemas register. This is a second, additive field type, not a replacement.
  *
  * Value format bridge: a `token-color-select`-style field stores a BARE token id (e.g.
  * `semantic.color.accent.main`), never a bracket alias — the stored attribute shape does not

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -14,8 +14,8 @@
  *
  * Color is out of scope here (see `renderColor`) exactly as in `BorderControl` — this control does
  * not import or build a color picker. The Custom tab's color row wraps whatever `renderColor`
- * renders (the Style Library's swatch-plus-label toggle, the block editor's `ShadowColorField`) in
- * plain layout chrome; it does not touch what that render prop returns.
+ * renders — both hosts now hand it the shared `ColorControl` — in plain layout chrome; it does not
+ * touch what that render prop returns.
  *
  * The token rows also hide their resolved value (`TokenPopover`'s `showValue={false}`) — a shadow's
  * value is a long CSS shorthand that crowds the row the way a short dimension value does not. Other
@@ -247,9 +247,9 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
 		<div className="kadence-token-field__custom kb-box-shadow-control__custom">
 			{renderColor && (
 				// A plain wrapper, not a rebuilt picker: whatever the caller's `renderColor` already renders
-				// (the Style Library's `TokenColorSelectField` swatch-plus-"Color"-label toggle, the block
-				// editor's `ShadowColorField`) keeps its own click-to-open mechanism and chrome untouched;
-				// this only gives it its own row above the axes instead of sitting inline with them.
+				// (both hosts wrap the shared `ColorControl`, the editor through `ShadowColorField`) keeps
+				// its own click-to-open mechanism and chrome untouched; this only gives it its own row
+				// above the axes instead of sitting inline with them.
 				<div className="kb-box-shadow-control__color-row">
 					{renderColor({ value: shadow.color, onChange: (next) => setPart('color', next), disabled })}
 				</div>

--- a/src/token-controls/styles/token-controls.scss
+++ b/src/token-controls/styles/token-controls.scss
@@ -301,8 +301,8 @@
 /*
  * The color row: a plain full-width wrapper around whatever `renderColor` renders (see the render
  * function's own comment on why this does not rebuild that markup). Margin only, no border/padding
- * of its own — the Style Library's `TokenColorSelectField` and the block editor's `ShadowColorField`
- * already draw their own bordered, clickable swatch-plus-label toggle, and adding a second border
+ * of its own — both hosts' color fields wrap the shared `ColorControl`, which already draws its own
+ * bordered, clickable swatch-plus-label toggle, and adding a second border
  * around it would double up the chrome the reference `ShadowField` only draws once.
  */
 .kb-box-shadow-control__color-row {


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/b1a4c066dd6348b9a9d4f64ffe317497)

Based on #1503.

## Summary

The Style Library's Button preset Shadow field was the last place still wrapping
`TokenColorSelectField` for its color row. It now renders the shared `ColorControl`, so both hosts
open the same popover from the same place in the same control.

`BorderField` already made this move; this is the one field that had not.

## The old reason no longer holds

The file header said color stayed out of scope because "a shadow's color packs opacity into the same
value, which the shared color popover has no place for". That was true when it was written. It is
not now — alpha rides inline as `#rrggbbaa`, and the host that needs the pair split back out does it
on its own side. The comment is corrected, along with two others that still named
`TokenColorSelectField` as the shadow picker.

## Value bridge

This host stores a **bare token id**, never a bracket alias, so the value is translated in both
directions with the same `toControlValue` / `toStoredValue` / `resolveLiteral` trio `BorderField` and
`ColorSelectField` already use. A Custom-tab literal carries its own alpha and is written through
untouched.

`TokenColorSelectField` stays — six preset schemas still register the `token-color-select` field
type. This only stops the shadow field from being one of its callers.

## Test plan

- `border-shadow-field-rendering.test.js`: the color sub-field renders through `ColorControl`; a
  token pick writes back as a bare id; a custom color is written through untouched, alpha included.
- Full JS suite green on this branch alone: 1918 tests.
- CodeRabbit CLI against #1503's branch: 0 findings.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated box-shadow color selection to use the shared color control.
  * Palette token colors are saved consistently, while custom colors—including transparency—remain unchanged.
  * Read-only box-shadow color fields continue to be supported.

* **Documentation**
  * Clarified supported color-control integrations and field behavior across the style library and editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->