### PR TITLE
[DTM] SOFT-4321 [5/5]: Seed the Custom tab from the block's own shadow when unset

### DIFF
--- a/src/extension/design-tokens/components/EditorShadowControl.js
+++ b/src/extension/design-tokens/components/EditorShadowControl.js
@@ -522,9 +522,10 @@ export function EditorShadowControl({
 				defaultValue={defaultValue}
 				renderColor={renderColor}
 				disabled={disabled}
-				// The stored legs are the fallback for a binding whose token has since been deleted — the
-				// same snapshot the renderers already fall back to when a binding no longer resolves.
-				fallbackShadow={bound ? fromNativeShadow(value) : undefined}
+				// The stored legs seed the Custom tab whenever the value itself carries none: a binding whose
+				// token has since been deleted, and an unset control, which would otherwise open the tab on
+				// a transparent all-zero shadow and let the user edit axes that paint nothing.
+				fallbackShadow={fromNativeShadow(value)}
 			/>
 		</TokenControlRow>
 	);

--- a/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
+++ b/src/extension/design-tokens/components/__tests__/EditorShadowControl.test.js
@@ -422,15 +422,30 @@ describe('EditorShadowControl fallbackShadow wiring', () => {
 	});
 
 	/**
-	 * An unbound (plain composite) value has no binding to fall back FROM, so `fallbackShadow` stays
-	 * undefined rather than shadowing `BoxShadowControl`'s own default-composite behavior.
+	 * An unbound value passes its legs down too. The Custom tab needs them whenever the value carries
+	 * none of its own — an unset control included — so that editing one axis produces the shadow the
+	 * block ships with instead of that axis over a transparent, all-zero one.
 	 *
 	 * @return {void}
 	 */
-	it('leaves fallbackShadow undefined for a value with no shadowToken binding', () => {
+	it('passes the stored legs as fallbackShadow for a value with no shadowToken binding', () => {
 		const { shadowControl } = renderEditorShadowControl();
 
-		expect(shadowControl.props.fallbackShadow).toBeUndefined();
+		expect(shadowControl.props.fallbackShadow).toEqual(fromNativeShadow(NATIVE_VALUE));
+	});
+
+	/**
+	 * An unset control still hands its legs down, which is the whole point: the trigger reads muted
+	 * "Default" from the empty value, while the Custom tab behind it seeds from the block's own shadow.
+	 *
+	 * @return {void}
+	 */
+	it('passes the stored legs even while the control reads as unset', () => {
+		const shipped = [{ color: '#000000', opacity: 0.2, spread: 0, blur: 14, hOffset: 0, vOffset: 0 }];
+		const { shadowControl } = renderEditorShadowControl({ value: shipped, enabled: false });
+
+		expect(shadowControl.props.value).toBe('');
+		expect(shadowControl.props.fallbackShadow).toEqual(fromNativeShadow(shipped));
 	});
 });
 

--- a/src/token-controls/__tests__/box-shadow-control.test.js
+++ b/src/token-controls/__tests__/box-shadow-control.test.js
@@ -395,6 +395,50 @@ describe('BoxShadowControl initial tab', () => {
 	});
 
 	/**
+	 * An unset control seeds its Custom tab from the host's stored legs, so the axes show the shadow the
+	 * block ships with rather than all zeros.
+	 *
+	 * @return {void}
+	 */
+	it('seeds the Custom tab from fallbackShadow when the value is unset', () => {
+		renderControl({
+			value: '',
+			fallbackShadow: { color: '#000000', offsetX: '0px', offsetY: '0px', blur: '14px', spread: '0px' },
+		});
+
+		click(container.querySelector('[data-testid="tab-custom"]'));
+
+		expect(numberInput('Blur').value).toBe('14');
+	});
+
+	/**
+	 * Editing one axis on an unset control commits the stored legs alongside it, so the shadow that
+	 * lands carries a real color instead of the transparent default that paints nothing.
+	 *
+	 * @return {void}
+	 */
+	it('commits the seeded legs when an axis is edited on an unset control', () => {
+		const onChange = jest.fn();
+		renderControl({
+			value: '',
+			onChange,
+			fallbackShadow: { color: '#000000', offsetX: '0px', offsetY: '0px', blur: '14px', spread: '0px' },
+		});
+
+		click(container.querySelector('[data-testid="tab-custom"]'));
+
+		act(() => {
+			const input = numberInput('Y');
+			Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set.call(input, '6');
+			input.dispatchEvent(new Event('change', { bubbles: true }));
+		});
+
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({ offsetY: '6px', blur: '14px', color: '#000000' })
+		);
+	});
+
+	/**
 	 * Blur is floored at zero, and the other three axes stay unbounded. CSS rejects a negative blur
 	 * radius, and one invalid component makes the browser drop the whole `box-shadow` — so a negative
 	 * blur removes the shadow instead of softening it, while X, Y and spread take negatives happily.

--- a/src/token-controls/controls/BoxShadowControl.js
+++ b/src/token-controls/controls/BoxShadowControl.js
@@ -293,11 +293,11 @@ function ShadowCustomTab({ shadow, onChange, renderColor, disabled = false }) {
  * @param {Function}  [props.renderColor] `({ value, onChange }) => Element` for the color sub-field.
  * @param {boolean}   [props.disabled]    Whether the control is read-only.
  * @param {Object}    [props.fallbackShadow] The host's stored composite legs, used to seed the Custom
- *                                        tab only when `value` is a token alias that no longer resolves
- *                                        against `tokens` (the token was deleted after the alias was
- *                                        saved). Without one, a stale alias falls back to the plain
- *                                        default composite, so a host that never binds a token (the
- *                                        Style Library) is unaffected.
+ *                                        tab whenever `value` carries none of its own: an unset
+ *                                        control, or a token alias that no longer resolves against
+ *                                        `tokens` (the token was deleted after the alias was saved).
+ *                                        Without one, both fall back to the plain default composite,
+ *                                        so a host that passes none (the Style Library) is unaffected.
  *
  * @since TBD
  *
@@ -328,9 +328,14 @@ export function BoxShadowControl({
 	// renderers already fall back to for a stale binding, so the Custom tab seeds from it here too,
 	// rather than from the all-zero default.
 	const resolvedAliasShadow = aliasedEntry ? parseResolvedShadow(aliasedEntry.value) : fallbackShadow;
+	// An unset control has no legs of its own to show, but the host still holds the composite the block
+	// ships with. Seeding the Custom tab from that means editing one axis produces the shadow the block
+	// is meant to have; seeding from the plain default instead puts that axis on a fully transparent,
+	// all-zero shadow, so the user moves X and Y and nothing appears.
+	const unsetSeed = hasValue(value) ? {} : fallbackShadow || {};
 	const shadow = aliased
 		? { ...DEFAULT_COMPOSITE, ...(resolvedAliasShadow || {}) }
-		: { ...DEFAULT_COMPOSITE, ...custom };
+		: { ...DEFAULT_COMPOSITE, ...unsetSeed, ...custom };
 	// A fixed pick keeps no live alias, so a sentinel is recognized after the fact by its shorthand.
 	const fixedMatch = !aliased && hasValue(value) ? matchFixedEntry(shadow, tokens) : null;
 	// Display only — `onChange` still sees the real underlying value.


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/b1a4c066dd6348b9a9d4f64ffe317497)

Based on #1516.

## Summary

On an unset shadow control, the Custom tab opened on a fully transparent, all-zero shadow instead of
the one the block ships with. Setting X or Y then produced geometry with no color — the flag rose,
the shadow rendered, and nothing appeared.

`BoxShadowControl` already takes `fallbackShadow` for the host's stored legs; it was only consulted
for a token alias that no longer resolves. It is now consulted whenever the value carries no legs of
its own, which includes an unset control. `EditorShadowControl` passes the block's legs always
instead of only for a binding.

The trigger is unaffected — it still reads muted "Default" from the empty value. Only what sits
behind it on the Custom tab changes.

## Before and after

A fresh Button opened its Custom tab on `0 / 0 / 0 / 0` with an empty swatch. It now opens on the
block's own `1 / 1 / 2` with its real color, and setting Y to 8 writes:

```
{ color: '#000000', opacity: 0.2, hOffset: 1, vOffset: 8, blur: 2, spread: 0 }
```

instead of a transparent shadow with the same offset and no blur.

## Scope

This is the editor path only. The Style Library passes no `fallbackShadow`, so it is unchanged.

## Test plan

- `box-shadow-control.test.js`: an unset control seeds its axes from `fallbackShadow`; editing one
  axis commits the seeded legs alongside it.
- `EditorShadowControl.test.js`: the legs are passed for an unbound value, and while the control
  reads as unset (`value` is `''` and the legs still travel).
- Full JS suite green on this branch alone: 1921 tests.
- CodeRabbit CLI against #1516's branch: 0 findings.
- Verified in wp-admin: a fresh Button's Custom tab opens on `1 / 1 / 2` with a real color, the
  trigger still reads muted "Default", and setting Y paints the block's shadow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved box-shadow editing for unset or outdated token values.
  * Preserves the existing shadow’s color and other dimensions when editing a single axis.
  * Custom shadow controls now start with the stored shadow instead of default zeroed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->