### PR TITLE
[SMTNC-1725] Advanced Image block editor crash: TypeError endsWith is not a function when dynamic image URL is non-string

### DIFF
--- a/changelog/fix-smtnc-1725.yaml
+++ b/changelog/fix-smtnc-1725.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where the Advanced Image block could stop rendering in
+  the editor when Dynamic Content supplied an image value that was not a url.
+timestamp: 2026-08-12T16:50:44.091Z

--- a/src/blocks/image/edit.js
+++ b/src/blocks/image/edit.js
@@ -43,6 +43,7 @@ import './editor.scss';
  * Internal dependencies
  */
 import Image from './image';
+import { isSvgUrl } from './utils';
 
 /**
  * Module constants
@@ -263,7 +264,7 @@ export function ImageEdit(props) {
 	uniqueIdHelper(props);
 
 	useEffect(() => {
-		//when the attr url changes set the dynamic url. Also set the attr url if we didn't have one ( initialized with dynamic seetings )
+		//when the attr url changes set the dynamic url. Also set the attr url if we didn't have one ( initialized with dynamic settings )
 		debouncedSetDynamicState(
 			'kadence.dynamicImage',
 			'',
@@ -522,7 +523,7 @@ export function ImageEdit(props) {
 		[`size-${sizeSlug}`]: sizeSlug,
 		[`filter-${imageFilter}`]: imageFilter && imageFilter !== 'none',
 		[`kb-image-is-ratio-size`]: useRatio,
-		'image-is-svg': url && url.endsWith('.svg'),
+		'image-is-svg': isSvgUrl(url),
 		[`kadence-image${uniqueID}`]: uniqueID,
 		'kb-image-max-width-set': imgMaxWidth,
 		'has-transparent-img': urlTransparent,

--- a/src/blocks/image/image.js
+++ b/src/blocks/image/image.js
@@ -42,6 +42,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from './helpers';
+import { isSvgUrl } from './utils';
 import useClientWidth from './use-client-width';
 import {
 	KadenceColorOutput,
@@ -430,7 +431,7 @@ export default function Image({
 	const [activeTab, setActiveTab] = useState('general');
 	const [externalBlob, setExternalBlob] = useState();
 	const clientWidth = useClientWidth(containerRef, [align]);
-	const isSVG = previewURL && previewURL.endsWith('.svg') ? true : false;
+	const isSVG = isSvgUrl(previewURL);
 	const isResizable = allowResize && !(isWideAligned && isLargeViewport) && !(isSVG && !previewMaxWidth);
 	const showMaxWidth = allowResize && !isWideAligned;
 	const { imageEditing, imageSizes, maxWidth, mediaUpload } = useSelect(

--- a/src/blocks/image/save.js
+++ b/src/blocks/image/save.js
@@ -9,6 +9,11 @@ import classnames from 'classnames';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import { isSvgUrl } from './utils';
+
 export default function save({ attributes }) {
 	const {
 		url,
@@ -61,7 +66,7 @@ export default function save({ attributes }) {
 		'is-resized': width || height,
 		[`kb-filter-${imageFilter}`]: imageFilter && imageFilter !== 'none',
 		[`kb-image-is-ratio-size`]: useRatio,
-		'image-is-svg': url && url.endsWith('.svg'),
+		'image-is-svg': isSvgUrl(url),
 	});
 
 	const allClasses = classnames({
@@ -72,7 +77,7 @@ export default function save({ attributes }) {
 		'is-resized': width || height,
 		[`kb-filter-${imageFilter}`]: imageFilter && imageFilter !== 'none',
 		[`kb-image-is-ratio-size`]: useRatio,
-		'image-is-svg': url && url.endsWith('.svg'),
+		'image-is-svg': isSvgUrl(url),
 		[`has-transparent-img`]: urlTransparent,
 	});
 

--- a/src/blocks/image/utils.js
+++ b/src/blocks/image/utils.js
@@ -58,6 +58,20 @@ export function getUpdatedLinkTargetSettings(value, { rel }) {
 }
 
 /**
+ * Determines whether an image url points at an SVG.
+ *
+ * Dynamic Content resolves the url at render time and can supply a non-string when the bound field
+ * does not come back as a url, so the type is checked rather than assumed.
+ *
+ * @param {*} url Image url to test.
+ *
+ * @return {boolean} True when the url is a string ending in `.svg`.
+ */
+export function isSvgUrl(url) {
+	return typeof url === 'string' && url.endsWith('.svg');
+}
+
+/**
  * Determines new Image block attributes size selection.
  *
  * @param {Object} image Media file object for gallery image.

--- a/src/blocks/image/utils.test.js
+++ b/src/blocks/image/utils.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+/* Run from the plugin root: npm run test:unit -- src/blocks/image/utils.test.js */
+import { isSvgUrl } from './utils';
+
+describe('image utils', () => {
+	describe('isSvgUrl', () => {
+		it('detects an svg url', () => {
+			expect(isSvgUrl('https://example.com/logo.svg')).toBe(true);
+		});
+
+		it('rejects a url of another type', () => {
+			expect(isSvgUrl('https://example.com/photo.jpg')).toBe(false);
+		});
+
+		it.each([
+			['an unresolved dynamic field object', { error: true, message: 'Invalid field' }],
+			['an attachment id', 42],
+			['an acf image array', { ID: 42, url: 'https://example.com/logo.svg' }],
+			['an empty string', ''],
+			['null', null],
+			['undefined', undefined],
+			['false', false],
+		])('returns false rather than throwing on %s', (_label, url) => {
+			expect(isSvgUrl(url)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1725](https://linear.app/nexcess/issue/SMTNC-1725/advanced-image-block-editor-crash-typeerror-endswith-is-not-a-function)

### 🎥 Artifacts

https://www.loom.com/share/406529cf2ba547c98c0923348d4543c6

### 🗒️ Description

Confirms an image url is a string before testing it for an `.svg` extension, so a non-string value resolved by Dynamic Content no longer stops the Image (Adv) block rendering in the editor.

### ⚠️ Blockers

None.

...

### Checklist
- [x] I have performed a self-review.
- [x] No unrelated files are modified.
- [x] No debugging statements exist (Ex: console.log, error_log).
- [x] There are no warnings or notices in the wordpress error log.
- [x] Passes all tests (linting, acceptance, & unit)

### Block specific checklist (where relevant)
- [ ] Tested with an existing instance of this block .
- [x] Tested creating a new instance of this block.
- [x] Tested with Dynamic content & Elements.
