### PR TITLE
[DTM] SOFT-4390 [1/2]: Seed the image border width from a media token that resolves to zero

### DIFF
--- a/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
+++ b/includes/resources/Design_Tokens/Registry/Baseline/baseline.json
@@ -487,6 +487,10 @@
 			"default-hover": {
 				"$type": "dimension",
 				"$value": "{primitive.dimension.border-width.sm}"
+			},
+			"media": {
+				"$type": "dimension",
+				"$value": "0"
 			}
 		},
 		"border-style": {
@@ -745,7 +749,7 @@
 						"tokens": {
 							"background": "{semantic.color.image-bg}",
 							"border": "{semantic.color.border}",
-							"borderWidth": "{semantic.border-width.default}",
+							"borderWidth": "{semantic.border-width.media}",
 							"borderRadius": "{semantic.radius.media}",
 							"shadow": "{semantic.shadow.media}",
 							"padding": "{semantic.spacing.media-padding}"

--- a/includes/resources/Design_Tokens/Registry/declarations.php
+++ b/includes/resources/Design_Tokens/Registry/declarations.php
@@ -488,6 +488,16 @@ return [
 				'group' => __( 'Media', 'kadence-blocks' ),
 			],
 			[
+				// Image border-width default for the block-default CSS projector. The image block's own stylesheet
+				// already paints `border: 0 solid currentColor` on the rendered <img>, so any non-zero width
+				// delivered on that same selector becomes a visible border. Resolves to 0, matching KB's default
+				// (no border until a width is set); a site owner can give every image a border by overriding it.
+				'id'    => 'semantic.border-width.media',
+				'type'  => 'dimension',
+				'label' => __( 'Media Border Width', 'kadence-blocks' ),
+				'group' => __( 'Media', 'kadence-blocks' ),
+			],
+			[
 				// Button shadow default for the block-default CSS projector, mirroring semantic.shadow.media.
 				// Registered so Css_Var emits --kb-token--semantic--shadow--button; the projector points
 				// kadence/singlebtn's box-shadow at it. Resolves to an invisible (transparent, zero) shadow,
@@ -700,9 +710,14 @@ return [
 			// Image color/border/shadow/radius: low-specificity block-default-CSS rules on the rendered
 			// `<img>`, where KB paints background, border, box-shadow, and border-radius. The projector groups
 			// these into one `.wp-block-kadence-image img { ... }` rule (padding gets its own descendant rule
-			// below). Each token is seeded to KB's existing default (transparent background, invisible border
-			// until a style is set, no shadow, square corners), so a fresh image is unchanged; any value the
-			// user sets renders at higher specificity (the `.kb-image<uid>` instance selector) and still wins.
+			// below). Each token is seeded to KB's existing default (transparent background, zero border width,
+			// no shadow, square corners), so a fresh image is unchanged; any value the user sets renders at
+			// higher specificity (the `.kb-image<uid>` instance selector) and still wins.
+			//
+			// The border width MUST seed to zero, not to the brand default: the block stylesheet paints
+			// `border: 0 solid currentColor` on the same `.wp-block-kadence-image img` selector, so the style is
+			// already `solid` and whichever of the two rules prints later decides the width. On the front end
+			// that is this projected rule, which would otherwise paint a hairline on every image.
 			//
 			// The `border` and `borderWidth` bindings below stay declared -- they feed the block-default rules
 			// that seed an image's border color and width from the tokens -- but the Style Library screen
@@ -747,7 +762,7 @@ return [
 					],
 				],
 				'borderWidth'  => [
-					'token'            => 'semantic.border-width.default',
+					'token'            => 'semantic.border-width.media',
 					'css_prop'         => 'border-width',
 					'css_selector'     => 'img',
 					'css_var'          => 'kb-img-border-width',

--- a/tests/wpunit/Blocks/ImageTest.php
+++ b/tests/wpunit/Blocks/ImageTest.php
@@ -233,6 +233,37 @@ class ImageTest extends KadenceBlocksUnit {
 	}
 
 	/**
+	 * An image with a box shadow and no border settings emits no border declaration of its own, so the
+	 * only border width reaching the rendered `<img>` is the zero the projected block-default rule falls
+	 * back to. Guards the light outline that appeared between an image and its shadow when that fallback
+	 * was the brand border width.
+	 *
+	 * @return void
+	 */
+	public function testShadowOnlyImageEmitsNoBorderDeclaration(): void {
+		$output = $this->render_image(
+			[
+				'displayBoxShadow' => true,
+				'boxShadow'        => [
+					[
+						'color'   => '#000000',
+						'opacity' => 0.2,
+						'hOffset' => 6,
+						'vOffset' => 6,
+						'blur'    => 14,
+						'spread'  => 0,
+						'inset'   => false,
+					],
+				],
+			]
+		);
+
+		$this->assertStringContainsString( 'box-shadow:6px 6px 14px 0px rgba(0, 0, 0, 0.2)', $output );
+		$this->assertStringNotContainsString( 'border-width', $output );
+		$this->assertStringNotContainsString( 'border-style', $output );
+	}
+
+	/**
 	 * The `boxShadow` attribute default as `block.json` actually registers it.
 	 *
 	 * Read from the schema rather than spelled out here on purpose. These tests stand in for a saved

--- a/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
+++ b/tests/wpunit/Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest.php
@@ -80,7 +80,7 @@ final class Css_BuilderTest extends TestCase {
 			$css
 		);
 		$this->assertStringContainsString( $this->declaration( 'border-color', 'kb-img-border-color', 'semantic.color.border', '#E2E8F0' ), $css );
-		$this->assertStringContainsString( $this->declaration( 'border-width', 'kb-img-border-width', 'semantic.border-width.default', '1px' ), $css );
+		$this->assertStringContainsString( $this->declaration( 'border-width', 'kb-img-border-width', 'semantic.border-width.media', '0' ), $css );
 		$this->assertStringContainsString( $this->declaration( 'border-radius', 'kb-img-radius', 'semantic.radius.media', '0' ), $css );
 
 		// Padding is rendered on the `.kb-img` descendant, so it gets its own rule.
@@ -94,6 +94,29 @@ final class Css_BuilderTest extends TestCase {
 		$this->assertStringNotContainsString( '.wp-block-kadence-image img{margin', $css );
 		$this->assertStringNotContainsString( 'margin:var(', $css );
 		$this->assertStringNotContainsString( '.wp-block-kadence-advancedbtn', $css );
+	}
+
+	/**
+	 * The image's projected border width falls back to zero. The block's own stylesheet already paints
+	 * `border: 0 solid currentColor` on the same `.wp-block-kadence-image img` selector, so the style is
+	 * already `solid` and a non-zero fallback here would paint a hairline on every image that never asked
+	 * for one -- while the var() indirection stays in place so an override still delivers a width.
+	 *
+	 * @return void
+	 */
+	public function testTheImageBorderWidthDefaultResolvesToZero(): void {
+		$registry = $this->container->get( Token_Registry::class );
+
+		$css = $this->builder( $registry )->css();
+
+		$this->assertStringContainsString(
+			'border-width:var(--kb-img-border-width,var(' . Css_Var::from_id( 'semantic.border-width.media' ) . ',0))',
+			$css
+		);
+		$this->assertStringNotContainsString(
+			'border-width:var(--kb-img-border-width,var(' . Css_Var::from_id( 'semantic.border-width.default' ),
+			$css
+		);
 	}
 
 	/**


### PR DESCRIPTION
🎥 [Walkthrough video](https://www.loom.com/share/c9d17cc21e714c9692c14588f7b8df11)

## Summary

Every image on the front end rendered with a 1px `#E2E8F0` border. On a white page it is nearly
invisible, but as soon as the image has a box shadow it sits between the image and the shadow and
reads as a thin white outline — the symptom reported in SOFT-4390.

Two rules target the same `.wp-block-kadence-image img` selector:

- the image block's own stylesheet sets `border: 0 solid currentColor`, so the border *style* is
  already `solid`;
- the block-default CSS projector emits `border-width`, seeded from `semantic.border-width.default`
  (the brand default, `1px`).

Both have specificity (0,1,1), so source order decides. On the front end the projected rule prints
after the block stylesheet, so a `1px` width lands on an already-`solid` border and paints.

This registers a new `semantic.border-width.media` token that resolves to `0` and points the image's
`borderWidth` binding and its preset alias at it. The projected declaration becomes:

```css
border-width: var(--kb-img-border-width, var(--kb-token--semantic--border-width--media, 0));
```

The `var()` indirection is unchanged, so the Style Library still delivers a width: overriding the
token gives every image that border, and a selected preset still writes through `--kb-img-border-width`.

The image already seeds radius, shadow and padding from media tokens that resolve to KB's own
defaults (`semantic.radius.media`, `semantic.shadow.media`, `semantic.spacing.media-padding`).
Border width was the one binding still borrowing the button's brand default; this makes it consistent.

### Why not the alternatives

- **Drop `css_prop` from the binding** — that also drops the `var(--kb-img-border-width, …)` wrapper,
  and the selected-preset projector would have nothing to write into. The Style Library could no
  longer give images a border width.
- **Change the block stylesheet's `border: 0 solid currentColor`** — the legacy border path and
  `render_border_styles()`'s color-only branch both depend on the style already being `solid`.
- **Change `semantic.border-width.default` to `0`** — that removes the button's visible default border.


## Behavior change worth knowing

Picking only a border **color** on an image (no width, no style) previously showed a 1px border,
because the projected width supplied it. It now shows nothing until a width is set. That is the
pre-Design-System behavior and what `render_border_styles()`'s color-only branch has always produced,
but it is a visible difference for QA.

## Scope

The ticket also reports that the box shadow's X/Y offsets appear to do nothing. That is fixed by
SOFT-4321 [5/5] (#1520), already merged into this feature branch: a fresh image's Custom tab now seeds
from the block's own stored shadow, so editing an axis paints immediately. Verified on top of this
branch — the Custom tab opens at X 0, Y 0, Blur 14, Spread 0 and setting X to 6 renders
`rgba(0, 0, 0, 0.2) 6px 0px 14px 0px`. Nothing further is needed here for that half of the report.

## Test plan

Automated:

- `slic run wpunit Resources/Design_Tokens/Projection/Block_Default_Css/Css_BuilderTest` — includes a
  new `testTheImageBorderWidthDefaultResolvesToZero` pinning the zero fallback and asserting the old
  brand-default binding is gone.
- `slic run wpunit Blocks/ImageTest` — includes a new `testShadowOnlyImageEmitsNoBorderDeclaration`
  proving a shadow-only image emits no border declaration of its own.
- Also green: `Rest/V1/Feed_ControllerTest`, `Registry/Preset_BindingsTest`, `Registry/BindingTest`,
  `Projection/Preset/Css_BuilderTest`, `Schema/Vocabulary/AliasConformanceTest`, plus the acceptance
  and snapshot suites.
- Full JS suite: 131 files, 1940 tests.
- `vendor/bin/phpstan analyse` clean; ESLint and cspell clean.

Manual (front end, verified in Chrome):

1. Page with an Advanced Image, box shadow on, no border settings.
2. Inspect the `<img>` → computed `border-top-width` is `0px` on all four sides. Before the change it
   was `1px` with `border-top-color: rgb(226, 232, 240)`.
3. No light line between the image and its shadow; the shadow itself is unchanged.
4. Override the media border-width token at `:root` → every image picks up the width (checked at 4px).
5. A legacy image with `borderColor` + `borderWidthDesktop` still renders its own border (3px solid red).

Editor canvas: unaffected before and after. `kadence-blocks-global-editor-styles` is a dependency of
`wp-block-library`, so the projected rule prints *before* the block stylesheet there and
`border: 0 solid currentColor` wins. Confirmed by stylesheet order in the canvas document — projection
at index 7, block stylesheet at index 29. The outline was front-end only.

## Reviewer notes

- `baseline.json` changes need an object-cache flush locally, or `Baseline_Guard` throws
  `Missing_Baseline_Entry` on `init` for the newly declared token.
- Token ids are kebab-case (`border-width`, `media`) as the registry requires.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Images no longer receive an unintended visible border by default.
  * Images with only a box shadow now display the shadow without adding border styles.
  * Image styling now uses a zero-width media border setting for more accurate appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
